### PR TITLE
Garbage collection on startup

### DIFF
--- a/src/ZoneTree.UnitTests/FixedSizeKeyAndValueTests.cs
+++ b/src/ZoneTree.UnitTests/FixedSizeKeyAndValueTests.cs
@@ -127,6 +127,7 @@ public sealed class FixedSizeKeyAndValueTests
         }
 
         // reload tree and check the length
+        for (var i = 0; i < 3; ++i)
         {
             using var data = new ZoneTreeFactory<int, string>()
                 .Configure(options => options.EnableSingleSegmentGarbageCollection = true)

--- a/src/ZoneTree/Core/ZoneTreeMeta.cs
+++ b/src/ZoneTree/Core/ZoneTreeMeta.cs
@@ -21,7 +21,7 @@ public sealed class ZoneTreeMeta
     public int DiskSegmentMaxItemCount { get; set; } = 20_000_000;
 
     public WriteAheadLogOptions WriteAheadLogOptions { get; set; }
-    
+
     public DiskSegmentOptions DiskSegmentOptions { get; set; }
 
     public long MutableSegment { get; set; }
@@ -31,4 +31,6 @@ public sealed class ZoneTreeMeta
     public long DiskSegment { get; set; }
 
     public IReadOnlyList<long> BottomSegments { get; set; }
+
+    public bool HasDiskSegment => DiskSegment != 0 && BottomSegments?.Count > 0;
 }

--- a/src/ZoneTree/Directory.Build.props
+++ b/src/ZoneTree/Directory.Build.props
@@ -5,8 +5,8 @@
     <Authors>Ahmed Yasin Koculu</Authors>
     <PackageId>ZoneTree</PackageId>
     <Title>ZoneTree</Title>
-    <ProductVersion>1.6.4.0</ProductVersion>
-    <Version>1.6.4.0</Version>
+    <ProductVersion>1.6.5.0</ProductVersion>
+    <Version>1.6.5.0</Version>
     <Authors>Ahmed Yasin Koculu</Authors>
     <AssemblyTitle>ZoneTree</AssemblyTitle>
     <Description>ZoneTree is a persistent, high-performance, transactional, ACID-compliant ordered key-value database for NET. It can operate in memory or on local/cloud storage.</Description>

--- a/src/ZoneTree/Options/ZoneTreeOptions.cs
+++ b/src/ZoneTree/Options/ZoneTreeOptions.cs
@@ -257,12 +257,6 @@ public sealed class ZoneTreeOptions<TKey, TValue>
     public DeleteValueConfigurationValidation DeleteValueConfigurationValidation { get; set; }
 
     /// <summary>
-    /// If ZoneTree contains single segment (which is the mutable segment),
-    /// there is the opportunity to hard delete the soft deleted values.
-    /// If enabled, tree performs a garbage collection on load if applicable.
-    /// </summary>
-    /// 
-    /// <summary>
     /// If the ZoneTree contains only a single segment (which is the mutable segment),
     /// there is an opportunity to perform a hard delete of the soft deleted values.
     /// If enabled, the tree performs garbage collection on load if it is applicable.

--- a/src/ZoneTree/Options/ZoneTreeOptions.cs
+++ b/src/ZoneTree/Options/ZoneTreeOptions.cs
@@ -257,6 +257,19 @@ public sealed class ZoneTreeOptions<TKey, TValue>
     public DeleteValueConfigurationValidation DeleteValueConfigurationValidation { get; set; }
 
     /// <summary>
+    /// If ZoneTree contains single segment (which is the mutable segment),
+    /// there is the opportunity to hard delete the soft deleted values.
+    /// If enabled, tree performs a garbage collection on load if applicable.
+    /// </summary>
+    /// 
+    /// <summary>
+    /// If the ZoneTree contains only a single segment (which is the mutable segment),
+    /// there is an opportunity to perform a hard delete of the soft deleted values.
+    /// If enabled, the tree performs garbage collection on load if it is applicable.
+    /// </summary>
+    public bool EnableSingleSegmentGarbageCollection { get; set; }
+
+    /// <summary>
     /// Creates default delete delegates for nullable types.
     /// </summary>
     public void CreateDefaultDeleteDelegates()

--- a/src/ZoneTree/Segments/InMemory/MutableSegmentLoader.cs
+++ b/src/ZoneTree/Segments/InMemory/MutableSegmentLoader.cs
@@ -1,6 +1,7 @@
 ﻿using Tenray.ZoneTree.Exceptions;
 using Tenray.ZoneTree.Core;
 using Tenray.ZoneTree.Options;
+using Tenray.ZoneTree.WAL;
 
 namespace Tenray.ZoneTree.Segments.InMemory;
 
@@ -17,9 +18,10 @@ public sealed class MutableSegmentLoader<TKey, TValue>
     public IMutableSegment<TKey, TValue> LoadMutableSegment(
         long segmentId,
         long maximumOpIndex,
-        bool collectGarbage)
+        bool collectGarbage,
+        out IWriteAheadLog<TKey, TValue> wal)
     {
-        var wal = Options.WriteAheadLogProvider
+        wal = Options.WriteAheadLogProvider
             .GetOrCreateWAL(
                 segmentId,
                 ZoneTree<TKey, TValue>.SegmentWalCategory,

--- a/src/ZoneTree/Segments/InMemory/MutableSegmentLoader.cs
+++ b/src/ZoneTree/Segments/InMemory/MutableSegmentLoader.cs
@@ -14,7 +14,10 @@ public sealed class MutableSegmentLoader<TKey, TValue>
         Options = options;
     }
 
-    public IMutableSegment<TKey, TValue> LoadMutableSegment(long segmentId, long maximumOpIndex)
+    public IMutableSegment<TKey, TValue> LoadMutableSegment(
+        long segmentId,
+        long maximumOpIndex,
+        bool collectGarbage)
     {
         var wal = Options.WriteAheadLogProvider
             .GetOrCreateWAL(
@@ -40,8 +43,13 @@ public sealed class MutableSegmentLoader<TKey, TValue>
             }
         }
         maximumOpIndex = Math.Max(result.MaximumOpIndex, maximumOpIndex);
-        return new MutableSegment<TKey, TValue>
-            (segmentId, wal, Options, result.Keys,
-            result.Values, maximumOpIndex + 1);
+        return new MutableSegment<TKey, TValue>(
+            segmentId,
+            wal,
+            Options,
+            result.Keys,
+            result.Values,
+            maximumOpIndex + 1,
+            collectGarbage);
     }
 }


### PR DESCRIPTION
New option: `EnableSingleSegmentGarbageCollection`

If the ZoneTree contains only a single segment (which is the mutable segment), there is an opportunity to perform a hard delete of the soft deleted values.
If enabled, the tree performs garbage collection on load if it is applicable.