### PR TITLE
Migration to .NET 8 and enable AOT compilation

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -20,6 +20,7 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: |
+          8.0.x
           7.0.x
           6.0.x
     - name: Display dotnet version

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -16,6 +16,7 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: |
+          8.0.x
           7.0.x
           6.0.x
     - name: Display dotnet version

--- a/src/Playground/Playground.csproj
+++ b/src/Playground/Playground.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net7.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
     <Configurations>Debug;Release;ReleaseWithDoc</Configurations>

--- a/src/ZoneTree.UnitTests/ZoneTree.UnitTests.csproj
+++ b/src/ZoneTree.UnitTests/ZoneTree.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
 

--- a/src/ZoneTree/ZoneTree.csproj
+++ b/src/ZoneTree/ZoneTree.csproj
@@ -4,7 +4,7 @@
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
     <RepositoryUrl>https://github.com/koculu/ZoneTree</RepositoryUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
Pull request contains:
- migration to .NET 8.0,
- Enabling AOT compilation for .NET 8.0 - it was enough to modify one JSON serialization and deserialization.