### PR TITLE
Added operation index to support asynchronous replication and audits

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ zoneTree.TryAtomicAddOrUpdate(39, "a", (ref string x) =>
 {
     x += "b";
     return true;
-});
+}, out var opIndex);
 ```
 
 ---

--- a/src/Playground/Test1.cs
+++ b/src/Playground/Test1.cs
@@ -108,7 +108,7 @@ public sealed class Test1
                     {
                         x += " ooops!";
                         return true;
-                    });
+                    }, out _);
             }
             maintainer.WaitForBackgroundThreads();
         }

--- a/src/ZoneTree.UnitTests/AtomicUpdateTests.cs
+++ b/src/ZoneTree.UnitTests/AtomicUpdateTests.cs
@@ -48,7 +48,8 @@ public sealed class AtomicUpdateTests
                         {
                             ++y;
                             return true;
-                        }
+                        },
+                        out _
                     );
                     Interlocked.Increment(ref off);
                 }
@@ -116,7 +117,7 @@ public sealed class AtomicUpdateTests
                         {
                             ++y;
                             return true;
-                        });
+                        }, out _);
                     Interlocked.Increment(ref off);
                 }
 
@@ -182,7 +183,7 @@ public sealed class AtomicUpdateTests
                         {
                             ++y;
                             return true;
-                        });
+                        }, out _);
                     Interlocked.Increment(ref off);
                 }
 

--- a/src/ZoneTree.UnitTests/FixedSizeKeyAndValueTests.cs
+++ b/src/ZoneTree.UnitTests/FixedSizeKeyAndValueTests.cs
@@ -75,10 +75,10 @@ public sealed class FixedSizeKeyAndValueTests
         using var data = new ZoneTreeFactory<int, string>()
             .SetDataDirectory(dataPath)
             .OpenOrCreate();
-        data.TryAtomicAdd(1, "1");
-        data.TryAtomicAdd(2, "2");
-        data.TryAtomicAdd(3, "3");
-        data.TryDelete(2);
+        data.TryAtomicAdd(1, "1", out _);
+        data.TryAtomicAdd(2, "2", out _);
+        data.TryAtomicAdd(3, "3", out _);
+        data.TryDelete(2, out _);
         Assert.That(data.ContainsKey(1), Is.True);
         Assert.That(data.ContainsKey(2), Is.False);
         Assert.That(data.ContainsKey(3), Is.True);
@@ -95,10 +95,10 @@ public sealed class FixedSizeKeyAndValueTests
             .SetDataDirectory(dataPath)
             .SetValueSerializer(new NullableInt32Serializer())
             .OpenOrCreate();
-        data.TryAtomicAdd(1, 1);
-        data.TryAtomicAdd(2, 2);
-        data.TryAtomicAdd(3, 3);
-        data.TryDelete(2);
+        data.TryAtomicAdd(1, 1, out _);
+        data.TryAtomicAdd(2, 2, out _);
+        data.TryAtomicAdd(3, 3, out _);
+        data.TryDelete(2, out _);
         Assert.That(data.ContainsKey(1), Is.True);
         Assert.That(data.ContainsKey(2), Is.False);
         Assert.That(data.ContainsKey(3), Is.True);
@@ -116,13 +116,13 @@ public sealed class FixedSizeKeyAndValueTests
             using var data = new ZoneTreeFactory<int, string>()
                 .SetDataDirectory(dataPath)
                 .OpenOrCreate();
-            data.TryAtomicAdd(1, "1");
-            data.TryAtomicAdd(2, "2");
-            data.TryAtomicAdd(3, "3");
-            data.TryDelete(2);
-            data.TryAtomicAdd(4, "4");
-            data.TryAtomicUpdate(3, "33");
-            data.TryDelete(2);
+            data.TryAtomicAdd(1, "1", out _);
+            data.TryAtomicAdd(2, "2", out _);
+            data.TryAtomicAdd(3, "3", out _);
+            data.TryDelete(2, out _);
+            data.TryAtomicAdd(4, "4", out _);
+            data.TryAtomicUpdate(3, "33", out _);
+            data.TryDelete(2, out _);
             Assert.That(data.ContainsKey(1), Is.True);
             Assert.That(data.ContainsKey(2), Is.False);
             Assert.That(data.ContainsKey(3), Is.True);
@@ -161,13 +161,13 @@ public sealed class FixedSizeKeyAndValueTests
             using var data = new ZoneTreeFactory<int, string>()
                 .SetDataDirectory(dataPath)
                 .OpenOrCreate();
-            data.TryAtomicAdd(1, "1");
-            data.TryAtomicAdd(2, "2");
-            data.TryAtomicAdd(3, "3");
-            data.TryDelete(2);
-            data.TryAtomicAdd(4, "4");
-            data.TryAtomicUpdate(3, "33");
-            data.TryDelete(2);
+            data.TryAtomicAdd(1, "1", out _);
+            data.TryAtomicAdd(2, "2", out _);
+            data.TryAtomicAdd(3, "3", out _);
+            data.TryDelete(2, out _);
+            data.TryAtomicAdd(4, "4", out _);
+            data.TryAtomicUpdate(3, "33", out _);
+            data.TryDelete(2, out _);
             Assert.That(data.ContainsKey(1), Is.True);
             Assert.That(data.ContainsKey(2), Is.False);
             Assert.That(data.ContainsKey(3), Is.True);
@@ -207,10 +207,10 @@ public sealed class FixedSizeKeyAndValueTests
             using var data = new ZoneTreeFactory<int, string>()
                 .SetDataDirectory(dataPath)
                 .OpenOrCreate();
-            data.TryAtomicAdd(1, "1");
-            data.TryAtomicAdd(2, "2");
-            data.TryAtomicAdd(3, "3");
-            data.TryDelete(2);
+            data.TryAtomicAdd(1, "1", out _);
+            data.TryAtomicAdd(2, "2", out _);
+            data.TryAtomicAdd(3, "3", out _);
+            data.TryDelete(2, out _);
             Assert.That(data.ContainsKey(1), Is.True);
             Assert.That(data.ContainsKey(2), Is.False);
             Assert.That(data.ContainsKey(3), Is.True);

--- a/src/ZoneTree.UnitTests/OpIndexTests.cs
+++ b/src/ZoneTree.UnitTests/OpIndexTests.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Concurrent;
+using Tenray.ZoneTree.PresetTypes;
+using Tenray.ZoneTree.Serializers;
+
+namespace Tenray.ZoneTree.UnitTests;
+
+public sealed class OpIndexTests
+{
+    [Test]
+    public void TestOpIndex()
+    {
+        var dataPath = "data/TestOpIndex";
+        if (Directory.Exists(dataPath))
+            Directory.Delete(dataPath, true);
+        var recordCount = 10_000;
+        var opIndexes = new ConcurrentBag<long>();
+        void CreateData()
+        {
+            using var zoneTree = new ZoneTreeFactory<int, int>()
+                .SetDataDirectory(dataPath)
+                .SetMutableSegmentMaxItemCount(100)
+                .OpenOrCreate();
+
+            using var maintainer = zoneTree.CreateMaintainer();
+            Parallel.For(0, recordCount, (i) =>
+            {
+                var opIndex = zoneTree.Upsert(i, i);
+                opIndexes.Add(opIndex);
+            });
+            maintainer.EvictToDisk();
+            maintainer.WaitForBackgroundThreads();
+        }
+
+        void ReloadData()
+        {
+            using var zoneTree = new ZoneTreeFactory<int, int>()
+                .SetDataDirectory(dataPath)
+                .SetMutableSegmentMaxItemCount(100)
+                .Open();
+
+            var opIndex = zoneTree.Upsert(recordCount + 1, recordCount + 1);
+            Assert.That(opIndex, Is.EqualTo(recordCount + 1));
+            zoneTree.Maintenance.Drop();
+        }
+        CreateData();
+        ReloadData();
+        Assert.IsTrue(
+            opIndexes.Order().ToArray()
+            .SequenceEqual(Enumerable.Range(1, recordCount).Select(x => (long)x)));
+    }
+}

--- a/src/ZoneTree.UnitTests/StringTreeTests.cs
+++ b/src/ZoneTree.UnitTests/StringTreeTests.cs
@@ -114,7 +114,7 @@ public sealed class StringTreeTests
             {
                 x += "b";
                 return true;
-            });
+            }, out _);
         zoneTree.TryGet(39, out value);
         Assert.That(value, Is.EqualTo("Hello Zone Tree!b"));
     }

--- a/src/ZoneTree.UnitTests/TTLTests.cs
+++ b/src/ZoneTree.UnitTests/TTLTests.cs
@@ -35,13 +35,15 @@ public sealed class TTLTests
             5,
             out v1,
             bool (ref TTLValue<int> v) =>
-                v.SlideExpiration(TimeSpan.FromMilliseconds(300)));
+                v.SlideExpiration(TimeSpan.FromMilliseconds(300)),
+            out _);
         Thread.Sleep(450); // initial expiration (300) + slided expiration (300) - Thread.Sleep(150)
         f2 = zoneTree.TryGetAndUpdate(
             5,
             out v2,
             bool (ref TTLValue<int> v) =>
-                v.SlideExpiration(TimeSpan.FromMilliseconds(300)));
+                v.SlideExpiration(TimeSpan.FromMilliseconds(300)),
+            out _);
 
         Assert.That(f1, Is.True);
         Assert.That(f2, Is.False);

--- a/src/ZoneTree/Core/ZoneTree.Merge.cs
+++ b/src/ZoneTree/Core/ZoneTree.Merge.cs
@@ -36,6 +36,7 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
 
             mutableSegment.Freeze();
             ReadOnlySegmentQueue.Enqueue(mutableSegment);
+            MetaWal.EnqueueMaximumOpIndex(mutableSegment.MaximumOpIndex);
             MetaWal.EnqueueReadOnlySegment(mutableSegment.SegmentId);
 
             MutableSegment = new MutableSegment<TKey, TValue>(

--- a/src/ZoneTree/Core/ZoneTree.cs
+++ b/src/ZoneTree/Core/ZoneTree.cs
@@ -144,6 +144,7 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
             options, IncrementalIdProvider.NextId(), new IncrementalIdProvider());
         IsDeleted = options.IsDeleted;
         FillZoneTreeMeta();
+        ZoneTreeMeta.MaximumOpIndex = MutableSegment.OpIndexProvider.LastId;
         MetaWal.SaveMetaData(
             ZoneTreeMeta,
             MutableSegment.SegmentId,
@@ -209,6 +210,7 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
         lock (ShortMergerLock)
             lock (AtomicUpdateLock)
             {
+                ZoneTreeMeta.MaximumOpIndex = MutableSegment.OpIndexProvider.LastId;
                 MetaWal.SaveMetaData(
                     ZoneTreeMeta,
                     MutableSegment.SegmentId,

--- a/src/ZoneTree/Core/ZoneTreeMeta.cs
+++ b/src/ZoneTree/Core/ZoneTreeMeta.cs
@@ -33,6 +33,8 @@ public sealed class ZoneTreeMeta
 
     public IReadOnlyList<long> BottomSegments { get; set; }
 
+    public long MaximumOpIndex { get; set; }
+
     [JsonIgnore]
     public bool HasDiskSegment => DiskSegment != 0 || BottomSegments?.Count > 0;
 }

--- a/src/ZoneTree/Core/ZoneTreeMetaWAL.cs
+++ b/src/ZoneTree/Core/ZoneTreeMetaWAL.cs
@@ -70,6 +70,16 @@ public sealed class ZoneTreeMetaWAL<TKey, TValue> : IDisposable
 
     }
 
+    public void EnqueueMaximumOpIndex(long maximumOpIndex)
+    {
+        var record = new MetaWalRecord
+        {
+            Operation = MetaWalOperation.EnqueueMaximumOpIndex,
+            SegmentId = maximumOpIndex
+        };
+        AppendRecord(record);
+    }
+
     public void EnqueueReadOnlySegment(long segmentId)
     {
         var record = new MetaWalRecord
@@ -230,6 +240,7 @@ public sealed class ZoneTreeMetaWAL<TKey, TValue> : IDisposable
             MutableSegmentMaxItemCount = zoneTreeMeta.MutableSegmentMaxItemCount,
             DiskSegmentMaxItemCount = zoneTreeMeta.DiskSegmentMaxItemCount,
             BottomSegments = bottomSegments,
+            MaximumOpIndex = zoneTreeMeta.MaximumOpIndex,
         };
 
         var bytes = JsonSerializeToUtf8Bytes(newZoneTreeMeta);
@@ -336,6 +347,7 @@ public enum MetaWalOperation
     DequeueBottomSegment,
     InsertBottomSegment,
     DeleteBottomSegment,
+    EnqueueMaximumOpIndex,
 }
 
 [StructLayout(LayoutKind.Sequential)]

--- a/src/ZoneTree/IZoneTree.cs
+++ b/src/ZoneTree/IZoneTree.cs
@@ -46,8 +46,9 @@ public interface IZoneTree<TKey, TValue> : IDisposable
     /// </summary>
     /// <param name="key">The key of the element to add.</param>
     /// <param name="value">The value of the element to add.</param>
+    /// <param name="opIndex">The operation index.</param>
     /// <returns>true if the key and value were added successfully; otherwise, false if the key already exists.</returns>
-    bool TryAdd(in TKey key, in TValue value);
+    bool TryAdd(in TKey key, in TValue value, out long opIndex);
 
     /// <summary>
     /// Tries to get the value of the given key and
@@ -56,8 +57,13 @@ public interface IZoneTree<TKey, TValue> : IDisposable
     /// <param name="key">The key of the element.</param>
     /// <param name="value">The value of the element associated with the key.</param>
     /// <param name="valueUpdater">The delegate function that updates the value.</param>
+    /// <param name="opIndex">The operation index.</param>
     /// <returns>true if the key is found; otherwise, false</returns>
-    bool TryGetAndUpdate(in TKey key, out TValue value, ValueUpdaterDelegate<TValue> valueUpdater);
+    bool TryGetAndUpdate(
+        in TKey key,
+        out TValue value,
+        ValueUpdaterDelegate<TValue> valueUpdater,
+        out long opIndex);
 
     /// <summary>
     /// Tries to get the value of the given key and
@@ -67,25 +73,30 @@ public interface IZoneTree<TKey, TValue> : IDisposable
     /// <param name="value">The value of the element associated with the key.</param>
     /// <param name="valueUpdater">The delegate function that updates the value.</param>
     /// <returns>true if the key is found; otherwise, false</returns>
-    bool TryAtomicGetAndUpdate(in TKey key, out TValue value, ValueUpdaterDelegate<TValue> valueUpdater);
+    bool TryAtomicGetAndUpdate(
+        in TKey key,
+        out TValue value,
+        ValueUpdaterDelegate<TValue> valueUpdater);
 
     /// <summary>
     /// Attempts to add the specified key and value atomically across LSM-Tree segments.
     /// </summary>
     /// <param name="key">The key of the element to add.</param>
     /// <param name="value">The value of the element to add. It can be null.</param>
+    /// <param name="opIndex">The operation index.</param>
     /// <returns>true if the key/value pair was added successfully;
     /// otherwise, false.</returns>
-    bool TryAtomicAdd(in TKey key, in TValue value);
+    bool TryAtomicAdd(in TKey key, in TValue value, out long opIndex);
 
     /// <summary>
     /// Attempts to update the specified key's value atomically across LSM-Tree segments.
     /// </summary>
     /// <param name="key">The key of the element to update.</param>
     /// <param name="value">The value of the element to update. It can be null.</param>
+    /// <param name="opIndex">The operation index.</param>
     /// <returns>true if the key/value pair was updated successfully;
     /// otherwise, false.</returns>
-    bool TryAtomicUpdate(in TKey key, in TValue value);
+    bool TryAtomicUpdate(in TKey key, in TValue value, out long opIndex);
 
     /// <summary>
     /// Attempts to add or update the specified key and value atomically across LSM-Tree segments.    
@@ -93,16 +104,22 @@ public interface IZoneTree<TKey, TValue> : IDisposable
     /// <param name="key">The key of the element to add.</param>
     /// <param name="valueToAdd">The value of the element to add. It can be null.</param>
     /// <param name="valueUpdater">The delegate function that updates the value.</param>
+    /// <param name="opIndex">The operation index.</param>
     /// <returns>true if the key/value pair was added;
     /// false, if the key/value pair was updated.</returns>
-    bool TryAtomicAddOrUpdate(in TKey key, in TValue valueToAdd, ValueUpdaterDelegate<TValue> valueUpdater);
+    bool TryAtomicAddOrUpdate(
+        in TKey key,
+        in TValue valueToAdd,
+        ValueUpdaterDelegate<TValue> valueUpdater,
+        out long opIndex);
 
     /// <summary>
     /// Adds or updates the specified key/value pair atomically across LSM-Tree segments.
     /// </summary>
     /// <param name="key">The key of the element to upsert.</param>
     /// <param name="value">The value of the element to upsert.</param>
-    void AtomicUpsert(in TKey key, in TValue value);
+    /// <returns>The operation index. It can be used to distrubute the operations in stable order.</returns>
+    long AtomicUpsert(in TKey key, in TValue value);
 
     /// <summary>
     /// Adds or updates the specified key/value pair.
@@ -133,7 +150,8 @@ public interface IZoneTree<TKey, TValue> : IDisposable
     /// </remarks>    
     /// <param name="key">The key of the element to upsert.</param>
     /// <param name="value">The value of the element to upsert.</param>
-    void Upsert(in TKey key, in TValue value);
+    /// <returns>The operation index. It can be used to distrubute the operations in stable order.</returns>
+    long Upsert(in TKey key, in TValue value);
 
     /// <summary>
     /// Attempts to delete the specified key.
@@ -141,7 +159,7 @@ public interface IZoneTree<TKey, TValue> : IDisposable
     /// <param name="key">The key of the element to delete.</param>
     /// <returns>true if the key was found and deleted;
     /// false if the key was not found.</returns>
-    bool TryDelete(in TKey key);
+    bool TryDelete(in TKey key, out long opIndex);
 
     /// <summary>
     /// Deletes the specified key regardless of existence. (hint: LSM Tree delete is an insert)
@@ -149,7 +167,8 @@ public interface IZoneTree<TKey, TValue> : IDisposable
     /// It increases the data lake size.
     /// </summary>
     /// <param name="key">The key of the element to delete.</param>
-    void ForceDelete(in TKey key);
+    /// <returns>The operation index. It can be used to distrubute the operations in stable order.</returns>
+    long ForceDelete(in TKey key);
 
     /// <summary>
     /// Counts Keys in the entire database.

--- a/src/ZoneTree/Segments/IMutableSegment.cs
+++ b/src/ZoneTree/Segments/IMutableSegment.cs
@@ -11,9 +11,9 @@ public interface IMutableSegment<TKey, TValue> : IReadOnlySegment<TKey, TValue>
     /// </summary>
     bool IsFrozen { get; }
 
-    AddOrUpdateResult Upsert(in TKey key, in TValue value);
+    AddOrUpdateResult Upsert(in TKey key, in TValue value, out long opIndex);
 
-    AddOrUpdateResult Delete(in TKey key);
+    AddOrUpdateResult Delete(in TKey key, out long opIndex);
 
     void Freeze();
 

--- a/src/ZoneTree/docs/ZoneTree/README-NUGET.md
+++ b/src/ZoneTree/docs/ZoneTree/README-NUGET.md
@@ -174,7 +174,7 @@ zoneTree.TryAtomicAddOrUpdate(39, "a", (ref string x) =>
 {
     x += "b";
     return true;
-});
+}, out var opIndex);
 ```
 
 ---


### PR DESCRIPTION
# Replication:

The index can act as a logical clock to track changes in the database, ensuring that replicas receive updates in the correct order. Each server can apply operations based on the index, and lagging replicas can catch up by processing operations in sequential order.

# Audit and Debugging:
The write operation index provides a way to audit database changes over time. It can help identify the exact sequence of operations that modified a record, which can be useful for troubleshooting or auditing.