### PR TITLE
Improve (%41) read speed by replacing concurrent queue

### DIFF
--- a/src/ZoneTree.UnitTests/BottomSegmentMergeTests.cs
+++ b/src/ZoneTree.UnitTests/BottomSegmentMergeTests.cs
@@ -39,10 +39,10 @@ public sealed class BottomSegmentMergeTests
             }
         }
 
-        var expected1 = new long[] { 11, 13, 15, 17, 19, 21 };
-        var expected2 = new long[] { 11, 13, 51, 21 };
+        var expected1 = new long[] { 21, 19, 17, 15, 13, 11 };
+        var expected2 = new long[] { 21, 51, 13, 11 };
 
-        var sum = 
+        var sum =
             m.BottomSegments.Sum(x => x.Length) +
             m.InMemoryRecordCount +
             m.DiskSegment.Length;

--- a/src/ZoneTree/Collections/SingleProducerSingleConsumerQueue.cs
+++ b/src/ZoneTree/Collections/SingleProducerSingleConsumerQueue.cs
@@ -1,0 +1,235 @@
+﻿using System.Collections;
+
+namespace Tenray.ZoneTree.Collections;
+
+/// <summary>
+/// Special Queue for ZoneTree.
+/// 1. SingleProducerSingleConsumerQueue is 
+///   - thread-safe for single producer and single consumer.
+///   - thread safe for many readers / enumerations
+/// 2. enquue method uses lock when it is full which makes it almost lock-free for inserts.
+/// 3. dequeue uses lock but the producer almost never hit the lock.
+/// 4. Despite this is a FIFO Queue, the enumerator is in LIFO order 
+/// to optimize record lookup at TryGetFromReadonlySegments.
+/// Enqueue/Dequeue items in FIFO order: i1,i2,i3,i4
+/// Enumeration in LIFO order: i4,i3,i2,i1
+/// </summary>
+/// <typeparam name="TQueueItem">Type of the queue item.</typeparam>
+public sealed class SingleProducerSingleConsumerQueue<TQueueItem>
+    : IEnumerable<TQueueItem>
+    where TQueueItem : class
+{
+    class QueueItemsChunk
+    {
+        const int ChunkSize = 16;
+
+        /// <summary>
+        /// Start of the queue inclusive.
+        /// </summary>
+        public volatile int Start = 0;
+
+        /// <summary>
+        /// End of the queue exclusive.
+        /// </summary>
+        public volatile int End = 0;
+
+        public volatile TQueueItem[] Items = new TQueueItem[ChunkSize];
+
+        public bool IsEmpty => Start == End;
+
+        public int Count()
+        {
+            var size = Items.Length;
+            return (End + size - Start) % size;
+        }
+
+        public IReadOnlyList<TQueueItem> ToFirstInFirstArray()
+        {
+            var items = Items;
+            var size = items.Length;
+            var end = End;
+            var start = Start;
+            var list = new List<TQueueItem>(Count());
+
+            while (start != end)
+            {
+                var item = items[start];
+                if (item == null)
+                    continue;
+                list.Add(item);
+                start = (start + 1) % size;
+            }
+            return list;
+        }
+
+        public IReadOnlyList<TQueueItem> ToLastInFirstArray()
+        {
+            var items = Items;
+            var size = items.Length;
+            var end = (size + End - 1) % size;
+            var start = (size + Start - 1) % size;
+            var list = new List<TQueueItem>(Count());
+
+            while (start != end)
+            {
+                var item = items[end];
+                if (item == null)
+                    continue;
+                list.Add(item);
+                end = (size + end - 1) % size;
+            }
+            return list;
+        }
+    }
+
+    public int Count => Chunk.Count();
+
+    public bool IsEmpty => Chunk.IsEmpty;
+
+    volatile QueueItemsChunk Chunk = new();
+
+    public SingleProducerSingleConsumerQueue()
+    {
+    }
+
+    public SingleProducerSingleConsumerQueue(IEnumerable<TQueueItem> list)
+    {
+        foreach (var item in list)
+        {
+            Enqueue(item);
+        }
+    }
+
+    /// <summary>
+    /// Enqueue should not be called more than once at the same time.
+    /// </summary>
+    public void Enqueue(TQueueItem item)
+    {
+        var chunk = Chunk;
+        var items = chunk.Items;
+        var size = items.Length;
+        var end = chunk.End;
+        if ((end + 1) % size == chunk.Start)
+        {
+            // queue is full or was full.
+            // lock frequency of enqueue is almost zero due to the exponential size increase.
+            lock (this)
+            {
+                var newItems = new TQueueItem[size * 2];
+                Array.Copy(items, newItems, size);
+                if (end < chunk.Start)
+                {
+                    Array.Copy(items, 0, newItems, size, end);
+                    Array.Fill(newItems, null, 0, end);
+                    end = size + chunk.End;
+                }
+                chunk = Chunk = new QueueItemsChunk
+                {
+                    Items = newItems,
+                    Start = chunk.Start,
+                    End = end
+                };
+                items = newItems;
+            }
+            size *= 2;
+        }
+        items[end] = item;
+        chunk.End = (end + 1) % size;
+    }
+
+    /// <summary>
+    /// TryDequeue should not be called more than once at the same time.
+    /// </summary>
+    public bool TryDequeue(out TQueueItem item)
+    {
+        var chunk = Chunk;
+        var start = chunk.Start;
+        var items = chunk.Items;
+        var size = items.Length;
+        item = items[start];
+        if (item == null)
+            return false;
+
+        lock (this)
+        {
+            if (!ReferenceEquals(chunk, Chunk))
+            {
+                chunk = Chunk;
+                items = chunk.Items;
+                size = items.Length;
+            }
+            items[start] = null;
+            chunk.Start = (start + 1) % size;
+        }
+        return true;
+    }
+
+    public IReadOnlyList<TQueueItem> ToLastInFirstArray() => Chunk.ToLastInFirstArray();
+
+    public IReadOnlyList<TQueueItem> ToFirstInFirstArray() => Chunk.ToFirstInFirstArray();
+
+    class LastInFirstEnumerator : IEnumerator<TQueueItem>
+    {
+        TQueueItem current;
+
+        public TQueueItem Current => current;
+
+        object IEnumerator.Current => current;
+
+        readonly QueueItemsChunk Chunk;
+
+        TQueueItem[] Items;
+
+        int Start;
+
+        int End;
+
+        int Size;
+
+        public LastInFirstEnumerator(QueueItemsChunk chunk)
+        {
+            Chunk = chunk;
+            Reset();
+        }
+
+        public void Dispose()
+        {
+        }
+
+        /// <summary>
+        /// The enumeration of this quewue is LIFO.
+        /// </summary>
+        /// <returns></returns>
+        public bool MoveNext()
+        {
+            do
+            {
+                if (Start == End)
+                    return false;
+                current = Items[End];
+                End = (Size + End - 1) % Size;
+            }
+            while (current == null);
+            return true;
+        }
+
+        public void Reset()
+        {
+            var chunk = Chunk;
+            Items = chunk.Items;
+            Size = Items.Length;
+            Start = (Size + chunk.Start - 1) % Size;
+            End = (Size + chunk.End - 1) % Size;
+        }
+    }
+
+    public IEnumerator<TQueueItem> GetEnumerator()
+    {
+        return new LastInFirstEnumerator(Chunk);
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return new LastInFirstEnumerator(Chunk);
+    }
+}

