### PR TITLE
Fix IsDroppping typo

### DIFF
--- a/src/ZoneTree/Segments/Disk/DiskSegment.cs
+++ b/src/ZoneTree/Segments/Disk/DiskSegment.cs
@@ -33,7 +33,7 @@ public abstract class DiskSegment<TKey, TValue> : IDiskSegment<TKey, TValue>
 
     volatile bool IsDropRequested;
 
-    protected volatile bool IsDroppping;
+    protected volatile bool IsDropping;
 
     bool IsDropped;
 
@@ -317,7 +317,7 @@ public abstract class DiskSegment<TKey, TValue> : IDiskSegment<TKey, TValue>
 
             // reads will increase ReadCount when they begin,
             // and decrease ReadCount when they end.
-            IsDroppping = true;
+            IsDropping = true;
             // After the flag change,
             // reads will start throwing DiskSegmentIsDroppingException
 

--- a/src/ZoneTree/Segments/DiskSegmentVariations/FixedSizeKeyAndValueDiskSegment.cs
+++ b/src/ZoneTree/Segments/DiskSegmentVariations/FixedSizeKeyAndValueDiskSegment.cs
@@ -131,7 +131,7 @@ public sealed class FixedSizeKeyAndValueDiskSegment<TKey, TValue> : DiskSegment<
         {
             if (CircularKeyCache.TryGet(index, out var key)) return key;
             Interlocked.Increment(ref ReadCount);
-            if (IsDroppping)
+            if (IsDropping)
             {
                 throw new DiskSegmentIsDroppingException();
             }
@@ -158,7 +158,7 @@ public sealed class FixedSizeKeyAndValueDiskSegment<TKey, TValue> : DiskSegment<
         {
             if (CircularValueCache.TryGet(index, out var value)) return value;
             Interlocked.Increment(ref ReadCount);
-            if (IsDroppping)
+            if (IsDropping)
             {
                 throw new DiskSegmentIsDroppingException();
             }

--- a/src/ZoneTree/Segments/DiskSegmentVariations/FixedSizeKeyDiskSegment.cs
+++ b/src/ZoneTree/Segments/DiskSegmentVariations/FixedSizeKeyDiskSegment.cs
@@ -151,7 +151,7 @@ public sealed class FixedSizeKeyDiskSegment<TKey, TValue> : DiskSegment<TKey, TV
         {
             if (CircularKeyCache.TryGet(index, out var key)) return key;
             Interlocked.Increment(ref ReadCount);
-            if (IsDroppping)
+            if (IsDropping)
             {
                 throw new DiskSegmentIsDroppingException();
             }
@@ -178,7 +178,7 @@ public sealed class FixedSizeKeyDiskSegment<TKey, TValue> : DiskSegment<TKey, TV
         {
             if (CircularValueCache.TryGet(index, out var value)) return value;
             Interlocked.Increment(ref ReadCount);
-            if (IsDroppping)
+            if (IsDropping)
             {
                 throw new DiskSegmentIsDroppingException();
             }

--- a/src/ZoneTree/Segments/DiskSegmentVariations/FixedSizeValueDiskSegment.cs
+++ b/src/ZoneTree/Segments/DiskSegmentVariations/FixedSizeValueDiskSegment.cs
@@ -150,7 +150,7 @@ public sealed class FixedSizeValueDiskSegment<TKey, TValue> : DiskSegment<TKey, 
         {
             if (CircularKeyCache.TryGet(index, out var key)) return key;
             Interlocked.Increment(ref ReadCount);
-            if (IsDroppping)
+            if (IsDropping)
             {
                 throw new DiskSegmentIsDroppingException();
             }
@@ -184,7 +184,7 @@ public sealed class FixedSizeValueDiskSegment<TKey, TValue> : DiskSegment<TKey, 
         {
             if (CircularValueCache.TryGet(index, out var value)) return value;
             Interlocked.Increment(ref ReadCount);
-            if (IsDroppping)
+            if (IsDropping)
             {
                 throw new DiskSegmentIsDroppingException();
             }

--- a/src/ZoneTree/Segments/DiskSegmentVariations/VariableSizeDiskSegment.cs
+++ b/src/ZoneTree/Segments/DiskSegmentVariations/VariableSizeDiskSegment.cs
@@ -156,7 +156,7 @@ public sealed partial class VariableSizeDiskSegment<TKey, TValue> : DiskSegment<
         {
             if (CircularKeyCache.TryGet(index, out var key)) return key;
             Interlocked.Increment(ref ReadCount);
-            if (IsDroppping)
+            if (IsDropping)
             {
                 throw new DiskSegmentIsDroppingException();
             }
@@ -189,7 +189,7 @@ public sealed partial class VariableSizeDiskSegment<TKey, TValue> : DiskSegment<
         {
             if (CircularValueCache.TryGet(index, out var value)) return value;
             Interlocked.Increment(ref ReadCount);
-            if (IsDroppping)
+            if (IsDropping)
             {
                 throw new DiskSegmentIsDroppingException();
             }


### PR DESCRIPTION
## Summary
- rename `IsDroppping` to `IsDropping`
- update disk segment variants to use new name

------
https://chatgpt.com/codex/tasks/task_e_684ce00a122c8328adb02a0c3d6a0388