### PR TITLE
Fixed DeletableRefSerializer issue: cut of last byte.

### DIFF
--- a/src/ZoneTree/Serializers/DeletableRefSerializer.cs
+++ b/src/ZoneTree/Serializers/DeletableRefSerializer.cs
@@ -27,7 +27,7 @@ public sealed class DeletableRefSerializer<TValue> : ISerializer<Deletable<TValu
         var len = b1.Length;
         var b2 = new byte[len + 1];
         Array.Copy(b1, b2, len);
-        b2[len - 1] = entry.IsDeleted ? (byte)1 : (byte)0;
+        b2[len] = entry.IsDeleted ? (byte)1 : (byte)0;
         return b2;
     }
 }


### PR DESCRIPTION
This fixes a bug within a DeletableRefSerializer which serializes TValue and than wipes its last byte with isDeleted field value.