--- a/src/ZoneTree/Collections/SingleProducerSingleConsumerQueue.cs
+++ b/src/ZoneTree/Collections/SingleProducerSingleConsumerQueue.cs
@@ -37,10 +37,13 @@ public sealed class SingleProducerSingleConsumerQueue<TQueueItem>
 
         public bool IsEmpty => Start == End;
 
-        public int Count()
+        public int ItemsCount
         {
-            var size = Items.Length;
-            return (End + size - Start) % size;
+            get
+            {
+                var size = Items.Length;
+                return (End + size - Start) % size;
+            }
         }
 
         public IReadOnlyList<TQueueItem> ToFirstInFirstArray()
@@ -49,7 +52,7 @@ public sealed class SingleProducerSingleConsumerQueue<TQueueItem>
             var size = items.Length;
             var end = End;
             var start = Start;
-            var list = new List<TQueueItem>(Count());
+            var list = new List<TQueueItem>(ItemsCount);
 
             while (start != end)
             {
@@ -68,7 +71,7 @@ public sealed class SingleProducerSingleConsumerQueue<TQueueItem>
             var size = items.Length;
             var end = (size + End - 1) % size;
             var start = (size + Start - 1) % size;
-            var list = new List<TQueueItem>(Count());
+            var list = new List<TQueueItem>(ItemsCount);
 
             while (start != end)
             {
@@ -82,7 +85,7 @@ public sealed class SingleProducerSingleConsumerQueue<TQueueItem>
         }
     }
 
