### PR TITLE
Fix cloned DiskSegmentOptions

### DIFF
--- a/src/ZoneTree/Core/ZoneTree.cs
+++ b/src/ZoneTree/Core/ZoneTree.cs
@@ -394,7 +394,7 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
             BTreeNodeSize = options.BTreeNodeSize,
             Comparer = options.Comparer,
             DiskSegmentMaxItemCount = options.DiskSegmentMaxItemCount,
-            DiskSegmentOptions = dsk,
+            DiskSegmentOptions = clonesDiskSegmentOptions,
             EnableSingleSegmentGarbageCollection = options.EnableSingleSegmentGarbageCollection,
             IsDeleted = options.IsDeleted,
             KeySerializer = options.KeySerializer,


### PR DESCRIPTION
## Summary
- ensure clone uses new DiskSegmentOptions instead of original reference

## Testing
- `dotnet vstest src/ZoneTree.UnitTests/bin/Debug/net9.0/ZoneTree.UnitTests.dll --logger:trx --ResultsDirectory:TestResults` *(fails: TerminalLogger exception)*

------
https://chatgpt.com/codex/tasks/task_e_684c480ab03883289a1200fcb925aaf5