### PR TITLE
Add contribute to the block cache option to the iterators.

### DIFF
--- a/src/ZoneTree/Collections/SeekableIterator.cs
+++ b/src/ZoneTree/Collections/SeekableIterator.cs
@@ -33,13 +33,17 @@ public sealed class SeekableIterator<TKey, TValue> : ISeekableIterator<TKey, TVa
     /// </summary>
     public bool IsFullyFrozen => true;
 
-    public SeekableIterator(IIndexedReader<TKey, TValue> indexedReader)
+    private bool ContributeToTheBlockCache = false;
+
+    public SeekableIterator(IIndexedReader<TKey, TValue> indexedReader, bool contributeToTheBlockCache = false)
     {
         IndexedReader = indexedReader;
         // Pin the length of the indexed reader to improve performance.
         // This seekable iterator is only used by immutable indexed readers.
         // Hence it is safe to pin the length here.
         Length = indexedReader.Length;
+
+        ContributeToTheBlockCache = contributeToTheBlockCache;
     }
 
     public bool Next()

--- a/src/ZoneTree/Core/ZoneTree.cs
+++ b/src/ZoneTree/Core/ZoneTree.cs
@@ -327,7 +327,7 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
 
     public long CountFullScan()
     {
-        using var iterator = CreateIterator(IteratorType.NoRefresh, false);
+        using var iterator = CreateIterator(IteratorType.NoRefresh, false, false);
         var count = 0;
         while (iterator.Next())
             ++count;

--- a/src/ZoneTree/Core/ZoneTreeIterator.cs
+++ b/src/ZoneTree/Core/ZoneTreeIterator.cs
@@ -72,6 +72,8 @@ public sealed class ZoneTreeIterator<TKey, TValue> : IZoneTreeIterator<TKey, TVa
 
     public IReadOnlyList<IDiskSegment<TKey, TValue>> BottomSegments { get; private set; }
 
+    public bool ContributeToTheBlockCache { get; set; }
+
     public ZoneTreeIterator(
         ZoneTreeOptions<TKey, TValue> options,
         ZoneTree<TKey, TValue> zoneTree,
@@ -241,7 +243,8 @@ public sealed class ZoneTreeIterator<TKey, TValue> : IZoneTreeIterator<TKey, TVa
             .CollectSegments(
                 IncludeMutableSegment,
                 IncludeDiskSegment,
-                IncludeBottomSegments);
+                IncludeBottomSegments,
+                ContributeToTheBlockCache);
         DiskSegment = segments.DiskSegment;
         BottomSegments = segments.BottomSegments;
         SeekableIterators = segments.SeekableIterators;

--- a/src/ZoneTree/Directory.Build.props
+++ b/src/ZoneTree/Directory.Build.props
@@ -5,8 +5,8 @@
     <Authors>Ahmed Yasin Koculu</Authors>
     <PackageId>ZoneTree</PackageId>
     <Title>ZoneTree</Title>
-    <ProductVersion>1.7.7.0</ProductVersion>
-    <Version>1.7.7.0</Version>
+    <ProductVersion>1.7.8.0</ProductVersion>
+    <Version>1.7.8.0</Version>
     <Authors>Ahmed Yasin Koculu</Authors>
     <AssemblyTitle>ZoneTree</AssemblyTitle>
     <Description>ZoneTree is a persistent, high-performance, transactional, ACID-compliant ordered key-value database for NET. It can operate in memory or on local/cloud storage.</Description>

--- a/src/ZoneTree/IZoneTree.cs
+++ b/src/ZoneTree/IZoneTree.cs
@@ -189,12 +189,15 @@ public interface IZoneTree<TKey, TValue> : IDisposable
     /// 
     /// <param name="iteratorType">Defines iterator type.</param>
     /// <param name="includeDeletedRecords">if true the iterator retrieves 
-    /// the deleted and normal records</param>
+    /// the deleted and normal records.</param>
+    /// <param name="contributeToTheBlockCache">if true the iterator disk segment reads 
+    /// contributes to the block cache.</param>
     /// 
     /// <returns>ZoneTree Iterator</returns>
     IZoneTreeIterator<TKey, TValue> CreateIterator(
         IteratorType iteratorType = IteratorType.AutoRefresh,
-        bool includeDeletedRecords = false);
+        bool includeDeletedRecords = false,
+        bool contributeToTheBlockCache = false);
 
     /// <summary>
     /// Creates a reverse iterator that enables scanning of the entire database.