-    public int Count => Chunk.Count();
+    public int Length => Chunk.ItemsCount;
 
     public bool IsEmpty => Chunk.IsEmpty;
 

--- a/src/ZoneTree/Core/ZoneTree.BottomSegments.Merge.cs
+++ b/src/ZoneTree/Core/ZoneTree.BottomSegments.Merge.cs
@@ -21,8 +21,7 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
         }
 
         OnBottomSegmentsMergeOperationStarted?.Invoke(this);
-        var thread = new Thread(() =>
-            StartBottomSegmentsMergeOperationInternal(from, to));
+        var thread = new Thread(() => StartBottomSegmentsMergeOperationInternal(from, to));
         thread.Start();
         return thread;
     }
@@ -93,6 +92,7 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
 
         if (IsCancelBottomSegmentsMergeRequested)
         {
+            // Do not remove null assignments because of GC issue!
             bottomSegments = null;
             mergingSegments = null;
             bottomDiskSegment = null;
@@ -167,6 +167,7 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
                     Logger.LogError(e);
                     OnCanNotDropDiskSegmentCreator?.Invoke(diskSegmentCreator, e);
                 }
+                // Do not remove null assignments because of GC issue!
                 bottomSegments = null;
                 mergingSegments = null;
                 bottomDiskSegment = null;
@@ -315,6 +316,9 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
                 TotalBottomSegmentsMergeDropCount,
                 TotalBottomSegmentsMergeSkipCount));
 
+        // Do not remove null assignments below and anywhere in this function!
+        // GC does not collect local variables,
+        // when this method is called by another thread.
         bottomSegments = null;
         mergingSegments = null;
         bottomDiskSegment = null;

--- a/src/ZoneTree/Core/ZoneTree.BottomSegments.Merge.cs
+++ b/src/ZoneTree/Core/ZoneTree.BottomSegments.Merge.cs
@@ -1,9 +1,7 @@
-﻿using System.Collections.Concurrent;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using Tenray.ZoneTree.Collections;
 using Tenray.ZoneTree.Exceptions;
 using Tenray.ZoneTree.Options;
-using Tenray.ZoneTree.Segments;
 using Tenray.ZoneTree.Segments.Disk;
 
 namespace Tenray.ZoneTree.Core;
@@ -23,7 +21,7 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
         }
 
         OnBottomSegmentsMergeOperationStarted?.Invoke(this);
-        var thread = new Thread(() => 
+        var thread = new Thread(() =>
             StartBottomSegmentsMergeOperationInternal(from, to));
         thread.Start();
         return thread;
@@ -74,7 +72,7 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
         var stopwatch = new Stopwatch();
         stopwatch.Start();
 
-        var bottomSegments = BottomSegmentQueue.ToArray().Reverse().ToArray();
+        var bottomSegments = BottomSegmentQueue.ToLastInFirstArray();
 
         var writeDeletedValues = from > 0;
 
@@ -88,7 +86,7 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
             return MergeResult.NOTHING_TO_MERGE;
         var bottomDiskSegment = bottomSegments[from];
         Logger.LogTrace($"Bottom Segments Merge started." +
-            $" from: {from} - to: {to} out of: {bottomSegments.Length} ");
+            $" from: {from} - to: {to} out of: {bottomSegments.Count} ");
 
         if (mergingSegments.Length == 0)
             return MergeResult.NOTHING_TO_MERGE;
@@ -107,14 +105,14 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
         var len = mergingSegments.Length;
         var bottomIndex = len - 1;
 
