### PR TITLE
Fix Discord badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ ZoneTree is a **persistent**, **high-performance**, **transactional**, and **ACI
 [![Downloads](https://img.shields.io/nuget/dt/ZoneTree)](https://www.nuget.org/packages/ZoneTree/)
 ![Platform](https://img.shields.io/badge/platform-.NET-blue.svg)
 ![Build](https://img.shields.io/badge/build-passing-brightgreen.svg)
-[![Join Discord](https://dcbadge.vercel.app/api/server/d9aDtzVNNv?logoColor=f1c400&theme=discord&style=flat)](https://discord.gg/d9aDtzVNNv)
+[![Join Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/d9aDtzVNNv)
 
 ## Table of Contents
 


### PR DESCRIPTION
### Motivation
- The existing Discord badge was using a broken badge provider and displayed incorrectly, so it was replaced with a reliable free Shields.io badge while preserving the invite link.

### Description
- Updated `README.md` to replace the `dcbadge.vercel.app` badge with a Shields.io badge: `[![Join Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/d9aDtzVNNv)`.

### Testing
- Documentation-only change; no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69875c9825888328b279bbf6b455da14)