### PR TITLE
Fixed invalid key deletion bug on tree load.

### DIFF
--- a/src/ZoneTree/Collections/DictionaryOfDictionaryWithWAL.cs
+++ b/src/ZoneTree/Collections/DictionaryOfDictionaryWithWAL.cs
@@ -73,7 +73,7 @@ public sealed class DictionaryOfDictionaryWithWAL<TKey1, TKey2, TValue> : IDispo
         var len = keys.Count;
         for (var i = 0; i < len; ++i)
         {
-            Upsert(keys[i], values[i].Value1, values[i].Value2);
+            UpsertWithoutWal(keys[i], values[i].Value1, values[i].Value2);
         }
     }
 
@@ -110,6 +110,22 @@ public sealed class DictionaryOfDictionaryWithWAL<TKey1, TKey2, TValue> : IDispo
         };
         Dictionary[key1] = dic;
         WriteAheadLog.Append(key1, new CombinedValue<TKey2, TValue>(key2, value), NextOpIndex());
+        return false;
+    }
+
+    bool UpsertWithoutWal(in TKey1 key1, in TKey2 key2, in TValue value)
+    {
+        if (Dictionary.TryGetValue(key1, out var dic))
+        {
+            dic.Remove(key2);
+            dic.Add(key2, value);
+            return true;
+        }
+        dic = new Dictionary<TKey2, TValue>
+        {
+            { key2, value }
+        };
+        Dictionary[key1] = dic;
         return false;
     }
 