-        using IDiskSegmentCreator<TKey, TValue> diskSegmentCreator = 
-            enableMultiPartDiskSegment ? 
+        using IDiskSegmentCreator<TKey, TValue> diskSegmentCreator =
+            enableMultiPartDiskSegment ?
             new MultiPartDiskSegmentCreator<TKey, TValue>(Options, IncrementalIdProvider) :
             new DiskSegmentCreator<TKey, TValue>(Options, IncrementalIdProvider);
 
         var heap = new FixedSizeMinHeap<HeapEntry<TKey, TValue>>(len + 1, MinHeapEntryComparer);
 
-        var fillHeap = () =>
+        void fillHeap()
         {
             for (int i = 0; i < len; i++)
             {
@@ -126,11 +124,11 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
                 var entry = new HeapEntry<TKey, TValue>(key, value, i);
                 heap.Insert(entry);
             }
-        };
+        }
 
         int minSegmentIndex = 0;
 
-        var skipElement = () =>
+        void skipElement()
         {
             var minSegment = mergingSegments[minSegmentIndex];
             if (minSegment.Next())
@@ -143,7 +141,7 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
             {
                 heap.RemoveMin();
             }
-        };
+        }
         fillHeap();
         var comparer = Options.Comparer;
         var hasPrev = false;
@@ -240,10 +238,10 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
                     if (islastKeySmallerThanAllOtherKeys)
                     {
                         diskSegmentCreator.Append(
-                            part, 
-                            minEntry.Key, 
+                            part,
+                            minEntry.Key,
                             lastKey,
-                            minEntry.Value, 
+                            minEntry.Value,
                             lastValuesOfEveryPart[currentPartIndex]);
                         mergingSegments[bottomIndex].Skip(part.Length - 2);
                         prevKey = lastKey;
@@ -256,7 +254,7 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
                 Logger.LogTrace(new LogMergerDrop(part.SegmentId, dropCount, skipCount));
 
             }
-            
+
             diskSegmentCreator.Append(minEntry.Key, minEntry.Value, iteratorPosition);
             skipElement();
         }
@@ -266,10 +264,10 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
         OnDiskSegmentCreated?.Invoke(this, newDiskSegment, true);
         lock (ShortMergerLock)
         {
-            bottomSegments = BottomSegmentQueue.ToArray().Reverse().ToArray();
-            var bottomSegmentsLength = bottomSegments.Length;
+            bottomSegments = BottomSegmentQueue.ToLastInFirstArray();
+            var bottomSegmentsLength = bottomSegments.Count;
             var queue = new Queue<IDiskSegment<TKey, TValue>>();
-            for(var i = 0; i < bottomSegmentsLength; ++i)
+            for (var i = 0; i < bottomSegmentsLength; ++i)
             {
                 var ri = bottomSegmentsLength - i - 1;
                 if (i > from && i <= to)
@@ -288,7 +286,7 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
                     queue.Enqueue(bottomSegments[i]);
                 }
             }
-            var newQueue = new ConcurrentQueue<IDiskSegment<TKey, TValue>>(queue.Reverse());
+            var newQueue = new SingleProducerSingleConsumerQueue<IDiskSegment<TKey, TValue>>(queue.Reverse());
             BottomSegmentQueue = newQueue;
 
             for (var i = from; i <= to; ++i)