@@ -205,13 +208,17 @@ public interface IZoneTree<TKey, TValue> : IDisposable
     /// Forward and backward iterator's performances are equal.
     /// </remarks>
     /// 
-    /// <param name="iteratorType">Defines iterator type.</param>/// <param name="includeDeletedRecords">if true the iterator retrieves 
-    /// the deleted and normal records</param>
+    /// <param name="iteratorType">Defines iterator type.</param>
+    /// <param name="includeDeletedRecords">if true the iterator retrieves 
+    /// the deleted and normal records.</param>
+    /// <param name="contributeToTheBlockCache">if true the iterator disk segment reads 
+    /// contributes to the block cache</param>
     /// 
     /// <returns>ZoneTree Iterator</returns>
     IZoneTreeIterator<TKey, TValue> CreateReverseIterator(
         IteratorType iteratorType = IteratorType.AutoRefresh,
-        bool includeDeletedRecords = false);
+        bool includeDeletedRecords = false,
+        bool contributeToTheBlockCache = false);
 
     /// <summary>
     /// Returns maintenance object belongs to this ZoneTree.

--- a/src/ZoneTree/Segments/Block/BlockPin.cs
+++ b/src/ZoneTree/Segments/Block/BlockPin.cs
@@ -3,7 +3,11 @@
 public sealed class BlockPin
 {
     public DecompressedBlock Device1;
+
     public DecompressedBlock Device2;
+
+    public bool ContributeToTheBlockCache;
+
     public BlockPin(DecompressedBlock device1 = null, DecompressedBlock device2 = null)
     {
         Device1 = device1;
@@ -11,8 +15,14 @@ public sealed class BlockPin
     }
     public SingleBlockPin ToSingleBlockPin(int num)
     {
-        if (num == 1) return new SingleBlockPin(Device1);
-        if (num == 2) return new SingleBlockPin(Device2);
+        if (num == 1) return new SingleBlockPin(Device1)
+        {
+            ContributeToTheBlockCache = ContributeToTheBlockCache
+        };
+        if (num == 2) return new SingleBlockPin(Device2)
+        {
+            ContributeToTheBlockCache = ContributeToTheBlockCache
+        };
         throw new ArgumentException("Supported device numbers are 1 and 2 but given " + num);
     }
 

--- a/src/ZoneTree/Segments/Block/SingleBlockPin.cs
+++ b/src/ZoneTree/Segments/Block/SingleBlockPin.cs
@@ -4,6 +4,8 @@ public sealed class SingleBlockPin
 {
     public DecompressedBlock Device;
 
+    public bool ContributeToTheBlockCache;
+
     public SingleBlockPin(DecompressedBlock device)
     {
         Device = device;

--- a/src/ZoneTree/Segments/Disk/DiskSegment.cs
+++ b/src/ZoneTree/Segments/Disk/DiskSegment.cs
@@ -371,9 +371,9 @@ public abstract class DiskSegment<TKey, TValue> : IDiskSegment<TKey, TValue>
         }
     }
 
-    public ISeekableIterator<TKey, TValue> GetSeekableIterator()
+    public ISeekableIterator<TKey, TValue> GetSeekableIterator(bool contributeToTheBlockCache)
     {
-        return new SeekableIterator<TKey, TValue>(this);
+        return new SeekableIterator<TKey, TValue>(this, contributeToTheBlockCache);
     }
 
     public long GetLastSmallerOrEqualPosition(in TKey key)

--- a/src/ZoneTree/Segments/IReadOnlySegment.cs
+++ b/src/ZoneTree/Segments/IReadOnlySegment.cs
@@ -20,7 +20,7 @@ public interface IReadOnlySegment<TKey, TValue>
 
     IIndexedReader<TKey, TValue> GetIndexedReader();
 
-    ISeekableIterator<TKey, TValue> GetSeekableIterator();
+    ISeekableIterator<TKey, TValue> GetSeekableIterator(bool contributeToTheBlockCache = false);
 
     /// <summary>
     /// This flag indicates that the readonly segment has completed all writes

--- a/src/ZoneTree/Segments/InMemory/MutableSegment.cs
+++ b/src/ZoneTree/Segments/InMemory/MutableSegment.cs
@@ -237,7 +237,7 @@ public sealed class MutableSegment<TKey, TValue> : IMutableSegment<TKey, TValue>
         throw new NotSupportedException("BTree Indexed Reader is not supported.");
     }
 
