### PR TITLE
Arm support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,20 +35,20 @@ It is possible with ZoneTree to insert 100 Million integer key-value pairs in 20
 
 Benchmark for all modes: [benchmark](https://raw.githubusercontent.com/koculu/ZoneTree/main/src/Playground/BenchmarkForAllModes.txt)
 
-| Insert Benchmarks                               | 1M      | 2M       | 3M         | 10M        |
-| ------------------------------------------------|---------|----------|------------|------------|
-| int-int ZoneTree async-compressed WAL                       | 267 ms  | 464 ms   | 716 ms     | 2693 ms    |
-| int-int ZoneTree sync-compressed WAL       | 834 ms  | 1617 ms  | 2546 ms    | 8642 ms    |
-| int-int ZoneTree sync WAL                  | 2742 ms | 5533 ms  | 8242 ms    | 27497 ms   |
-||
-| str-str ZoneTree async-compressed WAL                       | 892 ms  | 1833 ms  | 2711 ms    | 9443 ms    |
-| str-str ZoneTree sync-compressed WAL       | 1752 ms | 3397 ms  | 5070 ms    | 19153 ms   |
-| str-str ZoneTree sync WAL                  | 3488 ms | 7002 ms  | 10483 ms   | 38727 ms   |
-||
-| RocksDb sync WAL (10K => 11 sec)           | ~1.100.000 ms | N/A | N/A | N/A                             |
-| int-int RocksDb sync-compressed WAL        | 8059 ms | 16188 ms | 23599 ms   | 61947 ms   |
-| str-str RocksDb sync-compressed WAL        | 8215 ms | 16146 ms | 23760 ms   | 72491 ms   |
-||
+| Insert Benchmarks                     | 1M            | 2M       | 3M       | 10M      |
+| ------------------------------------- | ------------- | -------- | -------- | -------- |
+| int-int ZoneTree async-compressed WAL | 267 ms        | 464 ms   | 716 ms   | 2693 ms  |
+| int-int ZoneTree sync-compressed WAL  | 834 ms        | 1617 ms  | 2546 ms  | 8642 ms  |
+| int-int ZoneTree sync WAL             | 2742 ms       | 5533 ms  | 8242 ms  | 27497 ms |
+|                                       |
+| str-str ZoneTree async-compressed WAL | 892 ms        | 1833 ms  | 2711 ms  | 9443 ms  |
+| str-str ZoneTree sync-compressed WAL  | 1752 ms       | 3397 ms  | 5070 ms  | 19153 ms |
+| str-str ZoneTree sync WAL             | 3488 ms       | 7002 ms  | 10483 ms | 38727 ms |
+|                                       |
+| RocksDb sync WAL (10K => 11 sec)      | ~1.100.000 ms | N/A      | N/A      | N/A      |
+| int-int RocksDb sync-compressed WAL   | 8059 ms       | 16188 ms | 23599 ms | 61947 ms |
+| str-str RocksDb sync-compressed WAL   | 8215 ms       | 16146 ms | 23760 ms | 72491 ms |
+|                                       |
 
 Benchmark Configuration:
 ```c#
@@ -274,45 +274,49 @@ The following sample shows traditional way of doing transactions with ZoneTree.
 ```
 
 ## Features
-| ZoneTree Features                                          |
-| ---------------------------------------------------------- |
-| Works with .NET primitives, structs and classes.           |
-| High Speed and Low Memory consumption.                     |
-| Crash Resilience                                           |
-| Optimum disk space utilization.                            |
-| WAL and DiskSegment data compression.                      |
-| Very fast load/unload.                                     |
-| Standard read/upsert/delete functions.                     |
-| Optimistic Transaction Support                             |
-| Atomic Read Modify Update                                  |
-| Can work in memory.                                        |
-| Can work with any disk device including cloud devices.     |
-| Supports optimistic transactions.                          |
-| Supports Atomicity, Consistency, Isolation, Durability.    |
-| Supports Read Committed Isolation.                         |
-| 4 different modes for write ahead log.              |
-| Audit support with incremental transaction log backup.     |
-| Live backup.                                               |
-| Configurable amount of data that can stay in memory.       |
-| Partially (with sparse arrays) or completely load/unload data on disk to/from memory. |
-| Forward/Backward iteration.                                |
-| Allow optional dirty reads.                                |
-| Embeddable.                                                |
-| Optimized for SSDs.                                        |
-| Exceptionless Transaction API.                             |
-| Fluent Transaction API with ready to use retry capabilities. |
-| Easy Maintenance.                                          |
-| Configurable LSM merger.                                   |
-| Transparent and simple implementation that reveals your database's internals. |
-| Fully open-source with unrestrictive MIT license.          |
-| Transaction Log compaction. |
-| Analyze / control transactions. |
-| Concurrency Control with minimum overhead by novel separation of Concurrency Stamps and Data.|
-| TTL support. |
-| Use your custom serializer for keys and values. |
-| Use your custom comparer. |
-| MultipleDiskSegments Mode to enable dividing data files into configurable sized chunks.|
-|Snapshot iterators.|
+| ZoneTree Features                                                                             |
+| --------------------------------------------------------------------------------------------- |
+| Works with .NET primitives, structs and classes.                                              |
+| High Speed and Low Memory consumption.                                                        |
+| Crash Resilience                                                                              |
+| Optimum disk space utilization.                                                               |
+| WAL and DiskSegment data compression.                                                         |
+| Very fast load/unload.                                                                        |
+| Standard read/upsert/delete functions.                                                        |
+| Optimistic Transaction Support                                                                |
+| Atomic Read Modify Update                                                                     |
+| Can work in memory.                                                                           |
+| Can work with any disk device including cloud devices.                                        |
+| Supports optimistic transactions.                                                             |
+| Supports Atomicity, Consistency, Isolation, Durability.                                       |
+| Supports Read Committed Isolation.                                                            |
+| 4 different modes for write ahead log.                                                        |
+| Audit support with incremental transaction log backup.                                        |
+| Live backup.                                                                                  |
+| Configurable amount of data that can stay in memory.                                          |
+| Partially (with sparse arrays) or completely load/unload data on disk to/from memory.         |
+| Forward/Backward iteration.                                                                   |
+| Allow optional dirty reads.                                                                   |
+| Embeddable.                                                                                   |
+| Optimized for SSDs.                                                                           |
+| Exceptionless Transaction API.                                                                |
+| Fluent Transaction API with ready to use retry capabilities.                                  |
+| Easy Maintenance.                                                                             |
+| Configurable LSM merger.                                                                      |
+| Transparent and simple implementation that reveals your database's internals.                 |
+| Fully open-source with unrestrictive MIT license.                                             |
+| Transaction Log compaction.                                                                   |
+| Analyze / control transactions.                                                               |
+| Concurrency Control with minimum overhead by novel separation of Concurrency Stamps and Data. |
+| TTL support.                                                                                  |
+| Use your custom serializer for keys and values.                                               |
+| Use your custom comparer.                                                                     |
+| MultipleDiskSegments Mode to enable dividing data files into configurable sized chunks.       |
+| Snapshot iterators.                                                                           |
+| ARM support with few restrictions (see ARM section)                                           |
+
+## ARM support
+In this time ZoneTree does not support zstd compression on ARM.
 
 ## I want to contribute. What can I do?
 I appreciate any contribution to the project.

--- a/src/ZoneTree.UnitTests/Crc32ComputerTests.cs
+++ b/src/ZoneTree.UnitTests/Crc32ComputerTests.cs
@@ -1,0 +1,37 @@
+﻿using Tenray.ZoneTree.WAL;
+
+namespace Tenray.ZoneTree.UnitTests
+{
+    public class Crc32ComputerTests
+    {
+        [Test]
+        public void Crc32UintUlongTest()
+        {
+            var result = Crc32Computer.Compute(0, (ulong)123456789);
+            Assert.That(result, Is.EqualTo(3531890030));
+        }
+
+        [Test]
+        public void Crc32UintUintTest()
+        {
+            var result = Crc32Computer.Compute(0, (uint)123456789);
+            Assert.That(result, Is.EqualTo(3177508098));
+        }
+
+        [Test]
+        public void Crc32UintIntTest()
+        {
+            var result = Crc32Computer.Compute(0, 123456789);
+            Assert.That(result, Is.EqualTo(3177508098));
+        }
+
+        [Test]
+        [TestCase(new byte[]{0x1, 0x2, 0x3, 0x4, 0x5}, (uint)371456414)]
+        [TestCase(new byte[]{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0x10}, (uint)712557653)]
+        public void Crc32UintBytesTest(byte[] data, uint expected)
+        {
+            var result = Crc32Computer.Compute(0, data);
+            Assert.That(result, Is.EqualTo(expected));
+        }
+    }
+}

--- a/src/ZoneTree/WAL/Crc32Computer.cs
+++ b/src/ZoneTree/WAL/Crc32Computer.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.Intrinsics.X86;
+﻿using X86 = System.Runtime.Intrinsics.X86;
+using Arm = System.Runtime.Intrinsics.Arm;
 
 namespace Tenray.ZoneTree.WAL;
 
@@ -6,17 +7,17 @@ public sealed class Crc32Computer
 {
     public static uint Compute(uint crc, ulong data)
     {
-        return (uint)Sse42.X64.Crc32(crc, data);
+        return ComputeCrc32(crc, data);
     }
 
     public static uint Compute(uint crc, uint data)
     {
-        return Sse42.Crc32(crc, data);
+        return ComputeCrc32(crc, data);
     }
 
     public static uint Compute(uint crc, int data)
     {
-        return Sse42.Crc32(crc, (uint)data);
+        return ComputeCrc32(crc, (uint)data);
     }
 
     public static uint Compute(uint crc, byte[] array)
@@ -25,17 +26,62 @@ public sealed class Crc32Computer
         var len = array.Length;
         while (len >= 8)
         {
-            crc = (uint)Sse42.X64.Crc32(crc, BitConverter.ToUInt64(array, off));
+            crc = ComputeCrc32(crc, BitConverter.ToUInt64(array, off));
             off += 8;
             len -= 8;
         }
 
         while (len > 0)
         {
-            crc = Sse42.Crc32(crc, array[off]);
+            crc = ComputeCrc32(crc, array[off]);
             off++;
             len--;
         }
         return crc;
+    }
+
+    private static uint ComputeCrc32(uint crc, ulong data)
+    {
+        if (X86.Sse42.X64.IsSupported)
+        {
+            return (uint)X86.Sse42.X64.Crc32(crc, data);
+        }
+        
+        if (Arm.Crc32.Arm64.IsSupported)
+        {
+            return Arm.Crc32.Arm64.ComputeCrc32C(crc, data);
+        }
+
+        throw new PlatformNotSupportedException();
+    }
+    
+    private static uint ComputeCrc32(uint crc, uint data)
+    {
+        if (X86.Sse42.IsSupported)
+        {
+            return X86.Sse42.Crc32(crc, data);
+        }
+        
+        if (Arm.Crc32.IsSupported)
+        {
+            return Arm.Crc32.ComputeCrc32C(crc, data);
+        }
+
+        throw new PlatformNotSupportedException();
+    }
+    
+    private static uint ComputeCrc32(uint crc, byte data)
+    {
+        if (X86.Sse42.IsSupported)
+        {
+            return X86.Sse42.Crc32(crc, data);
+        }
+        
+        if (Arm.Crc32.IsSupported)
+        {
+            return Arm.Crc32.ComputeCrc32C(crc, data);
+        }
+
+        throw new PlatformNotSupportedException();
     }
 }


### PR DESCRIPTION
Closes #14 

- Added support Crc32 computing on ARM.
- Added ARM disclamer for ZStd Compression (Currently does not supporting by ZstdNet)
- Formatting Readme.md