--- a/src/ZoneTree/Core/ZoneTree.Iterators.cs
+++ b/src/ZoneTree/Core/ZoneTree.Iterators.cs
@@ -13,13 +13,13 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
         lock (ShortMergerLock)
             lock (AtomicUpdateLock)
             {
-                var roSegments = ReadOnlySegmentQueue.ToArray();
+                var roSegments = ReadOnlySegmentQueue.ToLastInFirstArray();
                 var seekableIterators = new List<ISeekableIterator<TKey, TValue>>();
                 if (includeMutableSegment)
                     seekableIterators.Add(MutableSegment.GetSeekableIterator());
 
                 var readOnlySegmentsArray = roSegments.Select(x => x.GetSeekableIterator()).ToArray();
-                seekableIterators.AddRange(readOnlySegmentsArray.Reverse());
+                seekableIterators.AddRange(readOnlySegmentsArray);
 
                 var result = new SegmentCollection
                 {
@@ -39,7 +39,7 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
 
                 if (includeBottomSegments)
                 {
-                    var bottomSegments = BottomSegmentQueue.Reverse().ToArray();
+                    var bottomSegments = BottomSegmentQueue.ToLastInFirstArray();
                     foreach (var bottom in bottomSegments)
                     {
                         bottom.AttachIterator();
@@ -56,8 +56,8 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
         public IReadOnlyList<ISeekableIterator<TKey, TValue>> SeekableIterators { get; set; }
 
         public IDiskSegment<TKey, TValue> DiskSegment { get; set; }
-        
-        public IDiskSegment<TKey, TValue>[] BottomSegments { get; set; }
+
+        public IReadOnlyList<IDiskSegment<TKey, TValue>> BottomSegments { get; set; }
     }
 
     public IZoneTreeIterator<TKey, TValue> CreateIterator(

--- a/src/ZoneTree/Core/ZoneTree.Merge.cs
+++ b/src/ZoneTree/Core/ZoneTree.Merge.cs
@@ -58,7 +58,7 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
             OnMergeOperationEnded?.Invoke(this, MergeResult.ANOTHER_MERGE_IS_RUNNING);
             return null;
         }
-            
+
         OnMergeOperationStarted?.Invoke(this);
         var thread = new Thread(StartMergeOperationInternal);
         thread.Start();
@@ -114,11 +114,11 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
         Logger.LogTrace("Merge starting.");
 
         var oldDiskSegment = DiskSegment;
-        var roSegments = ReadOnlySegmentQueue.ToArray();
+        var roSegments = ReadOnlySegmentQueue.ToLastInFirstArray();
 
         if (roSegments.Any(x => !x.IsFullyFrozen))
         {
-            SpinWait.SpinUntil(() => !roSegments.Any(x => !x.IsFullyFrozen), 
+            SpinWait.SpinUntil(() => !roSegments.Any(x => !x.IsFullyFrozen),
                 ReadOnlySegmentFullyFrozenSpinTimeout);
             if (roSegments.Any(x => !x.IsFullyFrozen))
                 return MergeResult.RETRY_READONLY_SEGMENTS_ARE_NOT_READY;
@@ -132,7 +132,7 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
             return MergeResult.NOTHING_TO_MERGE;
 
         var mergingSegments = new List<ISeekableIterator<TKey, TValue>>();
-        mergingSegments.AddRange(readOnlySegmentsArray.Reverse());
+        mergingSegments.AddRange(readOnlySegmentsArray);
         if (oldDiskSegment is not NullDiskSegment<TKey, TValue>)
             mergingSegments.Add(oldDiskSegment.GetSeekableIterator());
 
@@ -151,14 +151,14 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
         var len = mergingSegments.Count;
         var diskSegmentIndex = len - 1;
 
-        using IDiskSegmentCreator<TKey, TValue> diskSegmentCreator = 
-            enableMultiPartDiskSegment ? 
+        using IDiskSegmentCreator<TKey, TValue> diskSegmentCreator =
+            enableMultiPartDiskSegment ?
             new MultiPartDiskSegmentCreator<TKey, TValue>(Options, IncrementalIdProvider) :
             new DiskSegmentCreator<TKey, TValue>(Options, IncrementalIdProvider);
 
         var heap = new FixedSizeMinHeap<HeapEntry<TKey, TValue>>(len + 1, MinHeapEntryComparer);
 
-        var fillHeap = () =>
+        void fillHeap()
         {
             for (int i = 0; i < len; i++)
             {
@@ -170,11 +170,11 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
                 var entry = new HeapEntry<TKey, TValue>(key, value, i);
                 heap.Insert(entry);
             }
-        };
+        }
 
         int minSegmentIndex = 0;
 
-        var skipElement = () =>
+        void skipElement()
         {
             var minSegment = mergingSegments[minSegmentIndex];
             if (minSegment.Next())
@@ -187,7 +187,8 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
             {
                 heap.RemoveMin();
             }
-        };
+        }
+
         fillHeap();
         var comparer = Options.Comparer;
         var hasPrev = false;
@@ -285,10 +286,10 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
                     if (islastKeySmallerThanAllOtherKeys)
                     {
                         diskSegmentCreator.Append(
-                            part, 
-                            minEntry.Key, 
+                            part,
+                            minEntry.Key,
                             lastKey,
-                            minEntry.Value, 
+                            minEntry.Value,
                             lastValuesOfEveryPart[currentPartIndex]);
                         mergingSegments[diskSegmentIndex].Skip(part.Length - 2);
                         prevKey = lastKey;
@@ -301,7 +302,7 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
                 Logger.LogTrace(new LogMergerDrop(part.SegmentId, dropCount, skipCount));
 
             }
-            
+
             diskSegmentCreator.Append(minEntry.Key, minEntry.Value, iteratorPosition);
             skipElement();
         }
@@ -316,7 +317,7 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
                 BottomSegmentQueue.Enqueue(newDiskSegment);
                 MetaWal.EnqueueBottomSegment(newDiskSegment.SegmentId);
                 MetaWal.NewDiskSegment(0);
-                DiskSegment = new NullDiskSegment<TKey,TValue>();
+                DiskSegment = new NullDiskSegment<TKey, TValue>();
             }
             else
             {

--- a/src/ZoneTree/Core/ZoneTree.Merge.cs
+++ b/src/ZoneTree/Core/ZoneTree.Merge.cs
@@ -214,6 +214,7 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
                     Logger.LogError(e);
                     OnCanNotDropDiskSegmentCreator?.Invoke(diskSegmentCreator, e);
                 }
+                // Do not remove null assignments because of GC issue!
                 readOnlySegmentsArray = null;
                 mergingSegments = null;
                 roSegments = null;
@@ -361,6 +362,10 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
                 stopwatch.ElapsedMilliseconds,
                 TotalDropCount,
                 TotalSkipCount));