-    public ISeekableIterator<TKey, TValue> GetSeekableIterator()
+    public ISeekableIterator<TKey, TValue> GetSeekableIterator(bool contributeToTheBlockCache)
     {
         return IsFullyFrozen ?
             new FrozenBTreeSeekableIterator<TKey, TValue>(BTree) :

--- a/src/ZoneTree/Segments/InMemory/ReadOnlySegment.cs
+++ b/src/ZoneTree/Segments/InMemory/ReadOnlySegment.cs
@@ -90,9 +90,9 @@ public sealed class ReadOnlySegment<TKey, TValue> : IReadOnlySegment<TKey, TValu
         return this;
     }
 
-    public ISeekableIterator<TKey, TValue> GetSeekableIterator()
+    public ISeekableIterator<TKey, TValue> GetSeekableIterator(bool contributeToTheBlockCache)
     {
-        return new SeekableIterator<TKey, TValue>(this);
+        return new SeekableIterator<TKey, TValue>(this, contributeToTheBlockCache);
     }
 
     /// <summary>

--- a/src/ZoneTree/Segments/MultiPart/MultiPartDiskSegment.cs
+++ b/src/ZoneTree/Segments/MultiPart/MultiPartDiskSegment.cs
@@ -453,9 +453,9 @@ public sealed class MultiPartDiskSegment<TKey, TValue> : IDiskSegment<TKey, TVal
         return off + position;
     }
 
-    public ISeekableIterator<TKey, TValue> GetSeekableIterator()
+    public ISeekableIterator<TKey, TValue> GetSeekableIterator(bool contributeToTheBlockCache)
     {
-        return new SeekableIterator<TKey, TValue>(this);
+        return new SeekableIterator<TKey, TValue>(this, contributeToTheBlockCache);
     }
 
     public void InitSparseArray(int size)

--- a/src/ZoneTree/Segments/NullDisk/NullDiskSegment.cs
+++ b/src/ZoneTree/Segments/NullDisk/NullDiskSegment.cs
@@ -105,7 +105,7 @@ public sealed class NullDiskSegment<TKey, TValue> : IDiskSegment<TKey, TValue>
         return -1;
     }
 
-    public ISeekableIterator<TKey, TValue> GetSeekableIterator()
+    public ISeekableIterator<TKey, TValue> GetSeekableIterator(bool contributeToTheBlockCache)
     {
         return new NullDiskSegmentSeekableIterator<TKey, TValue>();
     }

--- a/src/ZoneTree/Segments/RandomAccess/CompressedFileRandomAccessDevice.cs
+++ b/src/ZoneTree/Segments/RandomAccess/CompressedFileRandomAccessDevice.cs
@@ -303,6 +303,8 @@ public sealed class CompressedFileRandomAccessDevice : IRandomAccessDevice
                 if (blockPin != null)
                 {
                     blockPin.Device = decompressedBlock;
+                    if (blockPin.ContributeToTheBlockCache)
+                        BlockCache.AddBlock(decompressedBlock);
                 }
                 else
                 {


### PR DESCRIPTION
### Summary

The `CreateIterator` method now includes a `contributeToTheBlockCache` flag, giving you control over whether the iterator’s scan should impact the block cache:

```csharp
IZoneTreeIterator<TKey, TValue> CreateIterator(
    IteratorType iteratorType = IteratorType.AutoRefresh,
    bool includeDeletedRecords = false,
    bool contributeToTheBlockCache = false);
```

#### New Flag: `contributeToTheBlockCache`

- **`contributeToTheBlockCache`**: When set to `true`, the blocks read by the iterator will be added to the block cache. When set to `false` (default), the iterator’s scan will not affect the block cache.

#### Example Usage:

```csharp
using var iterator = zoneTree.CreateIterator(contributeToTheBlockCache: true);
while(iterator.Next()) {
    var key = iterator.CurrentKey;
    var value = iterator.CurrentValue;
}
```
