### PR TITLE
MoveMutableSegmentForward should wait until all writes to the previous mutable segment finalized.

### DIFF
--- a/src/Playground/Benchmark/OldTests.cs
+++ b/src/Playground/Benchmark/OldTests.cs
@@ -125,7 +125,7 @@ public sealed class OldTests
         var iterate = false;
         if (iterate)
         {
-            var random = new Random();
+            var random = Random.Shared;
             Parallel.For(0, 750000, (i) =>
             {
                 var key = random.Next(0, 999_999_999);

--- a/src/Playground/DeadlockFinder.cs
+++ b/src/Playground/DeadlockFinder.cs
@@ -20,7 +20,7 @@ public class DeadlockFinder
             const int upsertLogFrequency = 1_000_000;
             const int iterationLogFrequency = 10_000_000;
             const int iterationYieldFrequency = 1000;
-            var rand = new Random();
+            var rand = Random.Shared;
 
             void resetTree()
             {

--- a/src/ZoneTree.UnitTests/AtomicUpdateTests.cs
+++ b/src/ZoneTree.UnitTests/AtomicUpdateTests.cs
@@ -29,7 +29,7 @@ public sealed class AtomicUpdateTests
         }
         data.Maintenance.MoveMutableSegmentForward();
         data.Maintenance.StartMergeOperation().Join();
-        var random = new Random();
+        var random = Random.Shared;
         var off = -1;
         Parallel.For(0, 1001, (x) =>
         {
@@ -100,7 +100,7 @@ public sealed class AtomicUpdateTests
         {
             data.Upsert(i, i + i);
         }
-        var random = new Random();
+        var random = Random.Shared;
         var off = -1;
         Parallel.For(0, 1001, (x) =>
         {
@@ -166,7 +166,7 @@ public sealed class AtomicUpdateTests
         {
             data.Upsert(i, i + i);
         }
-        var random = new Random();
+        var random = Random.Shared;
         var off = -1;
         Parallel.For(0, 1001, (x) =>
         {
@@ -228,7 +228,7 @@ public sealed class AtomicUpdateTests
             .ConfigureWriteAheadLogOptions(x => x.WriteAheadLogMode = walMode)
             .OpenOrCreate();
         var n = 1000;
-        var random = new Random();
+        var random = Random.Shared;
         Parallel.For(0, 1000, (x) =>
         {
             try

--- a/src/ZoneTree.UnitTests/ExceptionlessTransactionTests.cs
+++ b/src/ZoneTree.UnitTests/ExceptionlessTransactionTests.cs
@@ -82,7 +82,7 @@ public sealed class ExceptionlessTransactionTests
 
         zoneTree.Maintenance.TransactionLog.CompactionThreshold = compactionThreshold;
 
-        var random = new Random();
+        var random = Random.Shared;
         await Parallel.ForEachAsync(Enumerable.Range(0, 1000), async (x, cancel) =>
         {
             using var transaction =

--- a/src/ZoneTree.UnitTests/IteratorTests.cs
+++ b/src/ZoneTree.UnitTests/IteratorTests.cs
@@ -240,7 +240,7 @@ public sealed class IteratorTests
         if (Directory.Exists(dataPath))
             Directory.Delete(dataPath, true);
 
-        var random = new Random();
+        var random = Random.Shared;
         var insertCount = 100000;
         var iteratorCount = 1000;
 
@@ -289,7 +289,7 @@ public sealed class IteratorTests
         if (Directory.Exists(dataPath))
             Directory.Delete(dataPath, true);
 
-        var random = new Random();
+        var random = Random.Shared;
         var insertCount = 1000000;
         var iteratorCount = 1000;
 
@@ -352,7 +352,7 @@ public sealed class IteratorTests
         if (Directory.Exists(dataPath))
             Directory.Delete(dataPath, true);
 
-        var random = new Random();
+        var random = Random.Shared;
         var insertCount = 100000;
         var iteratorCount = 1000;
 
@@ -512,7 +512,7 @@ public sealed class IteratorTests
         if (merge)
             zoneTree.Maintenance.StartMergeOperation()?.Join();
 
-        var random = new Random();
+        var random = Random.Shared;
         DoPrefixSearch(zoneTree, list, random);
         zoneTree.Maintenance.DiskSegment.InitSparseArray(100);
         DoPrefixSearch(zoneTree, list, random);
@@ -604,7 +604,7 @@ public sealed class IteratorTests
                     x.MaximumRecordCount = maximumRecordCount;
             })
             .Open();
-        var random = new Random();
+        var random = Random.Shared;
         DoPrefixSearch(zoneTree, list, random);
         zoneTree.Maintenance.DiskSegment.InitSparseArray(100);
         DoPrefixSearch(zoneTree, list, random);

--- a/src/ZoneTree.UnitTests/ReplicatorTests.cs
+++ b/src/ZoneTree.UnitTests/ReplicatorTests.cs
@@ -5,15 +5,6 @@ namespace Tenray.ZoneTree.UnitTests;
 public sealed class ReplicatorTests
 {
     [Test]
-    public void TestReplicator2()
-    {
-        for (int i = 0; i < 100; i++)
-        {
-            TestReplicator();
-        }
-    }
-
-    [Test]
     public void TestReplicator()
     {
         var dataPath = "data/TestReplicator";
@@ -21,14 +12,17 @@ public sealed class ReplicatorTests
             Directory.Delete(dataPath, true);
         var recordCount = 50_000;
         var keyCount = 15_000;
+        var maxMemory = 2_000;
         void CreateData()
         {
             using var zoneTree = new ZoneTreeFactory<int, int>()
                 .SetDataDirectory(dataPath + "/source")
+                .SetMutableSegmentMaxItemCount(maxMemory)
                 .OpenOrCreate();
 
             using var replica = new ZoneTreeFactory<int, int>()
                 .SetDataDirectory(dataPath + "/replica")
+                .SetMutableSegmentMaxItemCount(maxMemory)
                 .OpenOrCreate();
 
             using var replicator = new Replicator<int, int>(replica, dataPath + "/replica-op-index");
@@ -83,5 +77,84 @@ public sealed class ReplicatorTests
 
         CreateData();
         TestEqual();
+    }
+
+    [Test]
+    public void TestReplicator2()
+    {
+        for (int i = 0; i < 5; i++)
+        {
+            var dataPath = "data/TestReplicator";
+            if (Directory.Exists(dataPath))
+                Directory.Delete(dataPath, true);
+
+            var recordCount = 50_000;
+            var keyCount = 15_000;
+            var maxMemory = 2_000;
+
+            void CreateData()
+            {
+                using var zoneTree = new ZoneTreeFactory<int, int>()
+                    .SetDataDirectory(dataPath + "/source")
+                    .SetMutableSegmentMaxItemCount(maxMemory)
+                    .OpenOrCreate();
+
+                using var replica = new ZoneTreeFactory<int, int>()
+                    .SetDataDirectory(dataPath + "/replica")
+                    .SetMutableSegmentMaxItemCount(maxMemory)
+                    .OpenOrCreate();
+
+                using var replicator = new Replicator<int, int>(replica, dataPath + "/replica-op-index");
+                using var maintainer1 = zoneTree.CreateMaintainer();
+                using var maintainer2 = replica.CreateMaintainer();
+                int replicated = 0;
+                var k = 0;
+                Parallel.For(0, recordCount, (i) =>
+                {
+                    var key = i % keyCount;
+                    var value = Interlocked.Increment(ref k);
+                    var opIndex = zoneTree.Upsert(key, value);
+                    Task.Run(() =>
+                    {
+                        replicator.OnUpsert(key, value, opIndex);
+                        Interlocked.Increment(ref replicated);
+                    });
+                });
+                while (replicated < recordCount) Task.Delay(500).Wait();
+                maintainer1.EvictToDisk();
+                maintainer2.EvictToDisk();
+                maintainer1.WaitForBackgroundThreads();
+                maintainer2.WaitForBackgroundThreads();
+            }
+
+            void TestEqual()
+            {
+                using var zoneTree = new ZoneTreeFactory<int, int>()
+                    .SetDataDirectory(dataPath + "/source")
+                    .Open();
+
+                using var replica = new ZoneTreeFactory<int, int>()
+                    .SetDataDirectory(dataPath + "/replica")
+                    .Open();
+
+                using var iterator1 = zoneTree.CreateIterator();
+                using var iterator2 = replica.CreateIterator();
+                var i = 0;
+                while (true)
+                {
+                    var n1 = iterator1.Next();
+                    var n2 = iterator2.Next();
+                    Assert.That(n2, Is.EqualTo(n1));
+                    if (!n1) break;
+                    Assert.That(iterator2.Current, Is.EqualTo(iterator1.Current));
+                    ++i;
+                }
+                Assert.That(i, Is.EqualTo(keyCount));
+                zoneTree.Maintenance.Drop();
+                replica.Maintenance.Drop();
+            }
+            CreateData();
+            TestEqual();
+        }
     }
 }

--- a/src/ZoneTree.UnitTests/SafeBplusTreeTests.cs
+++ b/src/ZoneTree.UnitTests/SafeBplusTreeTests.cs
@@ -22,13 +22,13 @@ public sealed class SafeBTreeTests
             tree.TryInsert(i, i + i, out _);
 
         var iterator = new BTreeSeekableIterator<int, int>(tree);
-        var j = 0; 
+        var j = 0;
         while (iterator.Next())
         {
             Assert.That(iterator.CurrentKey, Is.EqualTo(j));
             Assert.That(iterator.CurrentValue, Is.EqualTo(j + j));
             ++j;
-        } 
+        }
 
         iterator.SeekEnd();
         j = n - 1;
@@ -92,7 +92,7 @@ public sealed class SafeBTreeTests
             Assert.That(GetLastNodeSmallerOrEqual(iterator, 4), Is.EqualTo(3));
             Assert.That(GetLastNodeSmallerOrEqual(iterator, 3), Is.EqualTo(3));
             Assert.Throws<IndexOutOfRangeException>(
-                () => GetLastNodeSmallerOrEqual(iterator ,- 1));
+                () => GetLastNodeSmallerOrEqual(iterator, -1));
             Assert.That(GetLastNodeSmallerOrEqual(iterator, 10), Is.EqualTo(9));
             Assert.That(GetLastNodeSmallerOrEqual(iterator, 9), Is.EqualTo(9));
             Assert.That(GetLastNodeSmallerOrEqual(iterator, 1), Is.EqualTo(1));
@@ -135,7 +135,7 @@ public sealed class SafeBTreeTests
     [TestCase(BTreeLockMode.NodeLevelMonitor)]
     public void BTreeIteratorParallelInserts(BTreeLockMode lockMode)
     {
-        var random = new Random();
+        var random = Random.Shared;
         var insertCount = 100000;
         var iteratorCount = 1000;
 
@@ -190,7 +190,7 @@ public sealed class SafeBTreeTests
     [TestCase(BTreeLockMode.NodeLevelMonitor)]
     public void BTreeReverseIteratorParallelInserts(BTreeLockMode lockMode)
     {
-        var random = new Random();
+        var random = Random.Shared;
         var insertCount = 100000;
         var iteratorCount = 1550;
 
@@ -203,7 +203,7 @@ public sealed class SafeBTreeTests
             {
                 var key = random.Next();
                 tree.AddOrUpdate(key,
-                    AddOrUpdateResult  (ref int x) =>
+                    AddOrUpdateResult (ref int x) =>
                     {
                         x = key + key;
                         return AddOrUpdateResult.ADDED;
@@ -253,7 +253,7 @@ public sealed class SafeBTreeTests
     [TestCase(BTreeLockMode.NodeLevelMonitor)]
     public void IntIntDuplicateRecords(BTreeLockMode lockMode)
     {
-        var random = new Random();
+        var random = Random.Shared;
         var insertCount = 1000000;
         var iteratorCount = 1000;
 
@@ -297,7 +297,7 @@ public sealed class SafeBTreeTests
     [TestCase(BTreeLockMode.NodeLevelMonitor)]
     public void IntIntDuplicateReverseRecords(BTreeLockMode lockMode)
     {
-        var random = new Random();
+        var random = Random.Shared;
         var insertCount = 1000000;
         var iteratorCount = 1000;
 

--- a/src/ZoneTree/Core/Replicator.cs
+++ b/src/ZoneTree/Core/Replicator.cs
@@ -4,22 +4,61 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using Tenray.ZoneTree.Collections;
 
+/// <summary>
+/// The <see cref="Replicator{TKey, TValue}"/> class provides asynchronous replication for 
+/// <see cref="IZoneTree{TKey, TValue}"/> instances, allowing efficient upsert operations 
+/// and background maintenance tasks.
+/// </summary>
+/// <typeparam name="TKey">The type of the key used in the ZoneTree.</typeparam>
+/// <typeparam name="TValue">The type of the value used in the ZoneTree.</typeparam>
 public sealed class Replicator<TKey, TValue> : IDisposable
 {
-    readonly IZoneTree<TKey, TValue> Replica;
+    /// <summary>
+    /// The main <see cref="IZoneTree{TKey, TValue}"/> instance that acts as the replica.
+    /// This holds the replicated data.
+    /// </summary>
+    public readonly IZoneTree<TKey, TValue> Replica;
 
-    readonly IZoneTree<TKey, long> LatestOpIndexes;
+    /// <summary>
+    /// An <see cref="IZoneTree{TKey, long}"/> that tracks the latest operation indexes for each key.
+    /// This helps in ensuring that only the most recent updates are reflected in the <see cref="Replica"/>.
+    /// </summary>
+    public readonly IZoneTree<TKey, long> LatestOpIndexes;
 
-    readonly IMaintainer Maintainer;
+    /// <summary>
+    /// The <see cref="IMaintainer"/> responsible for managing background maintenance jobs,
+    /// such as cleaning inactive caches and evicting data to disk.
+    /// </summary>
+    public readonly IMaintainer Maintainer;
 
+    /// <summary>
+    /// A flag indicating whether data should be evicted to disk when the replicator is disposed.
+    /// </summary>
+    readonly bool EvictToDiskOnDispose;
+
+    /// <summary>
+    /// A flag indicating whether the replicator has already been disposed to avoid multiple disposal operations.
+    /// </summary>
     bool isDisposed;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Replicator{TKey, TValue}"/> class.
+    /// </summary>
+    /// <param name="replica">The <see cref="IZoneTree{TKey, TValue}"/> instance representing the replica.</param>
+    /// <param name="dataPath">The file path where data will be persisted to disk.</param>
+    /// <param name="evictToDiskOnDispose">Indicates whether the data should be evicted to disk on dispose.</param>
+    /// <param name="configure">
+    /// An optional action to configure the <see cref="ZoneTreeFactory{TKey, long}"/> instance used for 
+    /// creating or opening the <see cref="LatestOpIndexes"/> tree.
+    /// </param>
     public Replicator(
         IZoneTree<TKey, TValue> replica,
         string dataPath,
+        bool evictToDiskOnDispose = true,
         Action<ZoneTreeFactory<TKey, long>> configure = null)
     {
         this.Replica = replica;
+        EvictToDiskOnDispose = evictToDiskOnDispose;
         var factory = new ZoneTreeFactory<TKey, long>()
             .SetDataDirectory(dataPath);
         if (configure != null) configure(factory);
@@ -28,6 +67,18 @@ public sealed class Replicator<TKey, TValue> : IDisposable
         Maintainer.EnableJobForCleaningInactiveCaches = true;
     }
 
+    /// <summary>
+    /// Handles the upsert operation in the replicator, ensuring atomic updates 
+    /// to both the <see cref="LatestOpIndexes"/> and the <see cref="Replica"/>.
+    /// </summary>
+    /// <param name="key">The key of the element to be upserted.</param>
+    /// <param name="value">The value of the element to be upserted.</param>
+    /// <param name="opIndex">The operation index associated with this upsert operation.</param>
+    /// <remarks>
+    /// The upsert operation ensures that the <see cref="LatestOpIndexes"/> is updated atomically.
+    /// If the new operation index (<paramref name="opIndex"/>) is greater than or equal to the existing index,
+    /// the key-value pair is upserted into the <see cref="Replica"/>.
+    /// </remarks>
     public void OnUpsert(TKey key, TValue value, long opIndex)
     {
         LatestOpIndexes.TryAtomicAddOrUpdate(
@@ -51,11 +102,21 @@ public sealed class Replicator<TKey, TValue> : IDisposable
                 });
     }
 
+    /// <summary>
+    /// Releases all resources used by the <see cref="Replicator{TKey, TValue}"/>.
+    /// </summary>
+    /// <remarks>
+    /// If <see cref="EvictToDiskOnDispose"/> is set to <c>true</c>, the data is 
+    /// evicted to disk before disposal. The method ensures that all background 
+    /// maintenance jobs are completed and disposes of the <see cref="LatestOpIndexes"/> 
+    /// and the <see cref="Maintainer"/>.
+    /// </remarks>
     public void Dispose()
     {
         if (isDisposed) return;
         isDisposed = true;
-        Maintainer.EvictToDisk();
+        if (EvictToDiskOnDispose)
+            Maintainer.EvictToDisk();
         Maintainer.WaitForBackgroundThreads();
         Maintainer.Dispose();
         LatestOpIndexes.Dispose();

--- a/src/ZoneTree/Core/ZoneTree.ReadWrite.cs
+++ b/src/ZoneTree/Core/ZoneTree.ReadWrite.cs
@@ -240,6 +240,7 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
             switch (status)
             {
                 case AddOrUpdateResult.RETRY_SEGMENT_IS_FROZEN:
+                    Thread.Yield();
                     continue;
                 case AddOrUpdateResult.RETRY_SEGMENT_IS_FULL:
                     MoveMutableSegmentForward(mutableSegment);
@@ -318,6 +319,7 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
             switch (status)
             {
                 case AddOrUpdateResult.RETRY_SEGMENT_IS_FROZEN:
+                    Thread.Yield();
                     continue;
                 case AddOrUpdateResult.RETRY_SEGMENT_IS_FULL:
                     MoveMutableSegmentForward(mutableSegment);
@@ -349,6 +351,7 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
             switch (status)
             {
                 case AddOrUpdateResult.RETRY_SEGMENT_IS_FROZEN:
+                    Thread.Yield();
                     continue;
                 case AddOrUpdateResult.RETRY_SEGMENT_IS_FULL:
                     MoveMutableSegmentForward(mutableSegment);
@@ -370,6 +373,7 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
             switch (status)
             {
                 case AddOrUpdateResult.RETRY_SEGMENT_IS_FROZEN:
+                    Thread.Yield();
                     continue;
                 case AddOrUpdateResult.RETRY_SEGMENT_IS_FULL:
                     MoveMutableSegmentForward(mutableSegment);
@@ -405,6 +409,7 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
             switch (status)
             {
                 case AddOrUpdateResult.RETRY_SEGMENT_IS_FROZEN:
+                    Thread.Yield();
                     continue;
                 case AddOrUpdateResult.RETRY_SEGMENT_IS_FULL:
                     MoveMutableSegmentForward(mutableSegment);

--- a/src/ZoneTree/Segments/InMemory/FrozenMutableSegment.cs
+++ b/src/ZoneTree/Segments/InMemory/FrozenMutableSegment.cs
@@ -1,0 +1,79 @@
+﻿using Tenray.ZoneTree.Collections;
+using Tenray.ZoneTree.Collections.BTree;
+using Tenray.ZoneTree.Core;
+
+namespace Tenray.ZoneTree.Segments.InMemory;
+
+public sealed class FrozenMutableSegment<TKey, TValue> : IMutableSegment<TKey, TValue>
+{
+    private IMutableSegment<TKey, TValue> mutableSegment;
+
+    public FrozenMutableSegment(IMutableSegment<TKey, TValue> mutableSegment)
+    {
+        this.mutableSegment = mutableSegment;
+    }
+
+    public bool IsFrozen => true;
+
+    public IIncrementalIdProvider OpIndexProvider => mutableSegment.OpIndexProvider;
+
+    public long SegmentId => mutableSegment.SegmentId;
+
+    public long Length => mutableSegment.Length;
+
+    public long MaximumOpIndex => mutableSegment.MaximumOpIndex;
+
+    public bool IsFullyFrozen => false;
+
+    public bool ContainsKey(in TKey key)
+    {
+        return mutableSegment.ContainsKey(key);
+    }
+
+    public AddOrUpdateResult Delete(in TKey key, out long opIndex)
+    {
+        opIndex = 0;
+        return AddOrUpdateResult.RETRY_SEGMENT_IS_FROZEN;
+    }
+
+    public void Drop()
+    {
+        mutableSegment.Drop();
+    }
+
+    public void Freeze()
+    {
+    }
+
+    public IIndexedReader<TKey, TValue> GetIndexedReader()
+    {
+        throw new NotSupportedException("BTree Indexed Reader is not supported.");
+    }
+
+    public ISeekableIterator<TKey, TValue> GetSeekableIterator(bool contributeToTheBlockCache = false)
+    {
+        return mutableSegment.GetSeekableIterator(contributeToTheBlockCache);
+    }
+
+    public void ReleaseResources()
+    {
+        mutableSegment.ReleaseResources();
+    }
+
+    public bool TryGet(in TKey key, out TValue value)
+    {
+        return mutableSegment.TryGet(key, out value);
+    }
+
+    public AddOrUpdateResult Upsert(in TKey key, in TValue value, out long opIndex)
+    {
+        opIndex = 0;
+        return AddOrUpdateResult.RETRY_SEGMENT_IS_FROZEN;
+    }
+
+    public AddOrUpdateResult Upsert(in TKey key, GetValueDelegate<TKey, TValue> valueGetter, out long opIndex)
+    {
+        opIndex = 0;
+        return AddOrUpdateResult.RETRY_SEGMENT_IS_FROZEN;
+    }
+}

--- a/src/ZoneTree/Segments/InMemory/MutableSegment.cs
+++ b/src/ZoneTree/Segments/InMemory/MutableSegment.cs
@@ -207,12 +207,18 @@ public sealed class MutableSegment<TKey, TValue> : IMutableSegment<TKey, TValue>
         try
         {
             Interlocked.Increment(ref WritesInProgress);
-            opIndex = 0;
+
             if (IsFrozenFlag)
+            {
+                opIndex = 0;
                 return AddOrUpdateResult.RETRY_SEGMENT_IS_FROZEN;
+            }
 
             if (BTree.Length >= MutableSegmentMaxItemCount)
+            {
+                opIndex = 0;
                 return AddOrUpdateResult.RETRY_SEGMENT_IS_FULL;
+            }
 
             TValue insertedValue = default;
 

--- a/src/ZoneTree/Segments/MultiPart/MultiPartDiskSegmentCreator.cs
+++ b/src/ZoneTree/Segments/MultiPart/MultiPartDiskSegmentCreator.cs
@@ -34,7 +34,7 @@ public sealed class MultiPartDiskSegmentCreator<TKey, TValue> : IDiskSegmentCrea
 
     readonly List<TValue> PartValues = new();
 
-    readonly Random Random = new();
+    readonly Random Random = Random.Shared;
 
     TKey LastAppendedKey;
 


### PR DESCRIPTION
Recently, the internal operation index (op index) per mutable segment was exposed to simplify the replication process. [See Issue #93 for more details](https://github.com/koculu/ZoneTree/issues/93).

Initially, the op indexes were designed to increment only within the scope of their respective mutable segment. Consequently, when switching between mutable segments, the op index order is not guaranteed to remain incremental.

To ensure consistency, improve the mutable segment switch process to guarantee that the op index order remains incremental across segment transitions.