+
+        // Do not remove null assignments below and anywhere in this function!
+        // GC does not collect local variables,
+        // when this method is called by another thread.
 
         readOnlySegmentsArray = null;
         mergingSegments = null;

--- a/src/ZoneTree/Core/ZoneTree.ReadWrite.cs
+++ b/src/ZoneTree/Core/ZoneTree.ReadWrite.cs
@@ -15,12 +15,12 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
                 return !IsValueDeleted(value);
         }
 
-        return TryGetFromReadonlySegments(key, out value);
+        return TryGetFromReadonlySegments(in key, out _);
     }
 
     bool TryGetFromReadonlySegments(in TKey key, out TValue value)
     {
-        foreach (var segment in ReadOnlySegmentQueue.Reverse())
+        foreach (var segment in ReadOnlySegmentQueue)
         {
             if (segment.TryGet(key, out value))
             {
@@ -37,7 +37,7 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
                     return !IsValueDeleted(value);
                 }
 
-                foreach (var segment in BottomSegmentQueue.Reverse())
+                foreach (var segment in BottomSegmentQueue)
                 {
                     if (segment.TryGet(key, out value))
                     {
@@ -106,7 +106,7 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
                 // no update happened, but the value is found.
                 return true;
             }
-            
+
             Upsert(in key, in value);
             return true;
         }
@@ -237,15 +237,12 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
             switch (status)
             {
                 case AddOrUpdateResult.RETRY_SEGMENT_IS_FROZEN:
-                    ForceDelete(key);
                     continue;
                 case AddOrUpdateResult.RETRY_SEGMENT_IS_FULL:
                     MoveMutableSegmentForward(mutableSegment);
-                    ForceDelete(key);
                     continue;
                 default: return;
             }
-
         }
     }
 }

--- a/src/ZoneTree/Core/ZoneTreeIterator.cs
+++ b/src/ZoneTree/Core/ZoneTreeIterator.cs
@@ -70,7 +70,7 @@ public sealed class ZoneTreeIterator<TKey, TValue> : IZoneTreeIterator<TKey, TVa
 
     public IDiskSegment<TKey, TValue> DiskSegment { get; private set; }
 