--- a/src/ZoneTree/Collections/DictionaryWithWal.cs
+++ b/src/ZoneTree/Collections/DictionaryWithWal.cs
@@ -70,7 +70,7 @@ public sealed class DictionaryWithWAL<TKey, TValue> : IDisposable
 
     void LoadFromWriteAheadLog()
     {
-        var result = WriteAheadLog.ReadLogEntries(false, false, false);
+        var result = WriteAheadLog.ReadLogEntries(false, false, true);
         if (!result.Success)
         {
             if (result.HasFoundIncompleteTailRecord)
@@ -87,7 +87,7 @@ public sealed class DictionaryWithWAL<TKey, TValue> : IDisposable
         }
 
         (var newKeys, var newValues) = WriteAheadLogUtility
-            .StableSortAndCleanUpDeletedKeys(
+            .StableSortAndCleanUpDeletedAndDuplicatedKeys(
             result.Keys,
             result.Values,
             Comparer,

--- a/src/ZoneTree/Core/ZoneTreeLoader.cs
+++ b/src/ZoneTree/Core/ZoneTreeLoader.cs
@@ -244,16 +244,19 @@ public sealed class ZoneTreeLoader<TKey, TValue>
         if (collectGarbage)
         {
             var len = MutableSegment.Length;
-            var keys = new TKey[len];
-            var values = new TValue[len];
-            var iterator = MutableSegment.GetSeekableIterator();
-            var i = 0;
-            while (iterator.Next())
+            if (mutableSegmentWal.InitialLength != MutableSegment.Length)
             {
-                keys[i] = iterator.CurrentKey;
-                values[i++] = iterator.CurrentValue;
+                var keys = new TKey[len];
+                var values = new TValue[len];
+                var iterator = MutableSegment.GetSeekableIterator();
+                var i = 0;
+                while (iterator.Next())
+                {
+                    keys[i] = iterator.CurrentKey;
+                    values[i++] = iterator.CurrentValue;
+                }
+                mutableSegmentWal.ReplaceWriteAheadLog(keys, values, true);
             }
-            mutableSegmentWal.ReplaceWriteAheadLog(keys, values, true);
         }
         LoadDiskSegment();
         LoadBottomSegments();

--- a/src/ZoneTree/Segments/InMemory/ReadOnlySegmentLoader.cs
+++ b/src/ZoneTree/Segments/InMemory/ReadOnlySegmentLoader.cs
@@ -46,11 +46,10 @@ public sealed class ReadOnlySegmentLoader<TKey, TValue>
             ZoneTree<TKey, TValue>.SegmentWalCategory);
 
         (var newKeys, var newValues) = WriteAheadLogUtility
-            .StableSortAndCleanUpDeletedKeys(
+            .StableSortAndCleanUpDuplicatedKeys(
             result.Keys,
             result.Values,
-            Options.Comparer,
-            Options.IsValueDeleted);
+            Options.Comparer);
 
         var ros = new ReadOnlySegment<TKey, TValue>(
             segmentId,

--- a/src/ZoneTree/WAL/Async/AsyncCompressedFileSystemWriteAheadLog.cs
+++ b/src/ZoneTree/WAL/Async/AsyncCompressedFileSystemWriteAheadLog.cs
@@ -83,6 +83,8 @@ public sealed class AsyncCompressedFileSystemWriteAheadLog<TKey, TValue> : IWrit
 
     public bool EnableIncrementalBackup { get; set; }
 
+    public int InitialLength { get; private set; }
+
     public AsyncCompressedFileSystemWriteAheadLog(
         ILogger logger,
         IFileStreamProvider fileStreamProvider,
@@ -222,7 +224,7 @@ public sealed class AsyncCompressedFileSystemWriteAheadLog<TKey, TValue> : IWrit
         bool stopReadOnChecksumFailure,
         bool sortByOpIndexes)
     {
-        return WriteAheadLogEntryReader.ReadLogEntries<TKey, TValue, LogEntry>(
+        var result = WriteAheadLogEntryReader.ReadLogEntries<TKey, TValue, LogEntry>(
             Logger,
             FileStream,
             stopReadOnException,
@@ -230,6 +232,8 @@ public sealed class AsyncCompressedFileSystemWriteAheadLog<TKey, TValue> : IWrit
             LogEntry.ReadLogEntry,
             DeserializeLogEntry,
             sortByOpIndexes);
+        InitialLength = result.Keys.Count;
+        return result;
     }
 
     (bool isValid, TKey key, TValue value, long opIndex) DeserializeLogEntry(in LogEntry logEntry)

--- a/src/ZoneTree/WAL/IWriteAheadLog.cs
+++ b/src/ZoneTree/WAL/IWriteAheadLog.cs
@@ -8,6 +8,12 @@ public interface IWriteAheadLog<TKey, TValue> : IDisposable
 
     bool EnableIncrementalBackup { get; set; }
 
+    /// <summary>
+    /// The initial record count of the log.
+    /// It is available after the ReadLogEntries call.
+    /// </summary>
+    int InitialLength { get; }
+
     void Append(in TKey key, in TValue value, long opIndex);
 
     void Drop();
@@ -27,13 +33,13 @@ public interface IWriteAheadLog<TKey, TValue> : IDisposable
     /// <param name="disableBackup">disable backup regardless of wal flag.</param>
     /// <returns>the difference: old file length - new file length.</returns>
     long ReplaceWriteAheadLog(TKey[] keys, TValue[] values, bool disableBackup);
-    
+
     /// <summary>
     /// Informs the write ahead log that no further writes will be sent.
     /// to let WAL optimize itself.
     /// </summary>
     void MarkFrozen();
-    
+
     /// <summary>
     /// Truncates incomplete tail record.
     /// </summary>

--- a/src/ZoneTree/WAL/Null/NullWriteAheadLog.cs
+++ b/src/ZoneTree/WAL/Null/NullWriteAheadLog.cs
@@ -8,6 +8,8 @@ public sealed class NullWriteAheadLog<TKey, TValue> : IWriteAheadLog<TKey, TValu
 
     public bool EnableIncrementalBackup { get; set; }
 
+    public int InitialLength { get; private set; }
+
     public void Append(in TKey key, in TValue value, long opIndex)
     {
     }

--- a/src/ZoneTree/WAL/Sync/SyncFileSystemWriteAheadLog.cs
+++ b/src/ZoneTree/WAL/Sync/SyncFileSystemWriteAheadLog.cs
@@ -33,6 +33,8 @@ public sealed class SyncFileSystemWriteAheadLog<TKey, TValue> : IWriteAheadLog<T
 
     public bool EnableIncrementalBackup { get; set; }
 
+    public int InitialLength { get; private set; }
+
     public SyncFileSystemWriteAheadLog(
         ILogger logger,
         IFileStreamProvider fileStreamProvider,
@@ -88,7 +90,7 @@ public sealed class SyncFileSystemWriteAheadLog<TKey, TValue> : IWriteAheadLog<T
         bool stopReadOnChecksumFailure,
         bool sortByOpIndexes)
     {
-        return WriteAheadLogEntryReader.ReadLogEntries<TKey, TValue, LogEntry>(
+        var result = WriteAheadLogEntryReader.ReadLogEntries<TKey, TValue, LogEntry>(
             Logger,
             FileStream.ToStream(),
             stopReadOnException,
@@ -96,6 +98,8 @@ public sealed class SyncFileSystemWriteAheadLog<TKey, TValue> : IWriteAheadLog<T
             LogEntry.ReadLogEntry,
             DeserializeLogEntry,
             sortByOpIndexes);
+        InitialLength = result.Keys.Count;
+        return result;
     }
 
     (bool isValid, TKey key, TValue value, long opIndex) DeserializeLogEntry(in LogEntry logEntry)

--- a/src/ZoneTree/WAL/SyncCompressed/SyncCompressedFileSystemWriteAheadLog.cs
+++ b/src/ZoneTree/WAL/SyncCompressed/SyncCompressedFileSystemWriteAheadLog.cs
@@ -38,6 +38,8 @@ public sealed class SyncCompressedFileSystemWriteAheadLog<TKey, TValue> : IWrite
 
     public bool EnableIncrementalBackup { get; set; }
 
+    public int InitialLength { get; private set; }
+
     public SyncCompressedFileSystemWriteAheadLog(
         ILogger logger,
         IFileStreamProvider fileStreamProvider,
@@ -98,7 +100,7 @@ public sealed class SyncCompressedFileSystemWriteAheadLog<TKey, TValue> : IWrite
         bool stopReadOnChecksumFailure,
         bool sortByOpIndexes)
     {
-        return WriteAheadLogEntryReader.ReadLogEntries<TKey, TValue, LogEntry>(
+        var result = WriteAheadLogEntryReader.ReadLogEntries<TKey, TValue, LogEntry>(
             Logger,
             FileStream,
             stopReadOnException,
@@ -106,6 +108,8 @@ public sealed class SyncCompressedFileSystemWriteAheadLog<TKey, TValue> : IWrite
             LogEntry.ReadLogEntry,
             DeserializeLogEntry,
             sortByOpIndexes);
+        InitialLength = result.Keys.Count;
+        return result;
     }
 
     (bool isValid, TKey key, TValue value, long opIndex) DeserializeLogEntry(in LogEntry logEntry)

--- a/src/ZoneTree/WAL/WriteAheadLogUtility.cs
+++ b/src/ZoneTree/WAL/WriteAheadLogUtility.cs
@@ -7,7 +7,7 @@ namespace Tenray.ZoneTree.WAL;
 public static class WriteAheadLogUtility
 {
     public static (IReadOnlyList<TKey> keys, IReadOnlyList<TValue> values)
-        StableSortAndCleanUpDeletedKeys<TKey, TValue>(
+        StableSortAndCleanUpDeletedAndDuplicatedKeys<TKey, TValue>(
             IReadOnlyList<TKey> keys,
             IReadOnlyList<TValue> values,
             IRefComparer<TKey> comparer,
@@ -15,14 +15,14 @@ public static class WriteAheadLogUtility
     {
         // WAL has unsorted data. Need to do following.
         // 1. stable sort keys and values based on keys
-        // 2. discard deleted items
+        // 2. discard deleted and duplicated items
         // 3. create new keys and values arrays.
 
         int len = keys.Count;
         var list = new KeyValuePocket<TKey, TValue>[len];
         var pocketComparer = new KeyValuePocketRefComparer<TKey, TValue>(comparer);
         for (var i = 0; i < len; ++i)
-            list[i] = new KeyValuePocket<TKey, TValue>(keys[i], values[i]);
+            list[len - i - 1] = new KeyValuePocket<TKey, TValue>(keys[i], values[i]);
         TimSort<KeyValuePocket<TKey, TValue>>.Sort(list, pocketComparer);
 
         var newKeys = new List<TKey>(len);
@@ -47,6 +47,57 @@ public static class WriteAheadLogUtility
             }
             newKeys.Add(key);
             newValues.Add(value);
+
+            // discard duplicated keys found in log entries.
+            while (++i < len)
+            {
+                if (comparer.Compare(key, list[i].Key) != 0)
+                {
+                    --i;
+                    break;
+                }
+            }
+        }
+        return (newKeys, newValues);
+    }
+
+    public static (IReadOnlyList<TKey> keys, IReadOnlyList<TValue> values)
+        StableSortAndCleanUpDuplicatedKeys<TKey, TValue>(
+            IReadOnlyList<TKey> keys,
+            IReadOnlyList<TValue> values,
+            IRefComparer<TKey> comparer)
+    {
+        // WAL has unsorted data. Need to do following.
+        // 1. stable sort keys and values based on keys
+        // 2. discard duplicated keys
+        // 3. create new keys and values arrays.
+
+        int len = keys.Count;
+        var list = new KeyValuePocket<TKey, TValue>[len];
+        var pocketComparer = new KeyValuePocketRefComparer<TKey, TValue>(comparer);
+        for (var i = 0; i < len; ++i)
+            list[len - i - 1] = new KeyValuePocket<TKey, TValue>(keys[i], values[i]);
+        TimSort<KeyValuePocket<TKey, TValue>>.Sort(list, pocketComparer);
+
+        var newKeys = new List<TKey>(len);
+        var newValues = new List<TValue>(len);
+
+        for (var i = 0; i < len; ++i)
+        {
+            var value = list[i].Value;
+            var key = list[i].Key;
+            newKeys.Add(key);
+            newValues.Add(value);
+
+            // discard duplicated keys found in log entries.
+            while (++i < len)
+            {
+                if (comparer.Compare(key, list[i].Key) != 0)
+                {
+                    --i;
+                    break;
+                }
+            }
         }
         return (newKeys, newValues);
     }


### PR DESCRIPTION
During the loading process of read-only segments, an unexpected deletion of records was detected, which could result in the incorrect resurrection of deleted records.