### PR TITLE
Fix KeyCacheRecord lifetime default

### DIFF
--- a/src/ZoneTree/Options/DiskSegmentDefaultValues.cs
+++ b/src/ZoneTree/Options/DiskSegmentDefaultValues.cs
@@ -18,7 +18,7 @@ public static class DiskSegmentDefaultValues
 
     public static readonly int ValueCacheSize = 1024;
 
-    public static readonly int KeyCacheRecordLifeTimeInMillisecond = 1024;
+    public static readonly int KeyCacheRecordLifeTimeInMillisecond = 10_000;
 
     public static readonly int ValueCacheRecordLifeTimeInMillisecond = 10_000;
 


### PR DESCRIPTION
## Summary
- adjust default `KeyCacheRecordLifeTimeInMillisecond` value to match documentation

## Testing
- `dotnet test src/ZoneTree.sln --no-build` *(fails: network access needed for restore)*

------
https://chatgpt.com/codex/tasks/task_e_684c4401f53c8328b09f2549a57e7d20