-    public IDiskSegment<TKey, TValue>[] BottomSegments { get; private set; }
+    public IReadOnlyList<IDiskSegment<TKey, TValue>> BottomSegments { get; private set; }
 
     public ZoneTreeIterator(
         ZoneTreeOptions<TKey, TValue> options,
@@ -214,7 +214,7 @@ public sealed class ZoneTreeIterator<TKey, TValue> : IZoneTreeIterator<TKey, TVa
             if (BottomSegments == null)
                 return;
             var bos = BottomSegments;
-            var len = bos.Length;
+            var len = bos.Count;
             for (var i = 0; i < len; ++i)
             {
                 bos[i]?.DetachIterator();
@@ -243,7 +243,7 @@ public sealed class ZoneTreeIterator<TKey, TValue> : IZoneTreeIterator<TKey, TVa
                 IncludeDiskSegment,
                 IncludeBottomSegments);
         DiskSegment = segments.DiskSegment;
-        BottomSegments =segments.BottomSegments;
+        BottomSegments = segments.BottomSegments;
         SeekableIterators = segments.SeekableIterators;
         Length = SeekableIterators.Count;
         Heap = new FixedSizeMinHeap<HeapEntry<TKey, TValue>>(Length + 1, HeapEntryComparer);

--- a/src/ZoneTree/Core/ZoneTreeIterator.cs
+++ b/src/ZoneTree/Core/ZoneTreeIterator.cs
@@ -255,10 +255,8 @@ public sealed class ZoneTreeIterator<TKey, TValue> : IZoneTreeIterator<TKey, TVa
 
     bool PrevInternal()
     {
-#pragma warning disable IDE0059 // Unnecessary assignment of a value
-        int minSegmentIndex = 0;
-#pragma warning restore IDE0059 // Unnecessary assignment of a value
-        var skipElement = () =>
+        int minSegmentIndex;
+        void skipElement()
         {
             var minSegment = SeekableIterators[minSegmentIndex];
             if (minSegment.Prev())
@@ -271,7 +269,7 @@ public sealed class ZoneTreeIterator<TKey, TValue> : IZoneTreeIterator<TKey, TVa
             {
                 Heap.RemoveMin();
             }
-        };
+        }
 
         while (Heap.Count > 0)
         {
@@ -307,10 +305,8 @@ public sealed class ZoneTreeIterator<TKey, TValue> : IZoneTreeIterator<TKey, TVa
 
     bool NextInternal()
     {
-#pragma warning disable IDE0059 // Unnecessary assignment of a value
-        int minSegmentIndex = 0;
-#pragma warning restore IDE0059 // Unnecessary assignment of a value
-        var skipElement = () =>
+        int minSegmentIndex;
+        void skipElement()
         {
             var minSegment = SeekableIterators[minSegmentIndex];
             if (minSegment.Next())

--- a/src/ZoneTree/Directory.Build.props
+++ b/src/ZoneTree/Directory.Build.props
@@ -5,8 +5,8 @@
     <Authors>Ahmed Yasin Koculu</Authors>
     <PackageId>ZoneTree</PackageId>
     <Title>ZoneTree</Title>
-    <ProductVersion>1.6.1.0</ProductVersion>
-    <Version>1.6.1.0</Version>
+    <ProductVersion>1.6.2.0</ProductVersion>
+    <Version>1.6.2.0</Version>
     <Authors>Ahmed Yasin Koculu</Authors>
     <AssemblyTitle>ZoneTree</AssemblyTitle>
     <Description>ZoneTree is a persistent, high-performance, transactional, ACID-compliant ordered key-value database for NET. It can operate in memory or on local/cloud storage.</Description>

--- a/src/ZoneTree/Segments/Disk/IDiskSegment.cs
+++ b/src/ZoneTree/Segments/Disk/IDiskSegment.cs
@@ -82,7 +82,7 @@ public interface IDiskSegment<TKey, TValue> : IReadOnlySegment<TKey, TValue>, II
     IDiskSegment<TKey, TValue> GetPart(int partIndex);
 
     /// <summary>
-    /// Drops all sectos excluding given exclusion list.
+    /// Drops all sectors excluding given exclusion list.
     /// </summary>
     /// <param name="excludedPartIds"></param>
     void Drop(HashSet<long> excludedPartIds);


### PR DESCRIPTION
This PR avoids ConcurrentQueue Reverse calls and reads takes %41 less time.

![performance-gain](https://github.com/koculu/ZoneTree/assets/7453467/d1fe3d8c-acdf-4d03-afea-e18c6dd366bf)
