### PR TITLE
Add live backup and restore support.

### DIFF
--- a/docs/durability/backups.md
+++ b/docs/durability/backups.md
@@ -1,60 +1,389 @@
 # Backups
 
-Backup strategy depends on the WAL mode, maintenance behavior, and whether your application can reconstruct data.
+ZoneTree supports live backup for ordinary `IZoneTree<TKey, TValue>` instances and offline full backup for any deployment.
 
-## Basic Rule
+Live backup is the preferred shape for long-running applications. It creates complete backup generations while the tree remains open for reads and writes.
 
-Back up the full ZoneTree data directory as a unit. It contains metadata, WAL files, and segment files that together define the database.
+## Live Backup Model
 
-Do not copy one piece of the storage directory and assume it is enough.
+A live backup generation is a complete backup unit. It contains:
 
-## Simple Full Backup
+* immutable disk segment files,
+* optional in-memory records streamed into a record batch,
+* a generation catalog written by the backup store.
 
-The simplest reliable shape is:
+ZoneTree collects the current backup view, pins the disk segments that belong to that view, and lets the store upload or reuse the segment files. In-memory records are streamed through ZoneTree iterators.
 
-* stop or pause writes,
-* wait for background maintenance if you need a quiet storage shape,
-* dispose the tree or keep it closed during the copy,
-* copy the full data directory,
-* restore into a separate directory and open it as a test.
+This keeps the live system active while a backup generation is being created. Manual generations run in the caller's operation and complete before `CreateGenerationAsync()` returns. Scheduled and merge-triggered generations run asynchronously.
 
-For many embedded applications, this is the easiest operational model.
+Live backup is not exposed for transactional ZoneTree yet. Transactional backup must capture transaction-log state together with the storage-engine state, so it needs its own design.
 
-## Maintenance-Aware Backup
+## Quick Start
 
-Maintenance changes the physical storage shape by moving and merging segments. Coordinate backups so the copied state is consistent with metadata, WAL files, and segment files.
-
-For a stricter application-level backup window:
-
-* pause writes,
-* call `maintainer.EvictToDisk()` if you want to move current in-memory data toward disk,
-* call `maintainer.WaitForBackgroundThreads()`,
-* call `zoneTree.Maintenance.SaveMetaData()` if you want the JSON metadata file to be current for inspection,
-* copy the full data directory,
-* resume writes.
-
-`SaveMetaData` is useful for making the JSON metadata current, but the metadata file alone is not the database.
-
-## Incremental WAL Backup
-
-ZoneTree has WAL-related support for incremental backup scenarios through `WriteAheadLogOptions.EnableIncrementalBackup`.
+Use `CreateLiveBackup` with a local directory:
 
 ```csharp
+using ZoneTree.Backup;
+
 using var zoneTree = new ZoneTreeFactory<int, string>()
     .SetDataDirectory("data/app")
-    .ConfigureWriteAheadLogOptions(options =>
-    {
-        options.EnableIncrementalBackup = true;
-    })
     .OpenOrCreate();
+
+using var backup = zoneTree.CreateLiveBackup("backup/app");
+
+backup.Start();
+
+try
+{
+    await backup.CreateGenerationAsync();
+}
+finally
+{
+    backup.Stop();
+    await backup.WaitForLiveBackupAsync();
+}
 ```
 
-When a WAL is compacted or replaced, ZoneTree appends the previous WAL content to an incremental `.full` file beside that WAL. This preserves WAL history across WAL compaction; it is not a replacement for copying the full database directory.
+`Start()` activates the live backup coordinator by attaching merge-triggered backup handling and starting the configured scheduler. It does not create a generation by itself unless a schedule fires or a successful merge requests one.
 
-If you use incremental backup, test restore end to end. Backup is only real when restore has been verified.
+Use `CreateGenerationAsync()` when you want to create a backup generation immediately.
+
+`CreateGenerationAsync()` completes when the generation is finished. If the generation fails, the exception is propagated to the caller, usually as `LiveBackupGenerationException`.
+
+Use `Stop()` to disable automatic live backup triggers. Use `WaitForLiveBackupAsync()` when you want to wait until live backup is fully inactive.
+
+## Start, Stop, And Wait
+
+`Start()` and `Stop()` are synchronous lifecycle methods.
+
+```csharp
+backup.Start();
+backup.Stop();
+```
+
+`Start()` enables automatic live backup activity:
+
+* merge-triggered generations,
+* scheduled generations, if a schedule is configured.
+
+`Stop()` disables automatic live backup activity:
+
+* merge-triggered generation handling is detached,
+* scheduler cancellation is requested.
+
+`Stop()` does not wait for the scheduler to exit or for an active generation to finish. To wait until live backup activity is fully inactive, call:
+
+```csharp
+await backup.WaitForLiveBackupAsync();
+```
+
+For non-async callers:
+
+```csharp
+backup.WaitForLiveBackup();
+```
+
+`WaitForLiveBackupAsync()` waits while any of the following is true:
+
+* live backup is still started,
+* the scheduler is still running,
+* a backup generation is still running.
+
+This means `WaitForLiveBackupAsync()` normally returns after `Stop()` has been called and all background activity has completed.
+
+```csharp
+backup.Stop();
+await backup.WaitForLiveBackupAsync();
+```
+
+`Dispose()` calls `Stop()` and waits for live backup activity to finish. This makes `using var backup = ...` safe during shutdown.
+
+## Manual Generations
+
+To create a generation manually, use:
+
+```csharp
+await backup.CreateGenerationAsync();
+```
+
+For non-async callers:
+
+```csharp
+backup.CreateGeneration();
+```
+
+Manual generations do not require `Start()`.
+
+This is valid:
+
+```csharp
+using var backup = zoneTree.CreateLiveBackup("backup/app");
+
+await backup.CreateGenerationAsync();
+```
+
+A manual generation runs directly in the caller's operation. If the generation fails, the exception is thrown to the caller.
+
+## Generation Concurrency
+
+Live backup does not queue generations. ZoneTree allows only one live backup generation at a time.
+
+Manual generation requests are strict. If another generation is already running, `CreateGenerationAsync()` fails instead of queueing another generation.
+
+Scheduled and merge-triggered generation requests are opportunistic. If a generation is already running, the scheduled or merge-triggered request is skipped silently.
+
+In short:
+
+```text
+manual CreateGenerationAsync() while busy  -> throws
+scheduled generation while busy            -> skipped
+merge-triggered generation while busy      -> skipped
+```
+
+This avoids stale backup work and prevents scheduled or merge-triggered generations from building a backlog.
+
+## Local Store
+
+`LocalLiveBackupProvider` writes generations into a local directory.
+
+```csharp
+using var backup = zoneTree.CreateLiveBackup(new LiveBackupOptions
+{
+    Store = new LocalLiveBackupProvider("backup/app")
+});
+```
+
+The local implementation stores:
+
+* `manifest.json`: latest completed generation id,
+* `generations/*.json`: generation catalogs,
+* `data/*`: copied disk segment files,
+* `records/*.bin`: in-memory record batches.
+
+Disk segment files are immutable, so the store can reuse files that were already copied by earlier generations.
+
+The local backup directory is shaped like this:
+
+```text
+backup/app/
+├── manifest.json
+├── data/
+│   ├── <segment-file>
+│   └── ...
+├── records/
+│   ├── 00000000000000000001.bin
+│   └── ...
+└── generations/
+    ├── 00000000000000000001.json
+    └── ...
+```
+
+Generation catalogs and record batches use zero-padded numeric names so lexical filename ordering matches numeric generation or batch ordering.
+
+## In-Memory Records
+
+By default, live backup includes in-memory records:
+
+```csharp
+IncludeInMemoryRecords = true
+```
+
+These records are serialized with the ZoneTree key and value serializers. Record batches are compressed by default with LZ4.
+
+Use `Live` mode when you want the least intrusive backup pass:
+
+```csharp
+InMemoryMode = LiveBackupInMemoryMode.Live
+```
+
+`Live` mode iterates mutable and read-only in-memory segments without moving the mutable segment forward.
+
+Use `Snapshot` mode when you want a cleaner in-memory boundary:
+
+```csharp
+InMemoryMode = LiveBackupInMemoryMode.Snapshot
+```
+
+`Snapshot` mode moves the mutable segment forward and then iterates read-only in-memory segments.
+
+If in-memory records are disabled, a generation contains disk segments only. Recent writes become part of later generations after maintenance moves them to disk.
+
+## Merge-Triggered Generations
+
+By default, successful normal merges request a new live backup generation:
+
+```csharp
+BackupAfterMerge = true
+```
+
+This is useful because a normal merge can move recent in-memory data into immutable disk segments.
+
+Bottom-segment merges do not request live backup generations. They reshape already durable bottom data and do not move recent mutable data into disk coverage.
+
+If a backup generation is already running, merge-triggered generation requests are skipped. Live backup does not queue multiple generations behind the active one.
+
+Disable merge-triggered generations when you want only manual or scheduled backup:
+
+```csharp
+BackupAfterMerge = false
+```
+
+Merge-triggered generations run asynchronously. If a merge-triggered generation starts and then fails, the failure is logged through the ZoneTree logger.
+
+## Scheduling
+
+Live backup can create generations on a UTC schedule.
+
+```csharp
+using var backup = zoneTree.CreateLiveBackup(new LiveBackupOptions
+{
+    Store = new LocalLiveBackupProvider("backup/app"),
+    Schedule = LiveBackupSchedule.Daily(
+        new TimeOnly(2, 0),
+        new TimeOnly(14, 0))
+});
+
+backup.Start();
+```
+
+Available schedules:
+
+```csharp
+LiveBackupSchedule.Every(TimeSpan.FromMinutes(15));
+
+LiveBackupSchedule.Daily(
+    new TimeOnly(2, 0),
+    new TimeOnly(14, 0));
+
+LiveBackupSchedule.Weekly(
+    LiveBackupSchedule.On(DayOfWeek.Sunday, new TimeOnly(2, 0)));
+```
+
+If a scheduled generation is due while another backup generation is already running, ZoneTree skips that tick. Backup scheduling does not build a backlog.
+
+Scheduled generations run asynchronously. If a scheduled generation starts and then fails, the failure is logged through the ZoneTree logger.
+
+To stop the scheduler and wait until it has exited:
+
+```csharp
+backup.Stop();
+await backup.WaitForLiveBackupAsync();
+```
+
+## Shutdown
+
+A typical shutdown sequence is:
+
+```csharp
+backup.Stop();
+await backup.WaitForLiveBackupAsync();
+```
+
+`Stop()` disables new scheduled and merge-triggered generations. `WaitForLiveBackupAsync()` waits until the scheduler has exited and any active generation has completed.
+
+`Stop()` does not create a final generation by itself. If you want a final backup point before shutdown, create it explicitly:
+
+```csharp
+await backup.CreateGenerationAsync();
+
+backup.Stop();
+await backup.WaitForLiveBackupAsync();
+```
+
+For non-async callers:
+
+```csharp
+backup.CreateGeneration();
+
+backup.Stop();
+backup.WaitForLiveBackup();
+```
+
+If `LiveBackup` is disposed, it stops live backup and waits for live backup activity to finish.
+
+## Retention
+
+Local retention is configured on `LocalLiveBackupOptions`:
+
+```csharp
+using var backup = zoneTree.CreateLiveBackup(new LiveBackupOptions
+{
+    Store = new LocalLiveBackupProvider(new LocalLiveBackupOptions
+    {
+        Directory = "backup/app",
+        KeepLastGenerations = 7
+    })
+});
+```
+
+The local store keeps the latest completed generations and removes files that are no longer referenced by retained generation catalogs.
+
+Retention is applied at the backup-path level. If a retained generation reuses a segment file that was originally copied by an older generation, the physical segment file is preserved because the retained generation still references the same backup path.
+
+Custom stores own their own retention policy.
+
+## Custom Stores And Sources
+
+Implement `ILiveBackupStore` when backup data should go somewhere other than a local directory.
+
+Store implementations decide:
+
+* how generation ids are assigned,
+* where segment files are stored,
+* whether an existing segment file can be reused,
+* how record batches are written,
+* how retention works.
+
+ZoneTree decides:
+
+* which segments belong to a generation,
+* when disk segments must be pinned,
+* how in-memory records are streamed,
+* when manual, scheduled, and merge-triggered generations are started or skipped.
+
+ZoneTree allows only one live backup generation at a time. Manual generation requests fail if another generation is already running. Scheduled and merge-triggered generation requests are skipped while a generation is active.
+
+Segment reuse is handled by `UseSegmentAsync`:
+
+```csharp
+Task<bool> UseSegmentAsync(
+    long generationId,
+    DiskSegmentFile file,
+    CancellationToken cancellationToken);
+```
+
+Return `false` when the store already has the segment file. Return `true` when ZoneTree should upload the file through `UploadSegmentFileAsync`.
+
+Restore uses the matching read-side abstraction:
+
+```csharp
+public interface ILiveBackupSource
+```
+
+The local implementation supports both sides, so restoring the latest local generation is direct:
+
+```csharp
+using var restored = await new ZoneTreeFactory<int, string>()
+    .SetDataDirectory("data/restore")
+    .RestoreFromLatestLiveBackup("backup/app");
+```
+
+## Offline Full Backup
+
+Offline backup is the simple maintenance-window option:
+
+* stop writes,
+* wait for maintenance work to finish,
+* dispose the tree,
+* copy the full ZoneTree data directory,
+* copy the WAL directory too if it is configured separately.
+
+A ZoneTree database is a set of files, not a single file. Depending on configuration, storage can include metadata, disk segments, WAL files, meta WAL files, transaction WAL files, and multi-part segment files.
+
+If `SetWriteAheadLogDirectory(...)` points WAL files outside the data directory, copy both locations from the same backup point.
 
 ## Rebuildable Data
 
-Some ZoneTree deployments store indexes, caches, or derived views that can be rebuilt from another source. In those systems, backup may focus on the source of truth instead of the ZoneTree directory.
+Some applications use ZoneTree for indexes, projections, caches, or derived views. If the data can be rebuilt from another source of truth, backup can focus on that source instead of the ZoneTree files.
 
-Use `No WAL` only when that data-loss boundary is intentional.
+Use no-WAL or relaxed backup policies only when that data-loss boundary is intentional.

--- a/src/ZoneTree.UnitTests/DiskSegmentFactoryTests.cs
+++ b/src/ZoneTree.UnitTests/DiskSegmentFactoryTests.cs
@@ -1,0 +1,141 @@
+using ZoneTree.Options;
+using ZoneTree.Segments.Disk;
+using ZoneTree.Serializers;
+
+namespace ZoneTree.UnitTests;
+
+public sealed class DiskSegmentFactoryTests
+{
+  [Test]
+  public void CreatesFixedSizeKeyAndValueDiskSegmentFromFiles()
+  {
+    AssertDiskSegmentCanBeCreatedFromFiles<int, int>(
+        "CreatesFixedSizeKeyAndValueDiskSegmentFromFiles",
+        DiskSegmentMode.SingleDiskSegment,
+        i => i,
+        i => i + 1,
+        factory => factory.DisableDeletion());
+  }
+
+  [Test]
+  public void CreatesFixedSizeKeyDiskSegmentFromFiles()
+  {
+    AssertDiskSegmentCanBeCreatedFromFiles<int, string>(
+        "CreatesFixedSizeKeyDiskSegmentFromFiles",
+        DiskSegmentMode.SingleDiskSegment,
+        i => i,
+        i => "value-" + i,
+        factory => factory
+            .DisableDeletion()
+            .SetValueSerializer(new UnicodeStringSerializer()));
+  }
+
+  [Test]
+  public void CreatesFixedSizeValueDiskSegmentFromFiles()
+  {
+    AssertDiskSegmentCanBeCreatedFromFiles<string, int>(
+        "CreatesFixedSizeValueDiskSegmentFromFiles",
+        DiskSegmentMode.SingleDiskSegment,
+        i => i.ToString("D5"),
+        i => i + 1,
+        factory => factory
+            .DisableDeletion()
+            .SetKeySerializer(new UnicodeStringSerializer()));
+  }
+
+  [Test]
+  public void CreatesVariableSizeDiskSegmentFromFiles()
+  {
+    AssertDiskSegmentCanBeCreatedFromFiles<string, string>(
+        "CreatesVariableSizeDiskSegmentFromFiles",
+        DiskSegmentMode.SingleDiskSegment,
+        i => i.ToString("D5"),
+        i => "value-" + i,
+        factory => factory
+            .DisableDeletion()
+            .SetKeySerializer(new UnicodeStringSerializer())
+            .SetValueSerializer(new UnicodeStringSerializer()));
+  }
+
+  [Test]
+  public void CreatesMultiPartDiskSegmentFromFiles()
+  {
+    AssertDiskSegmentCanBeCreatedFromFiles<int, int>(
+        "CreatesMultiPartDiskSegmentFromFiles",
+        DiskSegmentMode.MultiPartDiskSegment,
+        i => i,
+        i => i + 1,
+        factory => factory.DisableDeletion(),
+        configureDiskSegmentOptions: options =>
+        {
+          options.MinimumRecordCount = 3;
+          options.MaximumRecordCount = 4;
+        },
+        recordCount: 12);
+  }
+
+  static void AssertDiskSegmentCanBeCreatedFromFiles<TKey, TValue>(
+      string name,
+      DiskSegmentMode diskSegmentMode,
+      Func<int, TKey> keyFactory,
+      Func<int, TValue> valueFactory,
+      Func<ZoneTreeFactory<TKey, TValue>, ZoneTreeFactory<TKey, TValue>> configureFactory,
+      Action<DiskSegmentOptions> configureDiskSegmentOptions = null,
+      int recordCount = 32)
+  {
+    var dataPath = "data/" + name;
+    DeleteDirectory(dataPath);
+
+    DiskSegmentFile[] files;
+    ZoneTreeOptions<TKey, TValue> options;
+    var keys = new TKey[recordCount];
+    var values = new TValue[recordCount];
+
+    using (var zoneTree = configureFactory(new ZoneTreeFactory<TKey, TValue>())
+        .SetDataDirectory(dataPath)
+        .SetWriteAheadLogDirectory(dataPath)
+        .ConfigureWriteAheadLogOptions(options =>
+            options.WriteAheadLogMode = WriteAheadLogMode.None)
+        .ConfigureDiskSegmentOptions(options =>
+        {
+          options.DiskSegmentMode = diskSegmentMode;
+          configureDiskSegmentOptions?.Invoke(options);
+        })
+        .OpenOrCreate())
+    {
+      for (var i = 0; i < recordCount; ++i)
+      {
+        keys[i] = keyFactory(i);
+        values[i] = valueFactory(i);
+        zoneTree.Upsert(keys[i], values[i]);
+      }
+
+      zoneTree.Maintenance.MoveMutableSegmentForward();
+      zoneTree.Maintenance.StartMergeOperation().Join();
+
+      files = zoneTree.Maintenance.DiskSegment.GetFiles();
+      options = zoneTree.Maintenance.CloneOptions();
+
+      Assert.That(files, Is.Not.Empty);
+    }
+
+    using (var diskSegment = DiskSegmentFactory.CreateDiskSegment<TKey, TValue>(
+        files,
+        options))
+    {
+      for (var i = 0; i < recordCount; ++i)
+      {
+        Assert.That(diskSegment.TryGet(keys[i], out var value), Is.True);
+        Assert.That(value, Is.EqualTo(values[i]));
+      }
+    }
+
+    DeleteDirectory(dataPath);
+  }
+
+  static void DeleteDirectory(string path)
+  {
+    if (Directory.Exists(path))
+      Directory.Delete(path, true);
+  }
+}

--- a/src/ZoneTree.UnitTests/LiveBackupTests.cs
+++ b/src/ZoneTree.UnitTests/LiveBackupTests.cs
@@ -1,0 +1,1353 @@
+using System.Reflection;
+using System.Text.Json;
+using ZoneTree.Backup;
+using ZoneTree.Logger;
+using ZoneTree.Options;
+using ZoneTree.Segments;
+using ZoneTree.Segments.Disk;
+
+namespace ZoneTree.UnitTests;
+
+public sealed class LiveBackupTests
+{
+  [Test]
+  public void LiveBackupStartDoesNotCreateGeneration()
+  {
+    var dataPath = "data/LiveBackupStartDoesNotCreateGeneration";
+    DeleteDirectory(dataPath);
+    var provider = new InMemoryLiveBackupProvider();
+
+    using var zoneTree = new ZoneTreeFactory<int, int>()
+        .SetDataDirectory(dataPath)
+        .SetWriteAheadLogDirectory(dataPath)
+        .OpenOrCreate();
+
+    using var backup = zoneTree.CreateLiveBackup(new LiveBackupOptions
+    {
+      Store = provider,
+      BackupAfterMerge = false,
+      IncludeInMemoryRecords = false
+    });
+
+    backup.Start();
+
+    Assert.That(backup.CurrentGenerationId, Is.EqualTo(0));
+    Assert.That(provider.BeginGenerationCount, Is.EqualTo(0));
+
+    backup.Stop();
+    backup.WaitForLiveBackup();
+    zoneTree.Maintenance.Drop();
+  }
+
+  [Test]
+  public void LiveBackupStreamsInMemoryRecordsWithoutMovingMutableSegment()
+  {
+    var dataPath = "data/LiveBackupStreamsInMemoryRecordsWithoutMovingMutableSegment";
+    var backupPath = "data/LiveBackupStreamsInMemoryRecordsWithoutMovingMutableSegment.Backup";
+    DeleteDirectory(dataPath);
+    DeleteDirectory(backupPath);
+
+    using var zoneTree = new ZoneTreeFactory<int, int>()
+        .SetDataDirectory(dataPath)
+        .SetWriteAheadLogDirectory(dataPath)
+        .OpenOrCreate();
+
+    for (var i = 0; i < 10; ++i)
+      zoneTree.Upsert(i, i);
+
+    var mutableSegmentId = zoneTree.Maintenance.MutableSegment.SegmentId;
+    using var backup = zoneTree.CreateLiveBackup(backupPath);
+
+    backup.Start();
+    backup.CreateGeneration();
+
+    var generationId = backup.CurrentGenerationId;
+    var catalog = ReadCurrentLocalGenerationCatalog(backupPath);
+    var recordBatch = catalog.RecordBatch;
+    Assert.That(zoneTree.Maintenance.MutableSegment.SegmentId, Is.EqualTo(mutableSegmentId));
+    Assert.That(catalog.GenerationId, Is.EqualTo(generationId));
+    Assert.That(recordBatch, Is.Not.Null);
+    Assert.That(recordBatch.Completed, Is.True);
+    Assert.That(recordBatch.RecordCount, Is.EqualTo(10));
+    Assert.That(recordBatch.CompressionMethod, Is.EqualTo(CompressionMethod.LZ4));
+    Assert.That(recordBatch.UncompressedLength, Is.GreaterThan(0));
+    Assert.That(recordBatch.StoredLength, Is.GreaterThan(0));
+    Assert.That(
+        File.Exists(Path.Combine(
+            backupPath,
+            recordBatch.BackupPath.Replace('/', Path.DirectorySeparatorChar))),
+        Is.True);
+
+    backup.Stop();
+    zoneTree.Maintenance.Drop();
+    DeleteDirectory(backupPath);
+  }
+
+  [Test]
+  public void LiveBackupCopiesDiskSegmentCreatedByMerge()
+  {
+    var dataPath = "data/LiveBackupCopiesDiskSegmentCreatedByMerge";
+    var backupPath = "data/LiveBackupCopiesDiskSegmentCreatedByMerge.Backup";
+    DeleteDirectory(dataPath);
+    DeleteDirectory(backupPath);
+
+    using var zoneTree = new ZoneTreeFactory<int, int>()
+        .DisableDeletion()
+        .SetMutableSegmentMaxItemCount(3)
+        .SetDataDirectory(dataPath)
+        .SetWriteAheadLogDirectory(dataPath)
+        .OpenOrCreate();
+
+    using var backup = zoneTree.CreateLiveBackup(backupPath);
+    backup.Start();
+
+    for (var i = 0; i < 10; ++i)
+      zoneTree.Upsert(i, i);
+
+    zoneTree.Maintenance.MoveMutableSegmentForward();
+    zoneTree.Maintenance.StartMergeOperation().Join();
+    backup.Stop();
+    backup.WaitForLiveBackup();
+
+    var diskSegment = zoneTree.Maintenance.DiskSegment;
+    var diskSegmentId = diskSegment.SegmentId;
+    var generationId = backup.CurrentGenerationId;
+    var catalog = ReadCurrentLocalGenerationCatalog(backupPath);
+    Assert.That(diskSegmentId, Is.GreaterThan(0));
+    Assert.That(catalog.GenerationId, Is.EqualTo(generationId));
+    Assert.That(catalog.SegmentIds, Does.Contain(diskSegmentId));
+    AssertDiskSegmentBackedUp(backupPath, catalog, diskSegment);
+
+    backup.Stop();
+    zoneTree.Maintenance.Drop();
+    DeleteDirectory(backupPath);
+  }
+
+  [Test]
+  public async Task LocalLiveBackupCanRestoreDiskSegmentsAndInMemoryRecords()
+  {
+    var dataPath = "data/LocalLiveBackupCanRestoreDiskSegmentsAndInMemoryRecords";
+    var backupPath = "data/LocalLiveBackupCanRestoreDiskSegmentsAndInMemoryRecords.Backup";
+    var restorePath = "data/LocalLiveBackupCanRestoreDiskSegmentsAndInMemoryRecords.Restore";
+    DeleteDirectory(dataPath);
+    DeleteDirectory(backupPath);
+    DeleteDirectory(restorePath);
+
+    using (var zoneTree = new ZoneTreeFactory<int, int>()
+        .DisableDeletion()
+        .SetMutableSegmentMaxItemCount(3)
+        .SetDataDirectory(dataPath)
+        .SetWriteAheadLogDirectory(dataPath)
+        .OpenOrCreate())
+    {
+      for (var i = 0; i < 10; ++i)
+        zoneTree.Upsert(i, i);
+
+      zoneTree.Maintenance.MoveMutableSegmentForward();
+      zoneTree.Maintenance.StartMergeOperation().Join();
+
+      for (var i = 10; i < 15; ++i)
+        zoneTree.Upsert(i, i);
+
+      using var backup = zoneTree.CreateLiveBackup(backupPath);
+      backup.Start();
+      backup.CreateGeneration();
+      backup.Stop();
+
+      zoneTree.Maintenance.Drop();
+    }
+
+    using (var restored = await new ZoneTreeFactory<int, int>()
+        .DisableDeletion()
+        .SetDataDirectory(restorePath)
+        .SetWriteAheadLogDirectory(restorePath)
+        .RestoreFromLatestLiveBackup(backupPath))
+    {
+      for (var i = 0; i < 15; ++i)
+      {
+        Assert.That(restored.TryGet(i, out var value), Is.True);
+        Assert.That(value, Is.EqualTo(i));
+      }
+
+      restored.Maintenance.Drop();
+    }
+
+    DeleteDirectory(backupPath);
+  }
+
+  [Test]
+  public async Task LocalLiveBackupRestorePreservesDeletedInMemoryRecords()
+  {
+    var dataPath = "data/LocalLiveBackupRestorePreservesDeletedInMemoryRecords";
+    var backupPath = "data/LocalLiveBackupRestorePreservesDeletedInMemoryRecords.Backup";
+    var restorePath = "data/LocalLiveBackupRestorePreservesDeletedInMemoryRecords.Restore";
+    DeleteDirectory(dataPath);
+    DeleteDirectory(backupPath);
+    DeleteDirectory(restorePath);
+
+    using (var zoneTree = new ZoneTreeFactory<int, int>()
+        .SetDataDirectory(dataPath)
+        .SetWriteAheadLogDirectory(dataPath)
+        .OpenOrCreate())
+    {
+      zoneTree.Upsert(1, 1);
+      zoneTree.ForceDelete(1);
+      zoneTree.Upsert(2, 2);
+
+      using var backup = zoneTree.CreateLiveBackup(backupPath);
+      backup.Start();
+      backup.CreateGeneration();
+      backup.Stop();
+
+      zoneTree.Maintenance.Drop();
+    }
+
+    using (var restored = await new ZoneTreeFactory<int, int>()
+        .SetDataDirectory(restorePath)
+        .SetWriteAheadLogDirectory(restorePath)
+        .RestoreFromLatestLiveBackup(backupPath))
+    {
+      Assert.That(restored.TryGet(1, out _), Is.False);
+      Assert.That(restored.TryGet(2, out var value), Is.True);
+      Assert.That(value, Is.EqualTo(2));
+
+      restored.Maintenance.Drop();
+    }
+
+    DeleteDirectory(backupPath);
+  }
+
+  [Test]
+  public async Task LocalLiveBackupCanRestoreSpecificGeneration()
+  {
+    var dataPath = "data/LocalLiveBackupCanRestoreSpecificGeneration";
+    var backupPath = "data/LocalLiveBackupCanRestoreSpecificGeneration.Backup";
+    var restoreFirstPath = "data/LocalLiveBackupCanRestoreSpecificGeneration.First";
+    var restoreLatestPath = "data/LocalLiveBackupCanRestoreSpecificGeneration.Latest";
+    DeleteDirectory(dataPath);
+    DeleteDirectory(backupPath);
+    DeleteDirectory(restoreFirstPath);
+    DeleteDirectory(restoreLatestPath);
+
+    long firstGenerationId;
+    using (var zoneTree = new ZoneTreeFactory<int, int>()
+        .DisableDeletion()
+        .SetDataDirectory(dataPath)
+        .SetWriteAheadLogDirectory(dataPath)
+        .OpenOrCreate())
+    {
+      for (var i = 0; i < 5; ++i)
+        zoneTree.Upsert(i, i);
+
+      using var backup = zoneTree.CreateLiveBackup(backupPath);
+      await backup.CreateGenerationAsync();
+      firstGenerationId = backup.CurrentGenerationId;
+
+      for (var i = 5; i < 10; ++i)
+        zoneTree.Upsert(i, i);
+
+      backup.CreateGeneration();
+      backup.Stop();
+      backup.WaitForLiveBackup();
+      zoneTree.Maintenance.Drop();
+    }
+
+    using (var restored = await new ZoneTreeFactory<int, int>()
+        .DisableDeletion()
+        .SetDataDirectory(restoreFirstPath)
+        .SetWriteAheadLogDirectory(restoreFirstPath)
+        .RestoreFromLiveBackupGeneration(backupPath, firstGenerationId))
+    {
+      for (var i = 0; i < 5; ++i)
+        Assert.That(restored.TryGet(i, out _), Is.True);
+      for (var i = 5; i < 10; ++i)
+        Assert.That(restored.TryGet(i, out _), Is.False);
+      restored.Maintenance.Drop();
+    }
+
+    using (var restored = await new ZoneTreeFactory<int, int>()
+        .DisableDeletion()
+        .SetDataDirectory(restoreLatestPath)
+        .SetWriteAheadLogDirectory(restoreLatestPath)
+        .RestoreFromLatestLiveBackup(backupPath))
+    {
+      for (var i = 0; i < 10; ++i)
+        Assert.That(restored.TryGet(i, out _), Is.True);
+      restored.Maintenance.Drop();
+    }
+
+    DeleteDirectory(backupPath);
+  }
+
+  [Test]
+  public void LocalLiveBackupRestoreThrowsDedicatedExceptionWhenTargetExists()
+  {
+    var dataPath = "data/LocalLiveBackupRestoreThrowsDedicatedExceptionWhenTargetExists";
+    var backupPath = "data/LocalLiveBackupRestoreThrowsDedicatedExceptionWhenTargetExists.Backup";
+    var restorePath = "data/LocalLiveBackupRestoreThrowsDedicatedExceptionWhenTargetExists.Restore";
+    DeleteDirectory(dataPath);
+    DeleteDirectory(backupPath);
+    DeleteDirectory(restorePath);
+
+    using (var zoneTree = new ZoneTreeFactory<int, int>()
+        .DisableDeletion()
+        .SetDataDirectory(dataPath)
+        .SetWriteAheadLogDirectory(dataPath)
+        .OpenOrCreate())
+    {
+      zoneTree.Upsert(1, 1);
+      using var backup = zoneTree.CreateLiveBackup(backupPath);
+      backup.Start();
+      backup.CreateGeneration();
+      backup.Stop();
+      zoneTree.Maintenance.Drop();
+    }
+
+    using (var existing = new ZoneTreeFactory<int, int>()
+        .DisableDeletion()
+        .SetDataDirectory(restorePath)
+        .SetWriteAheadLogDirectory(restorePath)
+        .OpenOrCreate())
+    {
+      existing.Upsert(2, 2);
+    }
+
+    Assert.ThrowsAsync<LiveBackupRestoreTargetAlreadyExistsException>(async () =>
+      await new ZoneTreeFactory<int, int>()
+         .DisableDeletion()
+         .SetDataDirectory(restorePath)
+         .SetWriteAheadLogDirectory(restorePath)
+         .RestoreFromLatestLiveBackup(backupPath)
+    );
+
+    using (var existing = new ZoneTreeFactory<int, int>()
+        .DisableDeletion()
+        .SetDataDirectory(restorePath)
+        .SetWriteAheadLogDirectory(restorePath)
+        .Open())
+    {
+      existing.Maintenance.Drop();
+    }
+
+    DeleteDirectory(backupPath);
+  }
+
+  [Test]
+  public void SnapshotReadOnlyLiveBackupMovesMutableSegmentForward()
+  {
+    var dataPath = "data/SnapshotReadOnlyLiveBackupMovesMutableSegmentForward";
+    var backupPath = "data/SnapshotReadOnlyLiveBackupMovesMutableSegmentForward.Backup";
+    DeleteDirectory(dataPath);
+    DeleteDirectory(backupPath);
+
+    using var zoneTree = new ZoneTreeFactory<int, int>()
+        .SetDataDirectory(dataPath)
+        .SetWriteAheadLogDirectory(dataPath)
+        .OpenOrCreate();
+
+    for (var i = 0; i < 10; ++i)
+      zoneTree.Upsert(i, i);
+
+    var mutableSegmentId = zoneTree.Maintenance.MutableSegment.SegmentId;
+    using var backup = zoneTree.CreateLiveBackup(new LiveBackupOptions
+    {
+      Store = new LocalLiveBackupProvider(backupPath),
+      InMemoryMode = LiveBackupInMemoryMode.Snapshot
+    });
+
+    backup.Start();
+    backup.CreateGeneration();
+
+    var catalog = ReadCurrentLocalGenerationCatalog(backupPath);
+    var recordBatch = catalog.RecordBatch;
+    Assert.That(zoneTree.Maintenance.MutableSegment.SegmentId, Is.Not.EqualTo(mutableSegmentId));
+    Assert.That(catalog.GenerationId, Is.EqualTo(backup.CurrentGenerationId));
+    Assert.That(recordBatch, Is.Not.Null);
+    Assert.That(recordBatch.Completed, Is.True);
+    Assert.That(recordBatch.RecordCount, Is.EqualTo(10));
+
+    backup.Stop();
+    zoneTree.Maintenance.Drop();
+    DeleteDirectory(backupPath);
+  }
+
+  [Test]
+  public void FailedLiveBackupReleasesDiskSegmentPin()
+  {
+    var dataPath = "data/FailedLiveBackupReleasesDiskSegmentPin";
+    DeleteDirectory(dataPath);
+
+    var logger = new NullLogger();
+    using var zoneTree = new ZoneTreeFactory<int, int>()
+        .DisableDeletion()
+        .SetMutableSegmentMaxItemCount(3)
+        .SetDataDirectory(dataPath)
+        .SetWriteAheadLogDirectory(dataPath)
+        .SetLogger(logger)
+        .OpenOrCreate();
+
+    for (var i = 0; i < 10; ++i)
+      zoneTree.Upsert(i, i);
+
+    zoneTree.Maintenance.MoveMutableSegmentForward();
+    zoneTree.Maintenance.StartMergeOperation().Join();
+
+    var diskSegment = zoneTree.Maintenance.DiskSegment;
+    Assert.That(diskSegment.SegmentId, Is.GreaterThan(0));
+
+    using var backup = zoneTree.CreateLiveBackup(new LiveBackupOptions
+    {
+      Store = new FailingLiveBackupProvider(),
+      IncludeInMemoryRecords = false
+    });
+
+    backup.Start();
+    var exception = Assert.Throws<LiveBackupGenerationException>(
+      () => backup.CreateGeneration());
+    Assert.That(exception, Is.Not.Null);
+    Assert.That(exception.InnerException, Is.TypeOf<InvalidOperationException>());
+
+    Assert.That(GetIteratorReaderCount(diskSegment), Is.EqualTo(0));
+
+    backup.Stop();
+    zoneTree.Maintenance.Drop();
+  }
+
+  [Test]
+  public void RepeatedLiveBackupGenerationReusesCopiedDiskSegmentFiles()
+  {
+    var dataPath = "data/RepeatedLiveBackupGenerationReusesCopiedDiskSegmentFiles";
+    var backupPath = "data/RepeatedLiveBackupGenerationReusesCopiedDiskSegmentFiles.Backup";
+    DeleteDirectory(dataPath);
+    DeleteDirectory(backupPath);
+
+    using var zoneTree = new ZoneTreeFactory<int, int>()
+        .DisableDeletion()
+        .SetMutableSegmentMaxItemCount(3)
+        .SetDataDirectory(dataPath)
+        .SetWriteAheadLogDirectory(dataPath)
+        .OpenOrCreate();
+
+    for (var i = 0; i < 10; ++i)
+      zoneTree.Upsert(i, i);
+
+    zoneTree.Maintenance.MoveMutableSegmentForward();
+    zoneTree.Maintenance.StartMergeOperation().Join();
+
+    var diskSegmentId = zoneTree.Maintenance.DiskSegment.SegmentId;
+    using var backup = zoneTree.CreateLiveBackup(new LiveBackupOptions
+    {
+      Store = new LocalLiveBackupProvider(backupPath),
+      IncludeInMemoryRecords = false
+    });
+
+    backup.Start();
+    backup.CreateGeneration();
+    var firstCatalog = ReadCurrentLocalGenerationCatalog(backupPath);
+    var firstFileCount = firstCatalog.Files.Count;
+
+    backup.CreateGeneration();
+
+    var latestGenerationId = backup.CurrentGenerationId;
+    var secondCatalog = ReadCurrentLocalGenerationCatalog(backupPath);
+    Assert.That(latestGenerationId, Is.GreaterThanOrEqualTo(2));
+    Assert.That(secondCatalog.SegmentIds, Does.Contain(diskSegmentId));
+    Assert.That(secondCatalog.Files.Count, Is.EqualTo(firstFileCount));
+
+    backup.Stop();
+    zoneTree.Maintenance.Drop();
+    DeleteDirectory(backupPath);
+  }
+
+  [Test]
+  public void LiveBackupAsksProviderBeforeUploadingExistingSegment()
+  {
+    var dataPath = "data/LiveBackupAsksProviderBeforeUploadingExistingSegment";
+    DeleteDirectory(dataPath);
+    var provider = new CatalogTrackingLiveBackupProvider();
+
+    using var zoneTree = new ZoneTreeFactory<int, int>()
+        .DisableDeletion()
+        .SetMutableSegmentMaxItemCount(3)
+        .SetDataDirectory(dataPath)
+        .SetWriteAheadLogDirectory(dataPath)
+        .OpenOrCreate();
+
+    for (var i = 0; i < 10; ++i)
+      zoneTree.Upsert(i, i);
+
+    zoneTree.Maintenance.MoveMutableSegmentForward();
+    zoneTree.Maintenance.StartMergeOperation().Join();
+
+    using var backup = zoneTree.CreateLiveBackup(new LiveBackupOptions
+    {
+      Store = provider,
+      IncludeInMemoryRecords = false
+    });
+
+    backup.Start();
+    backup.CreateGeneration();
+    var firstUploadCount = provider.FileUploadCount;
+    Assert.That(firstUploadCount, Is.GreaterThan(0));
+
+    backup.CreateGeneration();
+
+    Assert.That(provider.FileUploadCount, Is.EqualTo(firstUploadCount));
+    Assert.That(provider.UseSegmentCallCount, Is.GreaterThanOrEqualTo(2));
+
+    backup.Stop();
+    zoneTree.Maintenance.Drop();
+  }
+
+  [Test]
+  public void LocalLiveBackupRetentionKeepsLastGenerations()
+  {
+    var dataPath = "data/LocalLiveBackupRetentionKeepsLastGenerations";
+    var backupPath = "data/LocalLiveBackupRetentionKeepsLastGenerations.Backup";
+    DeleteDirectory(dataPath);
+    DeleteDirectory(backupPath);
+
+    using var zoneTree = new ZoneTreeFactory<int, int>()
+        .SetDataDirectory(dataPath)
+        .SetWriteAheadLogDirectory(dataPath)
+        .OpenOrCreate();
+
+    for (var i = 0; i < 10; ++i)
+      zoneTree.Upsert(i, i);
+
+    using var backup = zoneTree.CreateLiveBackup(new LiveBackupOptions
+    {
+      Store = new LocalLiveBackupProvider(
+          new LocalLiveBackupOptions
+          {
+            Directory = backupPath,
+            KeepLastGenerations = 2
+          }),
+      BackupAfterMerge = false
+    });
+
+    backup.Start();
+    backup.CreateGeneration();
+    backup.CreateGeneration();
+    backup.CreateGeneration();
+
+    var manifest = ReadLocalManifest(backupPath);
+    Assert.That(manifest.CurrentGenerationId, Is.EqualTo(3));
+
+    var generationsPath = Path.Combine(backupPath, "generations");
+    var generationFiles = Directory.GetFiles(generationsPath, "*.json")
+        .OrderBy(x => x, StringComparer.Ordinal)
+        .ToArray();
+    Assert.That(generationFiles.Length, Is.EqualTo(2));
+    Assert.That(
+        generationFiles.Select(x => Path.GetFileNameWithoutExtension(x)),
+        Is.EqualTo(new[]
+        {
+          2L.ToString("D20"),
+          3L.ToString("D20")
+        }));
+
+    var recordsPath = Path.Combine(backupPath, "records");
+    var recordFiles = Directory.GetFiles(recordsPath, "*.bin");
+    Assert.That(recordFiles.Length, Is.EqualTo(2));
+    foreach (var generationId in new[] { 2L, 3L })
+    {
+      var catalog = ReadLocalGenerationCatalog(backupPath, generationId);
+      Assert.That(
+          File.Exists(Path.Combine(
+              backupPath,
+              catalog.RecordBatch.BackupPath.Replace('/', Path.DirectorySeparatorChar))),
+          Is.True);
+    }
+
+    backup.Stop();
+    backup.WaitForLiveBackup();
+    zoneTree.Maintenance.Drop();
+    DeleteDirectory(backupPath);
+  }
+
+  [Test]
+  public void LiveBackupEveryScheduleCreatesAdditionalGenerations()
+  {
+    var dataPath = "data/LiveBackupEveryScheduleCreatesAdditionalGenerations";
+    var backupPath = "data/LiveBackupEveryScheduleCreatesAdditionalGenerations.Backup";
+    DeleteDirectory(dataPath);
+    DeleteDirectory(backupPath);
+
+    using var zoneTree = new ZoneTreeFactory<int, int>()
+        .SetDataDirectory(dataPath)
+        .SetWriteAheadLogDirectory(dataPath)
+        .OpenOrCreate();
+
+    using var backup = zoneTree.CreateLiveBackup(new LiveBackupOptions
+    {
+      Store = new LocalLiveBackupProvider(backupPath),
+      BackupAfterMerge = false,
+      IncludeInMemoryRecords = false,
+      Schedule = LiveBackupSchedule.Every(TimeSpan.FromMilliseconds(25))
+    });
+
+    backup.Start();
+    var generated = SpinWait.SpinUntil(() =>
+    {
+      return backup.CurrentGenerationId >= 2;
+    }, TimeSpan.FromSeconds(3));
+
+    backup.Stop();
+    backup.WaitForLiveBackup();
+    zoneTree.Maintenance.Drop();
+    DeleteDirectory(backupPath);
+
+    Assert.That(generated, Is.True);
+  }
+
+  [Test]
+  public void LiveBackupScheduleStopsCleanly()
+  {
+    var dataPath = "data/LiveBackupScheduleStopsCleanly";
+    DeleteDirectory(dataPath);
+
+    using var zoneTree = new ZoneTreeFactory<int, int>()
+        .SetDataDirectory(dataPath)
+        .SetWriteAheadLogDirectory(dataPath)
+        .OpenOrCreate();
+
+    using var backup = zoneTree.CreateLiveBackup(new LiveBackupOptions
+    {
+      Store = new InMemoryLiveBackupProvider(),
+      BackupAfterMerge = false,
+      IncludeInMemoryRecords = false,
+      Schedule = LiveBackupSchedule.Every(TimeSpan.FromMilliseconds(25))
+    });
+
+    backup.Start();
+    var generated = SpinWait.SpinUntil(() =>
+    {
+      return backup.CurrentGenerationId >= 2;
+    }, TimeSpan.FromSeconds(3));
+    Assert.That(generated, Is.True);
+
+    backup.Stop();
+    var generationId = backup.CurrentGenerationId;
+
+    Assert.That(backup.CurrentGenerationId, Is.EqualTo(generationId));
+    backup.WaitForLiveBackup();
+    zoneTree.Maintenance.Drop();
+  }
+
+  [Test]
+  public void LiveBackupScheduleDoesNotQueueBacklogWhenGenerationIsBusy()
+  {
+    var dataPath = "data/LiveBackupScheduleDoesNotQueueBacklogWhenGenerationIsBusy";
+    DeleteDirectory(dataPath);
+    var provider = new SlowCompleteLiveBackupProvider(TimeSpan.FromMilliseconds(150));
+
+    using var zoneTree = new ZoneTreeFactory<int, int>()
+        .SetDataDirectory(dataPath)
+        .SetWriteAheadLogDirectory(dataPath)
+        .OpenOrCreate();
+
+    using var backup = zoneTree.CreateLiveBackup(new LiveBackupOptions
+    {
+      Store = provider,
+      BackupAfterMerge = false,
+      IncludeInMemoryRecords = false,
+      Schedule = LiveBackupSchedule.Every(TimeSpan.FromMilliseconds(10))
+    });
+
+    backup.Start();
+    Thread.Sleep(80);
+    var generationIdWhileBusy = backup.CurrentGenerationId;
+    Assert.That(generationIdWhileBusy, Is.LessThanOrEqualTo(1));
+
+    backup.Stop();
+    zoneTree.Maintenance.Drop();
+  }
+
+  [Test]
+  public void LiveBackupSerializesConcurrentGenerationCompletion()
+  {
+    var dataPath = "data/LiveBackupSerializesConcurrentGenerationCompletion";
+    DeleteDirectory(dataPath);
+    var provider = new ConcurrentCompletionTrackingLiveBackupProvider(
+        TimeSpan.FromMilliseconds(50));
+
+    using var zoneTree = new ZoneTreeFactory<int, int>()
+        .SetDataDirectory(dataPath)
+        .SetWriteAheadLogDirectory(dataPath)
+        .OpenOrCreate();
+
+    using var backup = zoneTree.CreateLiveBackup(new LiveBackupOptions
+    {
+      Store = provider,
+      BackupAfterMerge = false,
+      IncludeInMemoryRecords = false,
+      Schedule = LiveBackupSchedule.Every(TimeSpan.FromMilliseconds(10))
+    });
+
+    backup.Start();
+    var written = SpinWait.SpinUntil(() =>
+    {
+      return provider.CompleteGenerationCount >= 3;
+    }, TimeSpan.FromSeconds(3));
+
+    backup.Stop();
+    backup.WaitForLiveBackup();
+    zoneTree.Maintenance.Drop();
+
+    Assert.That(written, Is.True);
+    Assert.That(provider.MaxConcurrentCompleteGenerations, Is.EqualTo(1));
+  }
+
+  [Test]
+  public void LiveBackupScheduleValidationRejectsInvalidSchedules()
+  {
+    Assert.Throws<ArgumentOutOfRangeException>(() =>
+        LiveBackupSchedule.Every(TimeSpan.Zero));
+    Assert.Throws<ArgumentException>(() =>
+        LiveBackupSchedule.Daily());
+    Assert.Throws<ArgumentException>(() =>
+        LiveBackupSchedule.Weekly());
+
+    var daily = LiveBackupSchedule.Daily(
+        new TimeOnly(2, 0),
+        new TimeOnly(2, 0),
+        new TimeOnly(14, 0));
+    var weekly = LiveBackupSchedule.Weekly(
+        LiveBackupSchedule.On(DayOfWeek.Sunday, new TimeOnly(2, 0)),
+        LiveBackupSchedule.On(DayOfWeek.Sunday, new TimeOnly(2, 0)));
+
+    Assert.That(daily.DailyUtcTimes.Length, Is.EqualTo(2));
+    Assert.That(weekly.WeeklyUtcTimes.Length, Is.EqualTo(1));
+  }
+
+  [Test]
+  public void LiveBackupCanRestartAfterStop()
+  {
+    var dataPath = "data/LiveBackupCanRestartAfterStop";
+    DeleteDirectory(dataPath);
+
+    using var zoneTree = new ZoneTreeFactory<int, int>()
+        .SetDataDirectory(dataPath)
+        .SetWriteAheadLogDirectory(dataPath)
+        .OpenOrCreate();
+
+    using var backup = zoneTree.CreateLiveBackup(new LiveBackupOptions
+    {
+      Store = new InMemoryLiveBackupProvider(),
+      BackupAfterMerge = false,
+      IncludeInMemoryRecords = false
+    });
+
+    backup.Start();
+    backup.CreateGeneration();
+    backup.Stop();
+    var firstGenerationId = backup.CurrentGenerationId;
+
+    backup.Start();
+    backup.CreateGeneration();
+    backup.Stop();
+
+    Assert.That(backup.CurrentGenerationId, Is.GreaterThan(firstGenerationId));
+
+    zoneTree.Maintenance.Drop();
+  }
+
+  [Test]
+  public void ScheduledLiveBackupFailureIsReportedByWait()
+  {
+    var dataPath = "data/ScheduledLiveBackupFailureIsReportedByWait";
+    DeleteDirectory(dataPath);
+    var provider = new FailingScheduledCompleteLiveBackupProvider();
+    var logger = new NullLogger();
+
+    using var zoneTree = new ZoneTreeFactory<int, int>()
+        .SetDataDirectory(dataPath)
+        .SetWriteAheadLogDirectory(dataPath)
+        .SetLogger(logger)
+        .OpenOrCreate();
+
+    using var backup = zoneTree.CreateLiveBackup(new LiveBackupOptions
+    {
+      Store = provider,
+      BackupAfterMerge = false,
+      IncludeInMemoryRecords = false,
+      Schedule = LiveBackupSchedule.Every(TimeSpan.FromMilliseconds(25))
+    });
+
+    backup.Start();
+    var scheduledGenerationStarted = SpinWait.SpinUntil(() =>
+        provider.BeginGenerationCount > 3,
+        TimeSpan.FromSeconds(3));
+
+    Assert.That(scheduledGenerationStarted, Is.True);
+    Assert.That(logger.Errors.Any(x => x is LiveBackupGenerationException), Is.True);
+
+    backup.Stop();
+    backup.WaitForLiveBackup();
+    zoneTree.Maintenance.Drop();
+  }
+
+  static void DeleteDirectory(string path)
+  {
+    if (Directory.Exists(path))
+      Directory.Delete(path, true);
+  }
+
+  static TestLocalDirectoryManifest ReadLocalManifest(string backupPath)
+  {
+    return JsonSerializer.Deserialize<TestLocalDirectoryManifest>(
+        File.ReadAllText(Path.Combine(backupPath, "manifest.json")));
+  }
+
+  static TestLiveBackupGenerationCatalog ReadCurrentLocalGenerationCatalog(
+      string backupPath)
+  {
+    var manifest = ReadLocalManifest(backupPath);
+    return ReadLocalGenerationCatalog(
+        backupPath,
+        manifest.CurrentGenerationId);
+  }
+
+  static TestLiveBackupGenerationCatalog ReadLocalGenerationCatalog(
+      string backupPath,
+      long generationId)
+  {
+    var path = Path.Combine(
+        backupPath,
+        "generations",
+        generationId.ToString("D20") + ".json");
+    return JsonSerializer.Deserialize<TestLiveBackupGenerationCatalog>(
+        File.ReadAllText(path));
+  }
+
+  static void AssertDiskSegmentBackedUp(
+      string backupPath,
+      TestLiveBackupGenerationCatalog catalog,
+      IDiskSegment<int, int> diskSegment)
+  {
+    var partCount = diskSegment.GetPartCount();
+    if (partCount == 0)
+    {
+      AssertBackupFileExists(
+          backupPath,
+          catalog,
+          diskSegment);
+      return;
+    }
+
+    AssertBackupFileExists(
+        backupPath,
+        catalog,
+        diskSegment);
+    for (var i = 0; i < partCount; ++i)
+      AssertDiskSegmentBackedUp(backupPath, catalog, diskSegment.GetPart(i));
+  }
+
+  static void AssertBackupFileExists(
+      string backupPath,
+      TestLiveBackupGenerationCatalog catalog,
+      IDiskSegment<int, int> diskSegment)
+  {
+    var file = catalog.Files.FirstOrDefault(x =>
+        x.SegmentId == diskSegment.SegmentId);
+    Assert.That(file, Is.Not.Null);
+    Assert.That(file.RecordCount, Is.EqualTo(diskSegment.Length));
+    Assert.That(file.ByteLength, Is.GreaterThan(0));
+    Assert.That(
+        File.Exists(Path.Combine(
+            backupPath,
+            file.BackupPath.Replace('/', Path.DirectorySeparatorChar))),
+        Is.True);
+  }
+
+  static int GetIteratorReaderCount(IDiskSegment<int, int> diskSegment)
+  {
+    var type = diskSegment.GetType();
+    while (type != null)
+    {
+      var field = type.GetField(
+          "IteratorReaderCount",
+          BindingFlags.Instance | BindingFlags.NonPublic);
+      if (field != null)
+        return (int)field.GetValue(diskSegment);
+      type = type.BaseType;
+    }
+    throw new MissingFieldException(
+        diskSegment.GetType().FullName,
+        "IteratorReaderCount");
+  }
+
+  public sealed class TestLiveBackupGenerationCatalog
+  {
+    public long GenerationId { get; set; }
+
+    public long[] SegmentIds { get; set; } = [];
+
+    public List<TestLocalLiveBackupFile> Files { get; set; } = [];
+
+    public TestLocalLiveBackupRecordBatch RecordBatch { get; set; }
+  }
+
+  public sealed class TestLocalDirectoryManifest
+  {
+    public long CurrentGenerationId { get; set; }
+  }
+
+  public sealed class TestLocalLiveBackupFile
+  {
+    public long SegmentId { get; set; }
+
+    public string FileName { get; set; }
+
+    public string BackupPath { get; set; }
+
+    public long RecordCount { get; set; }
+
+    public long ByteLength { get; set; }
+
+    public string CopiedAtUtc { get; set; }
+  }
+
+  public sealed class TestLocalLiveBackupRecordBatch
+  {
+    public long BatchId { get; set; }
+
+    public string BackupPath { get; set; }
+
+    public long RecordCount { get; set; }
+
+    public CompressionMethod CompressionMethod { get; set; }
+
+    public int CompressionLevel { get; set; }
+
+    public int CompressionBlockSize { get; set; }
+
+    public long UncompressedLength { get; set; }
+
+    public long StoredLength { get; set; }
+
+    public string StartedAtUtc { get; set; }
+
+    public string CompletedAtUtc { get; set; }
+
+    public bool Completed { get; set; }
+  }
+
+  sealed class FailingLiveBackupProvider : InMemoryLiveBackupProvider
+  {
+    public override Task UploadSegmentFileAsync(
+        long generationId,
+        DiskSegmentFile file,
+        Stream source,
+        CancellationToken cancellationToken)
+    {
+      throw new InvalidOperationException("Backup file copy failed.");
+    }
+  }
+
+  sealed class NullLogger : ILogger
+  {
+    readonly List<Exception> ErrorList = [];
+
+    public LogLevel LogLevel { get; set; }
+
+    public Exception[] Errors => [.. ErrorList];
+
+    public void LogError(Exception log)
+    {
+      ErrorList.Add(log);
+    }
+
+    public void LogWarning(object log)
+    {
+    }
+
+    public void LogInfo(object log)
+    {
+    }
+
+    public void LogTrace(object log)
+    {
+    }
+  }
+
+  sealed class NullLiveBackupRecordWriter : ILiveBackupRecordWriter
+  {
+    public Task WriteAsync(
+        LiveBackupRecord record,
+        CancellationToken cancellationToken)
+    {
+      return Task.CompletedTask;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+      return ValueTask.CompletedTask;
+    }
+  }
+
+  class InMemoryLiveBackupProvider : ILiveBackupStore
+  {
+    readonly List<long> Generations = [];
+
+    readonly List<DiskSegmentFile> Files = [];
+
+    readonly List<LiveBackupRecordBatch> RecordBatches = [];
+
+    int BeginGenerations;
+
+    long LastGenerationId;
+
+    public int GenerationCount => Generations.Count;
+
+    public int BeginGenerationCount => Volatile.Read(ref BeginGenerations);
+
+    public long LastGenerationIdValue => Generations.LastOrDefault();
+
+    public DiskSegmentFile[] UploadedFiles => [.. Files];
+
+    public LiveBackupRecordBatch[] UploadedRecordBatches => [.. RecordBatches];
+
+    public virtual Task<long> GetNextGenerationIdAsync(
+        CancellationToken cancellationToken)
+    {
+      return Task.FromResult(Interlocked.Increment(ref LastGenerationId));
+    }
+
+    public virtual Task BeginGenerationAsync(
+        long generationId,
+        DateTime startedAtUtc,
+        CancellationToken cancellationToken)
+    {
+      Interlocked.Increment(ref BeginGenerations);
+      return Task.CompletedTask;
+    }
+
+    public virtual Task<bool> UseSegmentAsync(
+        long generationId,
+        DiskSegmentFile file,
+        CancellationToken cancellationToken)
+    {
+      return Task.FromResult(true);
+    }
+
+    public virtual Task UploadSegmentFileAsync(
+        long generationId,
+        DiskSegmentFile file,
+        Stream source,
+        CancellationToken cancellationToken)
+    {
+      Files.Add(file);
+      return Task.CompletedTask;
+    }
+
+    public virtual Task<ILiveBackupRecordWriter> OpenRecordWriterAsync(
+        long generationId,
+        LiveBackupRecordBatch batch,
+        CancellationToken cancellationToken)
+    {
+      RecordBatches.Add(batch);
+      return Task.FromResult<ILiveBackupRecordWriter>(
+          new NullLiveBackupRecordWriter());
+    }
+
+    public virtual Task CompleteGenerationAsync(
+        long generationId, long lastOpIndex,
+        CancellationToken cancellationToken)
+    {
+      Generations.Add(generationId);
+      return Task.CompletedTask;
+    }
+  }
+
+  sealed class SlowCompleteLiveBackupProvider(TimeSpan delay) : InMemoryLiveBackupProvider
+  {
+    public override async Task CompleteGenerationAsync(
+        long generationId, long lastOpIndex,
+        CancellationToken cancellationToken)
+    {
+      await Task.Delay(delay, cancellationToken);
+      await base.CompleteGenerationAsync(generationId, lastOpIndex, cancellationToken);
+    }
+  }
+
+  sealed class ConcurrentCompletionTrackingLiveBackupProvider(TimeSpan delay)
+            : InMemoryLiveBackupProvider
+  {
+    readonly TimeSpan Delay = delay;
+
+    int CurrentCompleteGenerations;
+
+    int CompleteGenerations;
+
+    int MaxConcurrentWrites;
+
+    public int CompleteGenerationCount => Volatile.Read(ref CompleteGenerations);
+
+    public int MaxConcurrentCompleteGenerations => Volatile.Read(ref MaxConcurrentWrites);
+
+    public override async Task CompleteGenerationAsync(
+        long generationId, long lastOpIndex,
+        CancellationToken cancellationToken)
+    {
+      var current = Interlocked.Increment(ref CurrentCompleteGenerations);
+      Interlocked.Increment(ref CompleteGenerations);
+      UpdateMaxConcurrentWrites(current);
+      try
+      {
+        await Task.Delay(Delay, cancellationToken);
+        await base.CompleteGenerationAsync(generationId, lastOpIndex, cancellationToken);
+      }
+      finally
+      {
+        Interlocked.Decrement(ref CurrentCompleteGenerations);
+      }
+    }
+
+    void UpdateMaxConcurrentWrites(int current)
+    {
+      while (true)
+      {
+        var observed = Volatile.Read(ref MaxConcurrentWrites);
+        if (current <= observed)
+          return;
+        if (Interlocked.CompareExchange(
+            ref MaxConcurrentWrites,
+            current,
+            observed) == observed)
+        {
+          return;
+        }
+      }
+    }
+  }
+
+  sealed class FailingScheduledCompleteLiveBackupProvider
+      : InMemoryLiveBackupProvider
+  {
+    public override Task CompleteGenerationAsync(
+        long generationId, long lastOpIndex,
+        CancellationToken cancellationToken)
+    {
+      if (generationId >= 2)
+        throw new InvalidOperationException("Scheduled backup failed.");
+      return base.CompleteGenerationAsync(generationId, lastOpIndex, cancellationToken);
+    }
+  }
+
+  sealed class CatalogTrackingLiveBackupProvider
+      : InMemoryLiveBackupProvider
+  {
+    readonly HashSet<string> Files = new(StringComparer.Ordinal);
+
+    int FileUploads;
+
+    int UseSegmentCalls;
+
+    public int FileUploadCount => Volatile.Read(ref FileUploads);
+
+    public int UseSegmentCallCount => Volatile.Read(ref UseSegmentCalls);
+
+    public override Task UploadSegmentFileAsync(
+        long generationId,
+        DiskSegmentFile file,
+        Stream source,
+        CancellationToken cancellationToken)
+    {
+      cancellationToken.ThrowIfCancellationRequested();
+      Interlocked.Increment(ref FileUploads);
+      Files.Add(file.SegmentId.ToString());
+      return Task.CompletedTask;
+    }
+
+    public override Task<bool> UseSegmentAsync(
+        long generationId,
+        DiskSegmentFile file,
+        CancellationToken cancellationToken)
+    {
+      cancellationToken.ThrowIfCancellationRequested();
+      Interlocked.Increment(ref UseSegmentCalls);
+      return Task.FromResult(!Files.Contains(file.SegmentId.ToString()));
+    }
+  }
+
+  [TestCase(true)]
+  [TestCase(false)]
+  public async Task LiveBackupIncrementalBackup(bool single)
+  {
+    for (var k = 0; k < 1; k++)
+    {
+      var restorePath = "data/LiveBackupIncrementalBackup.Restore";
+      var dataPath = "data/LiveBackupIncrementalBackup";
+      var backupPath = "data/LiveBackupIncrementalBackup.Backup";
+      DeleteDirectory(restorePath);
+      DeleteDirectory(dataPath);
+      DeleteDirectory(backupPath);
+
+      using var zoneTree = new ZoneTreeFactory<int, int>()
+          .DisableDeletion()
+          .ConfigureDiskSegmentOptions(x =>
+          {
+            x.DiskSegmentMode = single ? DiskSegmentMode.SingleDiskSegment : DiskSegmentMode.MultiPartDiskSegment;
+            x.MinimumRecordCount = 10;
+            x.MaximumRecordCount = 20;
+          })
+          .SetDataDirectory(dataPath)
+          .OpenOrCreate();
+
+      using var backup = zoneTree.CreateLiveBackup(new LocalLiveBackupOptions
+      {
+        Directory = backupPath,
+        KeepLastGenerations = 222,
+      });
+
+      for (var i = 0; i < 100; ++i)
+        zoneTree.Upsert(i, i * 2);
+
+      zoneTree.Maintenance.MoveMutableSegmentForward();
+      zoneTree.Maintenance.StartMergeOperation().Join();
+      await backup.CreateGenerationAsync();
+      await backup.CreateGenerationAsync();
+      await backup.CreateGenerationAsync();
+      await backup.CreateGenerationAsync();
+
+      using var restored = await new ZoneTreeFactory<int, int>()
+          .DisableDeletion().ConfigureDiskSegmentOptions(x =>
+          {
+            x.MinimumRecordCount = 10;
+            x.MaximumRecordCount = 20;
+          })
+          .SetDataDirectory(restorePath).RestoreFromLatestLiveBackup(backupPath);
+
+      for (var i = 0; i < 100; ++i)
+      {
+        var hasKey = restored.TryGet(i, out var j);
+        Assert.That(hasKey, Is.True);
+        Assert.That(j, Is.EqualTo(i * 2));
+      }
+      restored.Maintenance.Drop();
+
+      for (var i = 100; i < 200; ++i)
+        zoneTree.Upsert(i, i * 2);
+
+      zoneTree.Maintenance.MoveMutableSegmentForward();
+      zoneTree.Maintenance.StartMergeOperation().Join();
+      for (var i = 200; i < 300; ++i)
+        zoneTree.Upsert(i, i * 2);
+      await backup.CreateGenerationAsync();
+      await backup.CreateGenerationAsync();
+      await backup.CreateGenerationAsync();
+
+      using var restored2 = await new ZoneTreeFactory<int, int>()
+          .DisableDeletion().ConfigureDiskSegmentOptions(x =>
+          {
+            x.MinimumRecordCount = 10;
+            x.MaximumRecordCount = 20;
+          })
+          .SetDataDirectory(restorePath).RestoreFromLatestLiveBackup(backupPath);
+
+      for (var i = 0; i < 300; ++i)
+      {
+        var hasKey = restored2.TryGet(i, out var j);
+        Assert.That(hasKey, Is.True);
+        Assert.That(j, Is.EqualTo(i * 2));
+      }
+      zoneTree.Maintenance.SaveMetaData();
+      //restored2.Maintenance.Drop();
+      zoneTree.Maintenance.Drop();
+      DeleteDirectory(backupPath);
+    }
+  }
+
+  [TestCase(true)]
+  [TestCase(false)]
+  public async Task LiveBackupBottomSegmentsIncrementalBackup(bool single)
+  {
+    const int Chunk = 100;
+    for (var k = 0; k < 1; k++)
+    {
+      var restorePath = "data/LiveBackupBottomSegmentsIncrementalBackup.Restore";
+      var dataPath = "data/LiveBackupBottomSegmentsIncrementalBackup";
+      var backupPath = "data/LiveBackupBottomSegmentsIncrementalBackup.Backup";
+      DeleteDirectory(restorePath);
+      DeleteDirectory(dataPath);
+      DeleteDirectory(backupPath);
+
+      using var zoneTree = new ZoneTreeFactory<int, int>()
+          .DisableDeletion()
+          .SetDiskSegmentMaxItemCount(50)
+          .ConfigureDiskSegmentOptions(x =>
+          {
+            x.DiskSegmentMode = single ? DiskSegmentMode.SingleDiskSegment : DiskSegmentMode.MultiPartDiskSegment;
+            x.MinimumRecordCount = 10;
+            x.MaximumRecordCount = 20;
+          })
+          .SetDataDirectory(dataPath)
+          .OpenOrCreate();
+
+      using var backup = zoneTree.CreateLiveBackup(new LocalLiveBackupOptions
+      {
+        Directory = backupPath,
+        KeepLastGenerations = 222,
+      });
+
+      for (var i = 0; i < Chunk; ++i)
+        zoneTree.Upsert(i, i * 2);
+
+      zoneTree.Maintenance.MoveMutableSegmentForward();
+      zoneTree.Maintenance.StartMergeOperation().Join();
+      await backup.CreateGenerationAsync();
+      await backup.CreateGenerationAsync();
+      await backup.CreateGenerationAsync();
+      await backup.CreateGenerationAsync();
+
+      using var restored = await new ZoneTreeFactory<int, int>()
+          .DisableDeletion().ConfigureDiskSegmentOptions(x =>
+          {
+            x.MinimumRecordCount = 10;
+            x.MaximumRecordCount = 20;
+          })
+          .SetDataDirectory(restorePath).RestoreFromLatestLiveBackup(backupPath);
+
+      for (var i = 0; i < Chunk; ++i)
+      {
+        var hasKey = restored.TryGet(i, out var j);
+        Assert.That(hasKey, Is.True);
+        Assert.That(j, Is.EqualTo(i * 2));
+      }
+      restored.Maintenance.Drop();
+
+      for (var i = Chunk; i < 2 * Chunk; ++i)
+        zoneTree.Upsert(i, i * 2);
+
+      zoneTree.Maintenance.MoveMutableSegmentForward();
+      zoneTree.Maintenance.StartMergeOperation().Join();
+      for (var i = 2 * Chunk; i < 3 * Chunk; ++i)
+        zoneTree.Upsert(i, i * 2);
+      await backup.CreateGenerationAsync();
+      await backup.CreateGenerationAsync();
+      await backup.CreateGenerationAsync();
+
+      using var restored2 = await new ZoneTreeFactory<int, int>()
+          .DisableDeletion().ConfigureDiskSegmentOptions(x =>
+          {
+            x.MinimumRecordCount = 10;
+            x.MaximumRecordCount = 20;
+          })
+          .SetDataDirectory(restorePath).RestoreFromLatestLiveBackup(backupPath);
+
+      for (var i = 0; i < 3 * Chunk; ++i)
+      {
+        var hasKey = restored2.TryGet(i, out var j);
+        Assert.That(hasKey, Is.True);
+        Assert.That(j, Is.EqualTo(i * 2));
+      }
+      zoneTree.Maintenance.SaveMetaData();
+      restored2.Maintenance.Drop();
+      zoneTree.Maintenance.Drop();
+      DeleteDirectory(backupPath);
+    }
+  }
+
+}

--- a/src/ZoneTree/Backup/ILiveBackupRecordWriter.cs
+++ b/src/ZoneTree/Backup/ILiveBackupRecordWriter.cs
@@ -1,0 +1,13 @@
+namespace ZoneTree.Backup;
+
+public interface ILiveBackupRecordWriter : IAsyncDisposable
+{
+  /// <summary>
+  /// Writes one logical key/value record from an in-memory backup pass.
+  /// The key and value buffers in the record are already serialized with
+  /// the ZoneTree serializers configured for the database.
+  /// </summary>
+  Task WriteAsync(
+      LiveBackupRecord record,
+      CancellationToken cancellationToken);
+}

--- a/src/ZoneTree/Backup/ILiveBackupSource.cs
+++ b/src/ZoneTree/Backup/ILiveBackupSource.cs
@@ -1,0 +1,22 @@
+namespace ZoneTree.Backup;
+
+/// <summary>
+/// Reads live backup generations for restore.
+/// </summary>
+public interface ILiveBackupSource
+{
+  Task<LiveBackupGeneration> ReadLatestGenerationAsync(
+      CancellationToken cancellationToken);
+
+  Task<LiveBackupGeneration> ReadGenerationAsync(
+      long generationId,
+      CancellationToken cancellationToken);
+
+  Task<Stream> OpenSegmentFileAsync(
+      LiveBackupFile file,
+      CancellationToken cancellationToken);
+
+  Task<Stream> OpenRecordBatchAsync(
+      LiveBackupRecordBatch batch,
+      CancellationToken cancellationToken);
+}

--- a/src/ZoneTree/Backup/ILiveBackupStore.cs
+++ b/src/ZoneTree/Backup/ILiveBackupStore.cs
@@ -1,0 +1,58 @@
+using ZoneTree.Segments.Disk;
+
+namespace ZoneTree.Backup;
+
+/// <summary>
+/// Receives live backup generation operations.
+/// Implement this interface to write backup files to local disk, object
+/// storage, a remote service, or any other destination.
+/// </summary>
+public interface ILiveBackupStore
+{
+  /// <summary>
+  /// Allocates the next backup generation id.
+  /// </summary>
+  Task<long> GetNextGenerationIdAsync(CancellationToken cancellationToken);
+
+  /// <summary>
+  /// Called when a new backup generation starts.
+  /// </summary>
+  Task BeginGenerationAsync(
+      long generationId,
+      DateTime startedAtUtc,
+      CancellationToken cancellationToken);
+
+  /// <summary>
+  /// Adds an immutable disk segment to the current generation.
+  /// Returns true when ZoneTree must upload this segment file.
+  /// </summary>
+  Task<bool> UseSegmentAsync(
+      long generationId,
+      DiskSegmentFile file,
+      CancellationToken cancellationToken);
+
+  /// <summary>
+  /// Uploads one immutable disk segment file.
+  /// </summary>
+  Task UploadSegmentFileAsync(
+      long generationId,
+      DiskSegmentFile file,
+      Stream source,
+      CancellationToken cancellationToken);
+
+  /// <summary>
+  /// Opens a writer for one logical in-memory record batch.
+  /// </summary>
+  Task<ILiveBackupRecordWriter> OpenRecordWriterAsync(
+      long generationId,
+      LiveBackupRecordBatch batch,
+      CancellationToken cancellationToken);
+
+  /// <summary>
+  /// Called when the generation is complete.
+  /// </summary>
+  Task CompleteGenerationAsync(
+      long generationId,
+      long lastOpIndex,
+      CancellationToken cancellationToken);
+}

--- a/src/ZoneTree/Backup/LiveBackup.cs
+++ b/src/ZoneTree/Backup/LiveBackup.cs
@@ -1,0 +1,636 @@
+using ZoneTree.AbstractFileStream;
+using ZoneTree.Options;
+using ZoneTree.Segments;
+using ZoneTree.Segments.Disk;
+using ZoneTree.Segments.NullDisk;
+
+namespace ZoneTree.Backup;
+
+/// <summary>
+/// Coordinates live backup of immutable ZoneTree disk segments and in-memory
+/// records without changing the live ZoneTree state.
+/// </summary>
+public sealed class LiveBackup<TKey, TValue> : IDisposable
+{
+  readonly IZoneTree<TKey, TValue> ZoneTree;
+
+  readonly IZoneTreeMaintenance<TKey, TValue> Maintenance;
+
+  readonly Core.ZoneTree<TKey, TValue> CoreZoneTree;
+
+  readonly LiveBackupOptions Options;
+
+  readonly ZoneTreeOptions<TKey, TValue> ZoneTreeOptions;
+
+  readonly object SyncRoot = new();
+
+  readonly IFileStreamProvider SourceDataFileStreamProvider;
+
+  readonly ILiveBackupStore Store;
+
+  TaskCompletionSource<bool> StateChanged = CreateTaskSource();
+
+  CancellationTokenSource SchedulerCancellation;
+
+  int RunningSchedulerCount;
+
+  long RecordBatchId;
+
+  long CurrentBackupGenerationId;
+
+  bool IsLiveBackupStarted;
+
+  bool IsGenerationRunning;
+
+  public LiveBackup(
+      IZoneTree<TKey, TValue> zoneTree,
+      LiveBackupOptions options)
+  {
+    ZoneTree = zoneTree ?? throw new ArgumentNullException(nameof(zoneTree));
+    CoreZoneTree = zoneTree as Core.ZoneTree<TKey, TValue> ??
+        throw new NotSupportedException(
+            "Live backup requires the built-in ZoneTree implementation.");
+
+    Options = options ?? throw new ArgumentNullException(nameof(options));
+    Options.Normalize();
+
+    if (Options.Store == null)
+      throw new ArgumentException(
+          "Live backup store is required.",
+          nameof(options));
+
+    Maintenance = zoneTree.Maintenance;
+    ZoneTreeOptions = Maintenance.CloneOptions();
+    SourceDataFileStreamProvider =
+        ZoneTreeOptions.RandomAccessDeviceManager.FileStreamProvider;
+    Store = options.Store;
+    Maintenance.OnZoneTreeIsDisposing += OnZoneTreeIsDisposing;
+  }
+
+  void OnZoneTreeIsDisposing(IZoneTreeMaintenance<TKey, TValue> zoneTree)
+  {
+    Dispose();
+  }
+
+  public long CurrentGenerationId
+  {
+    get
+    {
+      lock (SyncRoot)
+        return CurrentBackupGenerationId;
+    }
+  }
+
+  /// <summary>
+  /// Starts live backup by attaching merge-triggered backup handling and
+  /// starting the configured scheduler.
+  /// </summary>
+  public void Start()
+  {
+    lock (SyncRoot)
+    {
+      if (IsLiveBackupStarted)
+        return;
+
+      IsLiveBackupStarted = true;
+      Maintenance.OnMergeOperationEnded += OnMergeOperationEnded;
+      StartScheduler();
+      SignalStateChanged();
+    }
+  }
+
+  /// <summary>
+  /// Stops live backup by detaching merge-triggered backup handling and
+  /// requesting scheduler cancellation.
+  /// </summary>
+  public void Stop()
+  {
+    lock (SyncRoot)
+    {
+      if (IsLiveBackupStarted)
+      {
+        Maintenance.OnMergeOperationEnded -= OnMergeOperationEnded;
+        IsLiveBackupStarted = false;
+      }
+
+      var schedulerCancellation = SchedulerCancellation;
+      schedulerCancellation?.Cancel();
+      SchedulerCancellation = null;
+
+      SignalStateChanged();
+    }
+  }
+
+  /// <summary>
+  /// Creates a live backup generation immediately.
+  /// </summary>
+  /// <remarks>
+  /// Manual generations are not queued and do not require Start().
+  /// If another generation is already running, this method throws.
+  /// </remarks>
+  public void CreateGeneration()
+  {
+    CreateGenerationAsync().GetAwaiter().GetResult();
+  }
+
+  /// <summary>
+  /// Creates a live backup generation immediately.
+  /// </summary>
+  /// <remarks>
+  /// Manual generations are not queued and do not require Start().
+  /// If another generation is already running, this method throws.
+  /// </remarks>
+  public async Task CreateGenerationAsync(
+      CancellationToken cancellationToken = default)
+  {
+    cancellationToken.ThrowIfCancellationRequested();
+
+    BeginBackupGeneration(
+        skipIfBusy: false,
+        requireLiveBackupStarted: false);
+
+    try
+    {
+      await BackupGenerationAsync(cancellationToken)
+          .ConfigureAwait(false);
+    }
+    finally
+    {
+      CompleteBackupGenerationActivity();
+    }
+  }
+
+  /// <summary>
+  /// Waits until live backup is stopped and all live backup activity has
+  /// finished.
+  /// </summary>
+  /// <remarks>
+  /// This method waits while Start() is active. Call Stop() to detach automatic
+  /// triggers and request scheduler shutdown. The method also waits for the
+  /// scheduler to exit and for any running generation to complete.
+  /// </remarks>
+  public void WaitForLiveBackup()
+  {
+    WaitForLiveBackupAsync().GetAwaiter().GetResult();
+  }
+
+  /// <summary>
+  /// Waits until live backup is stopped and all live backup activity has
+  /// finished.
+  /// </summary>
+  /// <remarks>
+  /// This method waits while Start() is active. Call Stop() to detach automatic
+  /// triggers and request scheduler shutdown. The method also waits for the
+  /// scheduler to exit and for any running generation to complete.
+  /// </remarks>
+  public async Task WaitForLiveBackupAsync(
+      CancellationToken cancellationToken = default)
+  {
+    while (true)
+    {
+      Task waitTask;
+
+      lock (SyncRoot)
+      {
+        if (!IsLiveBackupStarted &&
+            !IsGenerationRunning &&
+            RunningSchedulerCount == 0)
+        {
+          return;
+        }
+
+        waitTask = StateChanged.Task;
+      }
+
+      await waitTask.WaitAsync(cancellationToken)
+          .ConfigureAwait(false);
+    }
+  }
+
+  void StartScheduler()
+  {
+    if (Options.Schedule.Kind == LiveBackupScheduleKind.None)
+      return;
+
+    SchedulerCancellation?.Cancel();
+
+    var schedulerCancellation = new CancellationTokenSource();
+    SchedulerCancellation = schedulerCancellation;
+    ++RunningSchedulerCount;
+
+    _ = RunSchedulerAsync(schedulerCancellation);
+  }
+
+  async Task RunSchedulerAsync(
+      CancellationTokenSource schedulerCancellation)
+  {
+    var cancellationToken = schedulerCancellation.Token;
+
+    try
+    {
+      var nextUtc = Options.Schedule.GetNextUtc(DateTime.UtcNow);
+
+      while (true)
+      {
+        await DelayUntilUtcAsync(nextUtc, cancellationToken)
+            .ConfigureAwait(false);
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        StartBackgroundBackupGeneration();
+
+        nextUtc = Options.Schedule.GetNextUtc(DateTime.UtcNow);
+      }
+    }
+    catch (OperationCanceledException)
+        when (cancellationToken.IsCancellationRequested)
+    {
+    }
+    catch (Exception e)
+    {
+      LogBackupError(e);
+    }
+    finally
+    {
+      lock (SyncRoot)
+      {
+        --RunningSchedulerCount;
+
+        if (ReferenceEquals(SchedulerCancellation, schedulerCancellation))
+          SchedulerCancellation = null;
+
+        schedulerCancellation.Dispose();
+
+        SignalStateChanged();
+      }
+    }
+  }
+
+  static async Task DelayUntilUtcAsync(
+      DateTime utcTime,
+      CancellationToken cancellationToken)
+  {
+    while (true)
+    {
+      var delay = utcTime - DateTime.UtcNow;
+
+      if (delay <= TimeSpan.Zero)
+        return;
+
+      if (delay > TimeSpan.FromHours(1))
+        delay = TimeSpan.FromHours(1);
+
+      await Task.Delay(delay, cancellationToken)
+          .ConfigureAwait(false);
+    }
+  }
+
+  void OnMergeOperationEnded(
+      IZoneTreeMaintenance<TKey, TValue> zoneTree,
+      MergeResult mergeResult)
+  {
+    StartBackupGenerationOnSuccessfulMerge(mergeResult);
+  }
+
+  void StartBackupGenerationOnSuccessfulMerge(MergeResult mergeResult)
+  {
+    try
+    {
+      if (Options.BackupAfterMerge &&
+          mergeResult == MergeResult.SUCCESS)
+      {
+        StartBackgroundBackupGeneration();
+      }
+    }
+    catch (Exception e)
+    {
+      LogBackupError(e);
+    }
+  }
+
+  void StartBackgroundBackupGeneration()
+  {
+    if (!BeginBackupGeneration(
+        skipIfBusy: true,
+        requireLiveBackupStarted: true))
+    {
+      return;
+    }
+
+    _ = Task.Run(RunBackgroundBackupGenerationAsync);
+  }
+
+  async Task RunBackgroundBackupGenerationAsync()
+  {
+    try
+    {
+      await BackupGenerationAsync(CancellationToken.None)
+          .ConfigureAwait(false);
+    }
+    catch (Exception e)
+    {
+      LogBackupError(e);
+    }
+    finally
+    {
+      CompleteBackupGenerationActivity();
+    }
+  }
+
+  bool BeginBackupGeneration(
+      bool skipIfBusy,
+      bool requireLiveBackupStarted)
+  {
+    lock (SyncRoot)
+    {
+      if (requireLiveBackupStarted &&
+          !IsLiveBackupStarted)
+      {
+        return false;
+      }
+
+      if (IsGenerationRunning)
+      {
+        if (skipIfBusy)
+          return false;
+
+        throw new InvalidOperationException(
+            "A live backup generation is already running.");
+      }
+
+      IsGenerationRunning = true;
+      SignalStateChanged();
+
+      return true;
+    }
+  }
+
+  void CompleteBackupGenerationActivity()
+  {
+    lock (SyncRoot)
+    {
+      if (!IsGenerationRunning)
+        return;
+
+      IsGenerationRunning = false;
+      SignalStateChanged();
+    }
+  }
+
+  void SignalStateChanged()
+  {
+    var completion = StateChanged;
+    StateChanged = CreateTaskSource();
+    completion.TrySetResult(true);
+  }
+
+  async Task BackupGenerationAsync(CancellationToken cancellationToken)
+  {
+    long generationId = 0;
+    try
+    {
+      cancellationToken.ThrowIfCancellationRequested();
+
+      var moveMutableSegmentForward =
+          Options.InMemoryMode == LiveBackupInMemoryMode.Snapshot;
+
+      using var segments = CoreZoneTree.CollectBackupSegments(
+          moveMutableSegmentForward,
+          Options.IncludeInMemoryRecords);
+
+      var startedAtUtc = DateTime.UtcNow;
+
+      generationId = await Store.GetNextGenerationIdAsync(
+          cancellationToken).ConfigureAwait(false);
+
+      if (generationId <= 0)
+        throw new InvalidOperationException(
+            "Live backup store returned an invalid generation id.");
+
+      await Store.BeginGenerationAsync(
+          generationId,
+          startedAtUtc,
+          cancellationToken).ConfigureAwait(false);
+
+      if (Options.IncludeInMemoryRecords &&
+          segments.InMemoryIterator != null)
+      {
+        await BackupInMemoryRecordsAsync(
+            generationId,
+            segments.InMemoryIterator,
+            cancellationToken).ConfigureAwait(false);
+      }
+
+      await BackupDiskSegmentAsync(
+          segments.DiskSegment,
+          generationId,
+          order: 0,
+          cancellationToken).ConfigureAwait(false);
+
+      if (segments.BottomSegments != null)
+      {
+        var order = 1;
+
+        foreach (var bottomSegment in segments.BottomSegments)
+        {
+          await BackupDiskSegmentAsync(
+              bottomSegment,
+              generationId,
+              order++,
+              cancellationToken).ConfigureAwait(false);
+        }
+      }
+
+      await CompleteGenerationAsync(
+          generationId,
+          CoreZoneTree.LastOpIndex,
+          cancellationToken).ConfigureAwait(false);
+    }
+    catch (OperationCanceledException)
+        when (cancellationToken.IsCancellationRequested)
+    {
+      throw;
+    }
+    catch (LiveBackupException)
+    {
+      throw;
+    }
+    catch (Exception e)
+    {
+      throw new LiveBackupGenerationException(
+          generationId,
+          "creating generation",
+          e);
+    }
+  }
+
+  async Task BackupDiskSegmentAsync(
+      IDiskSegment<TKey, TValue> diskSegment,
+      long generationId,
+      int order,
+      CancellationToken cancellationToken)
+  {
+    if (diskSegment == null ||
+        diskSegment is NullDiskSegment<TKey, TValue> ||
+        diskSegment.SegmentId == 0)
+    {
+      return;
+    }
+
+    var files = GetExistingSegmentFiles(diskSegment, order);
+
+    if (files.Length == 0)
+      return;
+
+    foreach (var file in files)
+    {
+      if (await Store.UseSegmentAsync(
+          generationId,
+          file,
+          cancellationToken).ConfigureAwait(false))
+        await CopySegmentFileAsync(
+            file,
+            generationId,
+            cancellationToken).ConfigureAwait(false);
+    }
+  }
+
+  DiskSegmentFile[] GetExistingSegmentFiles(
+      IDiskSegment<TKey, TValue> diskSegment,
+      int order)
+  {
+    var diskSegmentFiles = diskSegment.GetFiles();
+    var files = new DiskSegmentFile[diskSegmentFiles.Length];
+    var index = 0;
+
+    foreach (var file in diskSegmentFiles)
+    {
+      if (string.IsNullOrWhiteSpace(file.Path))
+      {
+        throw new FileNotFoundException(
+            $"Disk segment {diskSegment.SegmentId} returned an empty file path.");
+      }
+
+      if (!SourceDataFileStreamProvider.FileExists(file.Path))
+      {
+        throw new FileNotFoundException(
+            $"Disk segment file was not found for segment {diskSegment.SegmentId}.",
+            file.Path);
+      }
+
+      files[index++] = file with { Order = order };
+    }
+
+    return files;
+  }
+
+  async Task CopySegmentFileAsync(
+      DiskSegmentFile file,
+      long generationId,
+      CancellationToken cancellationToken)
+  {
+    if (string.IsNullOrWhiteSpace(file.Path))
+      throw new FileNotFoundException(
+          $"Disk segment {file.SegmentId} returned an empty file path.");
+
+    if (!SourceDataFileStreamProvider.FileExists(file.Path))
+    {
+      throw new FileNotFoundException(
+          $"Disk segment file was not found for segment {file.SegmentId}.",
+          file.Path);
+    }
+
+    using var source = SourceDataFileStreamProvider.CreateFileStream(
+        file.Path,
+        FileMode.Open,
+        FileAccess.Read,
+        FileShare.ReadWrite);
+
+    await Store.UploadSegmentFileAsync(
+        generationId,
+        file,
+        source.ToStream(),
+        cancellationToken).ConfigureAwait(false);
+  }
+
+  async Task BackupInMemoryRecordsAsync(
+      long generationId,
+      IZoneTreeIterator<TKey, TValue> iterator,
+      CancellationToken cancellationToken)
+  {
+    var batchId = Interlocked.Increment(ref RecordBatchId);
+    var batch = new LiveBackupRecordBatch
+    {
+      BatchId = batchId,
+      CompressionMethod = Options.RecordBatchCompression.Method,
+      CompressionLevel = Options.RecordBatchCompression.Level,
+      CompressionBlockSize = Options.RecordBatchCompression.BlockSize
+    };
+
+    await using var writer = await Store.OpenRecordWriterAsync(
+        generationId,
+        batch,
+        cancellationToken).ConfigureAwait(false);
+
+    long recordIndex = 0;
+
+    while (iterator.Next())
+    {
+      cancellationToken.ThrowIfCancellationRequested();
+      var key = iterator.CurrentKey;
+      var value = iterator.CurrentValue;
+      var keyBytes = ZoneTree.KeySerializer.Serialize(in key);
+      var valueBytes = ZoneTree.ValueSerializer.Serialize(in value);
+
+      ++recordIndex;
+
+      var record = new LiveBackupRecord
+      {
+        RecordIndex = recordIndex,
+        IsDeleted = ZoneTreeOptions.IsDeleted(in key, in value),
+        Key = keyBytes,
+        Value = valueBytes
+      };
+
+      await writer.WriteAsync(
+          record,
+          cancellationToken).ConfigureAwait(false);
+    }
+
+    batch.RecordCount = recordIndex;
+  }
+
+  async Task CompleteGenerationAsync(
+      long generationId,
+      long lastOpIndex,
+      CancellationToken cancellationToken)
+  {
+    await Store.CompleteGenerationAsync(
+        generationId,
+        lastOpIndex,
+        cancellationToken).ConfigureAwait(false);
+
+    lock (SyncRoot)
+      CurrentBackupGenerationId = generationId;
+  }
+
+  static TaskCompletionSource<bool> CreateTaskSource()
+  {
+    return new TaskCompletionSource<bool>(
+        TaskCreationOptions.RunContinuationsAsynchronously);
+  }
+
+  void LogBackupError(Exception exception)
+  {
+    ZoneTree.Logger.LogError(exception);
+  }
+
+  public void Dispose()
+  {
+    Maintenance.OnZoneTreeIsDisposing -= OnZoneTreeIsDisposing;
+    Stop();
+    WaitForLiveBackup();
+    SchedulerCancellation?.Dispose();
+    SchedulerCancellation = null;
+  }
+}

--- a/src/ZoneTree/Backup/LiveBackupExceptions.cs
+++ b/src/ZoneTree/Backup/LiveBackupExceptions.cs
@@ -1,0 +1,56 @@
+using ZoneTree.Exceptions;
+
+namespace ZoneTree.Backup;
+
+public class LiveBackupException : ZoneTreeException
+{
+  public LiveBackupException(
+      string message,
+      Exception innerException = null)
+      : base(message, innerException)
+  {
+  }
+}
+
+public sealed class LiveBackupGenerationException : LiveBackupException
+{
+  public LiveBackupGenerationException(
+      long generationId,
+      string operation,
+      Exception innerException)
+      : base(
+          $"Live backup generation {generationId} failed while {operation}.",
+          innerException)
+  {
+    GenerationId = generationId;
+    Operation = operation;
+  }
+
+  public long GenerationId { get; }
+
+  public string Operation { get; }
+}
+
+public sealed class LiveBackupQueueException : LiveBackupException
+{
+  public LiveBackupQueueException(
+      string operation,
+      Exception innerException)
+      : base($"Live backup failed while {operation}.", innerException)
+  {
+    Operation = operation;
+  }
+
+  public string Operation { get; }
+}
+
+public sealed class LiveBackupRestoreTargetAlreadyExistsException
+    : LiveBackupException
+{
+  public LiveBackupRestoreTargetAlreadyExistsException()
+      : base(
+          "Live backup restore target already contains a ZoneTree database. " +
+          "Restore into an empty data directory or open the existing database.")
+  {
+  }
+}

--- a/src/ZoneTree/Backup/LiveBackupExtensions.cs
+++ b/src/ZoneTree/Backup/LiveBackupExtensions.cs
@@ -1,0 +1,69 @@
+namespace ZoneTree.Backup;
+
+public static class LiveBackupExtensions
+{
+  /// <summary>
+  /// Creates a live backup coordinator that writes into a local directory.
+  /// </summary>
+  public static LiveBackup<TKey, TValue> CreateLiveBackup<TKey, TValue>(
+      this IZoneTree<TKey, TValue> zoneTree,
+      string directory)
+  {
+    if (zoneTree == null)
+      throw new ArgumentNullException(nameof(zoneTree));
+
+    return new LiveBackup<TKey, TValue>(
+        zoneTree,
+        new LiveBackupOptions
+        {
+          Store = new LocalLiveBackupProvider(directory)
+        });
+  }
+
+  /// <summary>
+  /// Creates a live backup coordinator that writes into a local directory.
+  /// </summary>
+  public static LiveBackup<TKey, TValue> CreateLiveBackup<TKey, TValue>(
+      this IZoneTree<TKey, TValue> zoneTree,
+      LocalLiveBackupOptions localOptions)
+  {
+    if (zoneTree == null)
+      throw new ArgumentNullException(nameof(zoneTree));
+
+    return new LiveBackup<TKey, TValue>(
+        zoneTree,
+        new LiveBackupOptions
+        {
+          Store = new LocalLiveBackupProvider(localOptions)
+        });
+  }
+
+  /// <summary>
+  /// Creates a live backup coordinator that writes through the specified store.
+  /// </summary>
+  public static LiveBackup<TKey, TValue> CreateLiveBackup<TKey, TValue>(
+      this IZoneTree<TKey, TValue> zoneTree,
+      ILiveBackupStore store)
+  {
+    if (zoneTree == null)
+      throw new ArgumentNullException(nameof(zoneTree));
+
+    return new LiveBackup<TKey, TValue>(
+        zoneTree,
+        new LiveBackupOptions { Store = store });
+  }
+
+  /// <summary>
+  /// Creates a live backup coordinator for this ZoneTree.
+  /// </summary>
+  public static LiveBackup<TKey, TValue> CreateLiveBackup<TKey, TValue>(
+      this IZoneTree<TKey, TValue> zoneTree,
+      LiveBackupOptions options)
+  {
+    if (zoneTree == null)
+      throw new ArgumentNullException(nameof(zoneTree));
+
+    return new LiveBackup<TKey, TValue>(zoneTree, options);
+  }
+
+}

--- a/src/ZoneTree/Backup/LiveBackupModels.cs
+++ b/src/ZoneTree/Backup/LiveBackupModels.cs
@@ -1,0 +1,57 @@
+using ZoneTree.Options;
+
+namespace ZoneTree.Backup;
+
+public sealed class LiveBackupGeneration
+{
+  public long GenerationId { get; set; }
+
+  public long LastOpIndex { get; set; }
+
+  public long[] SegmentIds { get; set; } = [];
+
+  public LiveBackupFile[] Files { get; set; } = [];
+
+  public LiveBackupRecordBatch RecordBatch { get; set; }
+}
+
+public sealed class LiveBackupFile
+{
+  public long SegmentId { get; set; }
+
+  public int Order { get; set; }
+
+  public string FileName { get; set; }
+
+  public long RecordCount { get; set; }
+
+  public long ByteLength { get; set; }
+}
+
+public sealed class LiveBackupRecord
+{
+  public long RecordIndex { get; set; }
+
+  public bool IsDeleted { get; set; }
+
+  public ReadOnlyMemory<byte> Key { get; set; }
+
+  public ReadOnlyMemory<byte> Value { get; set; }
+}
+
+public sealed class LiveBackupRecordBatch
+{
+  public long BatchId { get; set; }
+
+  public long RecordCount { get; set; }
+
+  public CompressionMethod CompressionMethod { get; set; } = CompressionMethod.None;
+
+  public int CompressionLevel { get; set; }
+
+  public int CompressionBlockSize { get; set; }
+
+  public long UncompressedLength { get; set; }
+
+  public long StoredLength { get; set; }
+}

--- a/src/ZoneTree/Backup/LiveBackupOptions.cs
+++ b/src/ZoneTree/Backup/LiveBackupOptions.cs
@@ -1,0 +1,123 @@
+using ZoneTree.Options;
+
+namespace ZoneTree.Backup;
+
+/// <summary>
+/// Options for ZoneTree live backup.
+/// </summary>
+public sealed class LiveBackupOptions
+{
+  /// <summary>
+  /// Backup store implementation.
+  /// </summary>
+  public ILiveBackupStore Store { get; set; }
+
+  /// <summary>
+  /// If true, successful normal merge operations queue a complete backup generation.
+  /// </summary>
+  public bool BackupAfterMerge { get; set; } = true;
+
+  /// <summary>
+  /// Optional UTC schedule for automatic complete backup generations.
+  /// </summary>
+  public LiveBackupSchedule Schedule { get; set; } = LiveBackupSchedule.None;
+
+  /// <summary>
+  /// If true, the current mutable and read-only in-memory records are streamed
+  /// through a ZoneTree in-memory iterator.
+  /// </summary>
+  public bool IncludeInMemoryRecords { get; set; } = true;
+
+  /// <summary>
+  /// Controls how in-memory records are collected for each backup generation.
+  /// </summary>
+  public LiveBackupInMemoryMode InMemoryMode { get; set; }
+      = LiveBackupInMemoryMode.Live;
+
+  /// <summary>
+  /// Compression options for backup-created in-memory record batch files.
+  /// Physical disk segment files are copied as-is.
+  /// </summary>
+  public LiveBackupCompressionOptions RecordBatchCompression { get; set; } = new();
+
+  public void Normalize()
+  {
+    Schedule ??= LiveBackupSchedule.None;
+    RecordBatchCompression ??= new LiveBackupCompressionOptions();
+    RecordBatchCompression.Normalize();
+  }
+}
+
+public enum LiveBackupInMemoryMode
+{
+  /// <summary>
+  /// Iterates mutable and read-only in-memory segments without moving the
+  /// mutable segment.
+  /// </summary>
+  Live,
+
+  /// <summary>
+  /// Moves the mutable segment forward and iterates read-only in-memory
+  /// segments only.
+  /// </summary>
+  Snapshot
+}
+
+public sealed class LiveBackupCompressionOptions
+{
+  public const CompressionMethod DefaultMethod = CompressionMethod.LZ4;
+
+  public const int DefaultLevel = CompressionLevels.LZ4Fastest;
+
+  public const int DefaultBlockSize = 1024 * 1024;
+
+  /// <summary>
+  /// Compression method used for in-memory record batch files.
+  /// </summary>
+  public CompressionMethod Method { get; set; } = DefaultMethod;
+
+  /// <summary>
+  /// Compression level used for in-memory record batch files.
+  /// </summary>
+  public int Level { get; set; } = DefaultLevel;
+
+  /// <summary>
+  /// Uncompressed block size for record batch compression.
+  /// </summary>
+  public int BlockSize { get; set; } = DefaultBlockSize;
+
+  public void Normalize()
+  {
+    if (BlockSize <= 0)
+      BlockSize = DefaultBlockSize;
+
+    if (!IsLevelValid())
+    {
+      Method = DefaultMethod;
+      Level = DefaultLevel;
+    }
+  }
+  // TODO:fix code duplication in repo, this function logic is used somewhere else
+  bool IsLevelValid()
+  {
+    return Method switch
+    {
+      CompressionMethod.None => true,
+      CompressionMethod.Gzip =>
+          Level >= CompressionLevels.GzipOptimal &&
+          Level <= CompressionLevels.GzipSmallestSize,
+      CompressionMethod.LZ4 =>
+          Level >= CompressionLevels.LZ4Fastest &&
+          Level <= CompressionLevels.LZ4HighCompression12 &&
+          Level != 1 &&
+          Level != 2,
+      CompressionMethod.Zstd =>
+          Level >= CompressionLevels.ZstdMin &&
+          Level <= CompressionLevels.ZstdMax,
+      CompressionMethod.Brotli =>
+          Level >= CompressionLevels.BrotliOptimal &&
+          Level <= CompressionLevels.BrotliSmallestSize,
+      _ => false,
+    };
+  }
+}

--- a/src/ZoneTree/Backup/LiveBackupRecordBatchReader.cs
+++ b/src/ZoneTree/Backup/LiveBackupRecordBatchReader.cs
@@ -1,0 +1,149 @@
+using ZoneTree.Compression;
+using ZoneTree.Options;
+
+namespace ZoneTree.Backup;
+
+/// <summary>
+/// Reads the binary record-batch format used by live backup.
+/// </summary>
+public sealed class LiveBackupRecordBatchReader : IDisposable
+{
+  readonly Stream Source;
+
+  readonly LiveBackupRecordBatch Batch;
+
+  MemoryStream BlockBuffer;
+
+  public LiveBackupRecordBatchReader(
+      Stream source,
+      LiveBackupRecordBatch batch)
+  {
+    Source = source ?? throw new ArgumentNullException(nameof(source));
+    Batch = batch ?? throw new ArgumentNullException(nameof(batch));
+  }
+
+  public bool TryRead(out LiveBackupRecord record)
+  {
+    if (Batch.CompressionMethod == CompressionMethod.None)
+      return TryReadRecord(Source, out record);
+
+    while (BlockBuffer == null || BlockBuffer.Position == BlockBuffer.Length)
+    {
+      BlockBuffer?.Dispose();
+      BlockBuffer = null;
+      if (!TryReadCompressedBlock(out var block))
+      {
+        record = null;
+        return false;
+      }
+      BlockBuffer = new MemoryStream(block, writable: false);
+    }
+    return TryReadRecord(BlockBuffer, out record);
+  }
+
+  bool TryReadCompressedBlock(out byte[] block)
+  {
+    block = null;
+    if (!TryReadInt32(Source, out var uncompressedLength))
+      return false;
+    if (!TryReadInt32(Source, out var compressedLength))
+      throw new EndOfStreamException();
+    var compressed = ReadBytes(Source, compressedLength);
+    var decompressed = DataCompression.Decompress(
+        Batch.CompressionMethod,
+        compressed);
+    if (decompressed.Length != uncompressedLength)
+      throw new InvalidDataException("Invalid live backup compressed block length.");
+    block = decompressed.ToArray();
+    return true;
+  }
+
+  static bool TryReadRecord(
+      Stream source,
+      out LiveBackupRecord record)
+  {
+    record = null;
+    if (!TryReadInt64(source, out var recordIndex))
+      return false;
+    var isDeleted = source.ReadByte();
+    if (isDeleted < 0)
+      throw new EndOfStreamException();
+    if (!TryReadInt32(source, out var keyLength))
+      throw new EndOfStreamException();
+    if (!TryReadInt32(source, out var valueLength))
+      throw new EndOfStreamException();
+    record = new LiveBackupRecord
+    {
+      RecordIndex = recordIndex,
+      IsDeleted = isDeleted != 0,
+      Key = ReadBytes(source, keyLength),
+      Value = ReadBytes(source, valueLength)
+    };
+    return true;
+  }
+
+  static bool TryReadInt32(Stream source, out int value)
+  {
+    Span<byte> bytes = stackalloc byte[sizeof(int)];
+    if (!TryReadExactly(source, bytes))
+    {
+      value = 0;
+      return false;
+    }
+    value = BitConverter.ToInt32(bytes);
+    return true;
+  }
+
+  static bool TryReadInt64(Stream source, out long value)
+  {
+    Span<byte> bytes = stackalloc byte[sizeof(long)];
+    if (!TryReadExactly(source, bytes))
+    {
+      value = 0;
+      return false;
+    }
+    value = BitConverter.ToInt64(bytes);
+    return true;
+  }
+
+  static bool TryReadExactly(
+      Stream source,
+      Span<byte> bytes)
+  {
+    var read = source.Read(bytes);
+    if (read == 0)
+      return false;
+    while (read < bytes.Length)
+    {
+      var count = source.Read(bytes[read..]);
+      if (count == 0)
+        throw new EndOfStreamException();
+      read += count;
+    }
+    return true;
+  }
+
+  static byte[] ReadBytes(
+      Stream source,
+      int length)
+  {
+    if (length < 0)
+      throw new InvalidDataException("Invalid live backup record length.");
+    var bytes = new byte[length];
+    var read = 0;
+    while (read < length)
+    {
+      var count = source.Read(bytes, read, length - read);
+      if (count == 0)
+        throw new EndOfStreamException();
+      read += count;
+    }
+    return bytes;
+  }
+
+  public void Dispose()
+  {
+    BlockBuffer?.Dispose();
+    Source.Dispose();
+  }
+}

--- a/src/ZoneTree/Backup/LiveBackupRecordBatchWriter.cs
+++ b/src/ZoneTree/Backup/LiveBackupRecordBatchWriter.cs
@@ -1,0 +1,114 @@
+using ZoneTree.Compression;
+using ZoneTree.Options;
+
+namespace ZoneTree.Backup;
+
+/// <summary>
+/// Writes the binary record-batch format used by live backup.
+/// </summary>
+public sealed class LiveBackupRecordBatchWriter : ILiveBackupRecordWriter
+{
+  readonly Stream Destination;
+
+  readonly LiveBackupRecordBatch Batch;
+
+  readonly MemoryStream BlockBuffer;
+
+  public LiveBackupRecordBatchWriter(
+      Stream destination,
+      LiveBackupRecordBatch batch)
+  {
+    Destination = destination ?? throw new ArgumentNullException(nameof(destination));
+    Batch = batch ?? throw new ArgumentNullException(nameof(batch));
+    if (batch.CompressionMethod != CompressionMethod.None)
+      BlockBuffer = new MemoryStream(batch.CompressionBlockSize);
+  }
+
+  public async Task WriteAsync(
+      LiveBackupRecord record,
+      CancellationToken cancellationToken)
+  {
+    var destination = BlockBuffer ?? Destination;
+    await WriteRecordAsync(
+        destination,
+        record,
+        cancellationToken);
+
+    if (BlockBuffer != null)
+    {
+      if (BlockBuffer.Length >= Batch.CompressionBlockSize)
+        await FlushBlockAsync(cancellationToken);
+      return;
+    }
+
+    var recordLength =
+        sizeof(long) +
+        sizeof(byte) +
+        sizeof(int) * 2L +
+        record.Key.Length +
+        record.Value.Length;
+    Batch.UncompressedLength += recordLength;
+    Batch.StoredLength += recordLength;
+  }
+
+  static async Task WriteRecordAsync(
+      Stream destination,
+      LiveBackupRecord record,
+      CancellationToken cancellationToken)
+  {
+    await WriteInt64Async(destination, record.RecordIndex, cancellationToken);
+    var isDeleted = new[] { record.IsDeleted ? (byte)1 : (byte)0 };
+    await destination.WriteAsync(isDeleted, cancellationToken);
+    await WriteInt32Async(destination, record.Key.Length, cancellationToken);
+    await WriteInt32Async(destination, record.Value.Length, cancellationToken);
+    await destination.WriteAsync(record.Key, cancellationToken);
+    await destination.WriteAsync(record.Value, cancellationToken);
+  }
+
+  async Task FlushBlockAsync(CancellationToken cancellationToken)
+  {
+    if (BlockBuffer == null || BlockBuffer.Length == 0)
+      return;
+
+    var uncompressed = BlockBuffer.ToArray();
+    var compressed = DataCompression
+        .Compress(
+            Batch.CompressionMethod,
+            Batch.CompressionLevel,
+            uncompressed)
+        .ToArray();
+    await WriteInt32Async(Destination, uncompressed.Length, cancellationToken);
+    await WriteInt32Async(Destination, compressed.Length, cancellationToken);
+    await Destination.WriteAsync(compressed, cancellationToken);
+
+    Batch.UncompressedLength += uncompressed.Length;
+    Batch.StoredLength += sizeof(int) * 2L + compressed.Length;
+    BlockBuffer.SetLength(0);
+  }
+
+  static Task WriteInt32Async(
+      Stream destination,
+      int value,
+      CancellationToken cancellationToken)
+  {
+    var bytes = BitConverter.GetBytes(value);
+    return destination.WriteAsync(bytes, cancellationToken).AsTask();
+  }
+
+  static Task WriteInt64Async(
+      Stream destination,
+      long value,
+      CancellationToken cancellationToken)
+  {
+    var bytes = BitConverter.GetBytes(value);
+    return destination.WriteAsync(bytes, cancellationToken).AsTask();
+  }
+
+  public async ValueTask DisposeAsync()
+  {
+    await FlushBlockAsync(CancellationToken.None);
+    BlockBuffer?.Dispose();
+    await Destination.FlushAsync();
+    await Destination.DisposeAsync();
+  }
+}

--- a/src/ZoneTree/Backup/LiveBackupRestore.cs
+++ b/src/ZoneTree/Backup/LiveBackupRestore.cs
@@ -1,0 +1,222 @@
+using ZoneTree.Core;
+using ZoneTree.Options;
+using ZoneTree.WAL;
+
+namespace ZoneTree.Backup;
+
+public sealed class LiveBackupRestore<TKey, TValue>
+{
+  readonly ZoneTreeOptions<TKey, TValue> Options;
+
+  readonly ILiveBackupSource Source;
+
+  public LiveBackupRestore(
+      ZoneTreeOptions<TKey, TValue> options,
+      ILiveBackupSource source)
+  {
+    Options = options ?? throw new ArgumentNullException(nameof(options));
+    Source = source ?? throw new ArgumentNullException(nameof(source));
+  }
+
+  public async ValueTask RestoreLatest()
+  {
+    var generation = await Source.ReadLatestGenerationAsync(CancellationToken.None);
+    await Restore(generation);
+  }
+
+  public async ValueTask RestoreGeneration(long generationId)
+  {
+    var generation = await Source.ReadGenerationAsync(generationId, CancellationToken.None);
+    await Restore(generation);
+  }
+
+  async ValueTask Restore(LiveBackupGeneration generation)
+  {
+    if (ZoneTreeMetaWAL<TKey, TValue>.Exists(Options))
+      throw new LiveBackupRestoreTargetAlreadyExistsException();
+
+    await RestoreDiskSegmentFiles(generation);
+
+    (var readOnlySegments, var maximumSegmentId, var lastOpIndex) = await RestoreInMemoryRecordBatch(
+        generation,
+        GetMaximumSegmentId(generation));
+    var mutableSegmentId = ++maximumSegmentId;
+    var orderedSegmentIds = GetOrderedSegmentIds(generation);
+    var diskSegmentId = orderedSegmentIds.Length > 0 ? orderedSegmentIds[0] : 0;
+    var bottomSegments = orderedSegmentIds
+        .Skip(1)
+        .ToArray();
+
+    SaveMetaData(
+        lastOpIndex,
+        mutableSegmentId,
+        diskSegmentId,
+        readOnlySegments,
+        bottomSegments);
+  }
+
+  async ValueTask RestoreDiskSegmentFiles(
+      LiveBackupGeneration generation)
+  {
+    var dataDirectory = GetTargetDataDirectory();
+    Directory.CreateDirectory(dataDirectory);
+    foreach (var file in generation.Files)
+    {
+      var destination = Path.Combine(dataDirectory, file.FileName);
+      using var source = await Source.OpenSegmentFileAsync(file, CancellationToken.None);
+      using var destinationStream = File.Open(
+          destination,
+          FileMode.Create,
+          FileAccess.Write,
+          FileShare.None);
+      await source.CopyToAsync(destinationStream);
+    }
+  }
+
+  async ValueTask<(long[] readOnlySegments, long maximumSegmentId, long)> RestoreInMemoryRecordBatch(
+      LiveBackupGeneration generation, long maximumSegmentId)
+  {
+    var batch = generation.RecordBatch;
+    var hasInMemoryRecordBatch = batch == null || batch.RecordCount == 0;
+    var restoreWalOptions = CloneWriteAheadLogOptions(
+        Options.WriteAheadLogOptions);
+    restoreWalOptions.EnableIncrementalBackup = false;
+    Options.WriteAheadLogProvider.InitCategory(
+        ZoneTree<TKey, TValue>.SegmentWalCategory);
+
+    var mutableWalSegmentId = maximumSegmentId + (hasInMemoryRecordBatch ? 2 : 1);
+    CreateMutableWal(mutableWalSegmentId, restoreWalOptions);
+
+    var opIndex = generation.LastOpIndex;
+    if (hasInMemoryRecordBatch)
+      return ([], maximumSegmentId, opIndex);
+    var segmentId = ++maximumSegmentId;
+    using var source = await Source.OpenRecordBatchAsync(batch, CancellationToken.None);
+    using var reader = new LiveBackupRecordBatchReader(source, batch);
+    var wal = Options.WriteAheadLogProvider.GetOrCreateWAL(
+        segmentId,
+        ZoneTree<TKey, TValue>.SegmentWalCategory,
+        restoreWalOptions,
+        Options.KeySerializer,
+        Options.ValueSerializer);
+    try
+    {
+      while (reader.TryRead(out var record))
+      {
+        var key = Options.KeySerializer.Deserialize(record.Key.ToArray());
+        var value = Options.ValueSerializer.Deserialize(record.Value.ToArray());
+        if (record.IsDeleted)
+          Options.MarkValueDeleted(ref value);
+        wal.Append(in key, in value, ++opIndex);
+      }
+    }
+    finally
+    {
+      wal.Dispose();
+      Options.WriteAheadLogProvider.RemoveWAL(
+          segmentId,
+          ZoneTree<TKey, TValue>.SegmentWalCategory);
+    }
+    return ([segmentId], maximumSegmentId, opIndex);
+  }
+
+  private void CreateMutableWal(long mutableWalSegmentId, WriteAheadLogOptions restoreWalOptions)
+  {
+    using var mutableWal = Options.WriteAheadLogProvider.GetOrCreateWAL(
+        mutableWalSegmentId,
+        ZoneTree<TKey, TValue>.SegmentWalCategory,
+        restoreWalOptions,
+        Options.KeySerializer,
+        Options.ValueSerializer);
+    Options.WriteAheadLogProvider.RemoveWAL(
+        mutableWalSegmentId,
+        ZoneTree<TKey, TValue>.SegmentWalCategory);
+  }
+
+  void SaveMetaData(long lastOpIndex,
+      long mutableSegmentId,
+      long diskSegmentId,
+      long[] readOnlySegments,
+      long[] bottomSegments)
+  {
+    var meta = new ZoneTreeMeta
+    {
+      ComparerType = Options.Comparer.GetType().SimplifiedFullName(),
+      KeyType = typeof(TKey).SimplifiedFullName(),
+      ValueType = typeof(TValue).SimplifiedFullName(),
+      KeySerializerType = Options.KeySerializer.GetType().SimplifiedFullName(),
+      ValueSerializerType = Options.ValueSerializer.GetType().SimplifiedFullName(),
+      MutableSegmentMaxItemCount = Options.MutableSegmentMaxItemCount,
+      DiskSegmentMaxItemCount = Options.DiskSegmentMaxItemCount,
+      WriteAheadLogOptions = Options.WriteAheadLogOptions,
+      DiskSegmentOptions = Options.DiskSegmentOptions,
+      MaximumOpIndex = lastOpIndex,
+    };
+    using var metaWal = new ZoneTreeMetaWAL<TKey, TValue>(Options, false);
+    metaWal.SaveMetaData(
+        meta,
+        mutableSegmentId,
+        diskSegmentId,
+        readOnlySegments,
+        bottomSegments,
+        createNew: true);
+  }
+
+  static long GetMaximumSegmentId(
+      LiveBackupGeneration generation)
+  {
+    var maximumSegmentId = 0L;
+    foreach (var segmentId in generation.SegmentIds)
+      maximumSegmentId = Math.Max(maximumSegmentId, segmentId);
+    foreach (var file in generation.Files)
+      maximumSegmentId = Math.Max(maximumSegmentId, file.SegmentId);
+    return maximumSegmentId;
+  }
+
+  static long[] GetOrderedSegmentIds(LiveBackupGeneration generation)
+  {
+    return [.. generation.Files
+        .GroupBy(x => x.Order)
+        .OrderBy(g => g.Key)
+        .Select(g =>
+        {
+          var multi = g.FirstOrDefault(x =>
+              x.FileName.EndsWith(".multi", StringComparison.Ordinal));
+
+          if (multi is not null)
+            return multi.SegmentId;
+
+          return g.First().SegmentId;
+        })];
+  }
+
+  string GetTargetDataDirectory()
+  {
+    var metaPath = Options.RandomAccessDeviceManager.GetFilePath(0, ".json");
+    return Path.GetDirectoryName(metaPath);
+  }
+
+  static WriteAheadLogOptions CloneWriteAheadLogOptions(
+      WriteAheadLogOptions options)
+  {
+    return new WriteAheadLogOptions
+    {
+      WriteAheadLogMode = options.WriteAheadLogMode,
+      CustomOptions = options.CustomOptions,
+      CompressionBlockSize = options.CompressionBlockSize,
+      CompressionMethod = options.CompressionMethod,
+      CompressionLevel = options.CompressionLevel,
+      EnableIncrementalBackup = options.EnableIncrementalBackup,
+      SyncCompressedModeOptions = new SyncCompressedModeOptions
+      {
+        EnableTailWriterJob = options.SyncCompressedModeOptions.EnableTailWriterJob,
+        TailWriterJobInterval = options.SyncCompressedModeOptions.TailWriterJobInterval
+      },
+      AsyncCompressedModeOptions = new AsyncCompressedModeOptions
+      {
+        EmptyQueuePollInterval =
+            options.AsyncCompressedModeOptions.EmptyQueuePollInterval
+      }
+    };
+  }
+}

--- a/src/ZoneTree/Backup/LiveBackupSchedule.cs
+++ b/src/ZoneTree/Backup/LiveBackupSchedule.cs
@@ -1,0 +1,237 @@
+namespace ZoneTree.Backup;
+
+/// <summary>
+/// UTC schedule for automatic live backup generations.
+/// </summary>
+public sealed class LiveBackupSchedule
+{
+  readonly TimeOnly[] DailyUtcTimeArray;
+
+  readonly LiveBackupWeeklyTime[] WeeklyUtcTimeArray;
+
+  LiveBackupSchedule(
+      LiveBackupScheduleKind kind,
+      TimeSpan interval,
+      TimeOnly[] dailyUtcTimes,
+      LiveBackupWeeklyTime[] weeklyUtcTimes)
+  {
+    Kind = kind;
+    Interval = interval;
+    DailyUtcTimeArray = dailyUtcTimes;
+    WeeklyUtcTimeArray = weeklyUtcTimes;
+  }
+
+  /// <summary>
+  /// No scheduled backup generations.
+  /// </summary>
+  public static LiveBackupSchedule None { get; } = new(
+      LiveBackupScheduleKind.None,
+      TimeSpan.Zero,
+      [],
+      []);
+
+  public LiveBackupScheduleKind Kind { get; }
+
+  public TimeSpan Interval { get; }
+
+  public TimeOnly[] DailyUtcTimes => DailyUtcTimeArray;
+
+  public LiveBackupWeeklyTime[] WeeklyUtcTimes => WeeklyUtcTimeArray;
+
+  /// <summary>
+  /// Creates a schedule that runs after the specified interval.
+  /// </summary>
+  public static LiveBackupSchedule Every(TimeSpan interval)
+  {
+    if (interval <= TimeSpan.Zero)
+      throw new ArgumentOutOfRangeException(nameof(interval));
+
+    return new LiveBackupSchedule(
+        LiveBackupScheduleKind.Every,
+        interval,
+        [],
+        []);
+  }
+
+  /// <summary>
+  /// Creates a schedule that runs every day at the specified UTC times.
+  /// </summary>
+  public static LiveBackupSchedule Daily(params TimeOnly[] utcTimes)
+  {
+    return new LiveBackupSchedule(
+        LiveBackupScheduleKind.Daily,
+        TimeSpan.Zero,
+        NormalizeDailyTimes(utcTimes),
+        []);
+  }
+
+  /// <summary>
+  /// Creates a schedule that runs every week at the specified UTC times.
+  /// </summary>
+  public static LiveBackupSchedule Weekly(
+      params LiveBackupWeeklyTime[] utcTimes)
+  {
+    return new LiveBackupSchedule(
+        LiveBackupScheduleKind.Weekly,
+        TimeSpan.Zero,
+        [],
+        NormalizeWeeklyTimes(utcTimes));
+  }
+
+  /// <summary>
+  /// Creates one weekly UTC schedule point.
+  /// </summary>
+  public static LiveBackupWeeklyTime On(
+      DayOfWeek dayOfWeek,
+      TimeOnly utcTime)
+  {
+    return new LiveBackupWeeklyTime(dayOfWeek, utcTime);
+  }
+
+  internal DateTime GetNextUtc(DateTime utcNow)
+  {
+    utcNow = ToUtcDateTime(utcNow);
+    return Kind switch
+    {
+      LiveBackupScheduleKind.None => DateTime.MaxValue,
+      LiveBackupScheduleKind.Every => utcNow.Add(Interval),
+      LiveBackupScheduleKind.Daily => GetNextDailyUtc(utcNow),
+      LiveBackupScheduleKind.Weekly => GetNextWeeklyUtc(utcNow),
+      _ => DateTime.MaxValue
+    };
+  }
+
+  DateTime GetNextDailyUtc(DateTime utcNow)
+  {
+    var today = DateOnly.FromDateTime(utcNow);
+    foreach (var time in DailyUtcTimeArray)
+    {
+      var candidate = ToUtcDateTime(today, time);
+      if (candidate > utcNow)
+        return candidate;
+    }
+    return ToUtcDateTime(today.AddDays(1), DailyUtcTimeArray[0]);
+  }
+
+  DateTime GetNextWeeklyUtc(DateTime utcNow)
+  {
+    var today = DateOnly.FromDateTime(utcNow);
+    DateTime next = DateTime.MaxValue;
+    foreach (var weeklyTime in WeeklyUtcTimeArray)
+    {
+      var daysToAdd = ((int)weeklyTime.DayOfWeek - (int)utcNow.DayOfWeek + 7) % 7;
+      var candidate = ToUtcDateTime(
+          today.AddDays(daysToAdd),
+          weeklyTime.UtcTime);
+      if (candidate <= utcNow)
+      {
+        candidate = ToUtcDateTime(
+            today.AddDays(daysToAdd + 7),
+            weeklyTime.UtcTime);
+      }
+      if (candidate < next)
+        next = candidate;
+    }
+    return next;
+  }
+
+  static DateTime ToUtcDateTime(DateTime dateTime)
+  {
+    return dateTime.Kind == DateTimeKind.Utc
+        ? dateTime
+        : dateTime.ToUniversalTime();
+  }
+
+  static DateTime ToUtcDateTime(DateOnly date, TimeOnly time)
+  {
+    return new DateTime(
+        date.Year,
+        date.Month,
+        date.Day,
+        0,
+        0,
+        0,
+        DateTimeKind.Utc).Add(time.ToTimeSpan());
+  }
+
+  static TimeOnly[] NormalizeDailyTimes(TimeOnly[] utcTimes)
+  {
+    if (utcTimes == null)
+      throw new ArgumentNullException(nameof(utcTimes));
+    var times = utcTimes
+        .Distinct()
+        .OrderBy(x => x)
+        .ToArray();
+    if (times.Length == 0)
+      throw new ArgumentException(
+          "Daily schedule requires at least one UTC time.",
+          nameof(utcTimes));
+    return times;
+  }
+
+  static LiveBackupWeeklyTime[] NormalizeWeeklyTimes(
+      LiveBackupWeeklyTime[] utcTimes)
+  {
+    if (utcTimes == null)
+      throw new ArgumentNullException(nameof(utcTimes));
+    var times = utcTimes
+        .Distinct()
+        .OrderBy(x => x.DayOfWeek)
+        .ThenBy(x => x.UtcTime)
+        .ToArray();
+    if (times.Length == 0)
+      throw new ArgumentException(
+          "Weekly schedule requires at least one UTC time.",
+          nameof(utcTimes));
+    return times;
+  }
+}
+
+public enum LiveBackupScheduleKind
+{
+  None,
+  Every,
+  Daily,
+  Weekly
+}
+
+public readonly struct LiveBackupWeeklyTime : IEquatable<LiveBackupWeeklyTime>
+{
+  public LiveBackupWeeklyTime(
+      DayOfWeek dayOfWeek,
+      TimeOnly utcTime)
+  {
+    DayOfWeek = dayOfWeek;
+    UtcTime = utcTime;
+  }
+
+  public DayOfWeek DayOfWeek { get; }
+
+  public TimeOnly UtcTime { get; }
+
+  public bool Equals(LiveBackupWeeklyTime other)
+  {
+    return DayOfWeek == other.DayOfWeek &&
+        UtcTime.Equals(other.UtcTime);
+  }
+
+  public override bool Equals(object obj)
+  {
+    return obj is LiveBackupWeeklyTime other && Equals(other);
+  }
+
+  public override int GetHashCode()
+  {
+    return HashCode.Combine(DayOfWeek, UtcTime);
+  }
+
+  public static bool operator ==(LiveBackupWeeklyTime left, LiveBackupWeeklyTime right)
+  {
+    return left.Equals(right);
+  }
+
+  public static bool operator !=(LiveBackupWeeklyTime left, LiveBackupWeeklyTime right)
+  {
+    return !(left == right);
+  }
+}

--- a/src/ZoneTree/Backup/LocalLiveBackupOptions.cs
+++ b/src/ZoneTree/Backup/LocalLiveBackupOptions.cs
@@ -1,0 +1,34 @@
+namespace ZoneTree.Backup;
+
+/// <summary>
+/// Options for the local-directory live backup provider.
+/// </summary>
+public sealed class LocalLiveBackupOptions
+{
+  /// <summary>
+  /// The local backup root directory.
+  /// </summary>
+  public string Directory { get; set; }
+
+  /// <summary>
+  /// Buffer size used while copying backup files.
+  /// </summary>
+  public int CopyBufferSize { get; set; } = 128 * 1024;
+
+  /// <summary>
+  /// Keeps only the latest completed backup generations.
+  /// Null disables local retention.
+  /// </summary>
+  public int? KeepLastGenerations { get; set; }
+
+  public void Normalize()
+  {
+    if (CopyBufferSize <= 0)
+      CopyBufferSize = 128 * 1024;
+    if (KeepLastGenerations.HasValue &&
+        KeepLastGenerations.Value <= 0)
+    {
+      KeepLastGenerations = null;
+    }
+  }
+}

--- a/src/ZoneTree/Backup/LocalLiveBackupProvider.cs
+++ b/src/ZoneTree/Backup/LocalLiveBackupProvider.cs
@@ -1,0 +1,769 @@
+using System.Globalization;
+using System.Text.Json;
+using ZoneTree.Options;
+using ZoneTree.Segments.Disk;
+
+namespace ZoneTree.Backup;
+
+/// <summary>
+/// Streams live backup generations into a local directory using asynchronous
+/// file I/O.
+/// </summary>
+public sealed class LocalLiveBackupProvider
+    : ILiveBackupStore,
+      ILiveBackupSource
+{
+  const string ManifestFileName = "manifest.json";
+
+  const string DataDirectory = "data";
+
+  const string RecordsDirectory = "records";
+
+  const string GenerationsDirectory = "generations";
+
+  static readonly JsonSerializerOptions IndentedJsonOptions = new()
+  {
+    WriteIndented = true
+  };
+
+  readonly object SyncRoot = new();
+
+  readonly Dictionary<long, LocalLiveBackupGenerationCatalog> ActiveGenerations = [];
+
+  readonly string BackupDirectory;
+
+  readonly int BufferSize;
+
+  readonly LocalDirectoryManifest Manifest = new();
+
+  bool ManifestLoaded;
+
+  long LastGenerationId;
+
+  public LocalLiveBackupProvider(
+      string backupDirectory,
+      int bufferSize = 128 * 1024)
+      : this(new LocalLiveBackupOptions
+      {
+        Directory = backupDirectory,
+        CopyBufferSize = bufferSize
+      })
+  {
+  }
+
+  public LocalLiveBackupProvider(
+      LocalLiveBackupOptions options)
+  {
+    if (options == null)
+      throw new ArgumentNullException(nameof(options));
+    options.Normalize();
+    if (string.IsNullOrWhiteSpace(options.Directory))
+      throw new ArgumentException(
+          "Live backup directory is required.",
+          nameof(options));
+    BackupDirectory = options.Directory;
+    BufferSize = options.CopyBufferSize;
+    KeepLastGenerations = options.KeepLastGenerations;
+  }
+
+  public int? KeepLastGenerations { get; }
+
+  public LocalLiveBackupGenerationCatalog ReadCurrentGeneration()
+  {
+    lock (SyncRoot)
+    {
+      LoadManifestIfNeeded();
+      if (Manifest.CurrentGenerationId <= 0)
+        throw new InvalidOperationException(
+            "Local live backup does not contain a completed generation.");
+      return ReadGenerationCatalog(Manifest.CurrentGenerationId);
+    }
+  }
+
+  public LocalLiveBackupGenerationCatalog ReadGeneration(long generationId)
+  {
+    lock (SyncRoot)
+      return ReadGenerationCatalog(generationId);
+  }
+
+  public Task<LiveBackupGeneration> ReadLatestGenerationAsync(
+      CancellationToken cancellationToken)
+  {
+    cancellationToken.ThrowIfCancellationRequested();
+    lock (SyncRoot)
+    {
+      LoadManifestIfNeeded();
+      if (Manifest.CurrentGenerationId <= 0)
+        throw new InvalidOperationException(
+            "Local live backup does not contain a completed generation.");
+      return Task.FromResult(ToLiveBackupGeneration(
+          ReadGenerationCatalog(Manifest.CurrentGenerationId)));
+    }
+  }
+
+  public Task<LiveBackupGeneration> ReadGenerationAsync(
+      long generationId,
+      CancellationToken cancellationToken)
+  {
+    cancellationToken.ThrowIfCancellationRequested();
+    lock (SyncRoot)
+      return Task.FromResult(ToLiveBackupGeneration(
+          ReadGenerationCatalog(generationId)));
+  }
+
+  public Task<Stream> OpenSegmentFileAsync(
+      LiveBackupFile file,
+      CancellationToken cancellationToken)
+  {
+    if (file == null)
+      throw new ArgumentNullException(nameof(file));
+    cancellationToken.ThrowIfCancellationRequested();
+    return Task.FromResult<Stream>(new FileStream(
+        GetFullPath(GetSegmentBackupPath(file.FileName)),
+        FileMode.Open,
+        FileAccess.Read,
+        FileShare.Read,
+        BufferSize,
+        FileOptions.Asynchronous));
+  }
+
+  public Task<Stream> OpenRecordBatchAsync(
+      LiveBackupRecordBatch batch,
+      CancellationToken cancellationToken)
+  {
+    if (batch == null)
+      throw new ArgumentNullException(nameof(batch));
+    cancellationToken.ThrowIfCancellationRequested();
+    return Task.FromResult<Stream>(new FileStream(
+        GetFullPath(GetRecordBatchBackupPath(batch.BatchId)),
+        FileMode.Open,
+        FileAccess.Read,
+        FileShare.Read,
+        BufferSize,
+        FileOptions.Asynchronous));
+  }
+
+  public Task<long> GetNextGenerationIdAsync(CancellationToken cancellationToken)
+  {
+    cancellationToken.ThrowIfCancellationRequested();
+    EnsureRootDirectories();
+    lock (SyncRoot)
+    {
+      LoadManifestIfNeeded();
+      return Task.FromResult(++LastGenerationId);
+    }
+  }
+
+  public Task BeginGenerationAsync(
+      long generationId,
+      DateTime startedAtUtc,
+      CancellationToken cancellationToken)
+  {
+    cancellationToken.ThrowIfCancellationRequested();
+    EnsureRootDirectories();
+    lock (SyncRoot)
+    {
+      ActiveGenerations[generationId] =
+          new LocalLiveBackupGenerationCatalog
+          {
+            GenerationId = generationId,
+            StartedAtUtc = startedAtUtc.ToString("O")
+          };
+    }
+    return Task.CompletedTask;
+  }
+
+  public Task<bool> UseSegmentAsync(
+      long generationId,
+      DiskSegmentFile file,
+      CancellationToken cancellationToken)
+  {
+    cancellationToken.ThrowIfCancellationRequested();
+    if (file == null)
+      throw new ArgumentNullException(nameof(file));
+
+    var mustUpload = false;
+    lock (SyncRoot)
+    {
+      var catalog = GetActiveGeneration(generationId);
+      AddSegmentId(catalog, file.SegmentId);
+      var backupFile = CreateCatalogFile(file);
+      var path = GetFullPath(backupFile.BackupPath);
+      if (File.Exists(path))
+      {
+        backupFile.ByteLength = new FileInfo(path).Length;
+      }
+      else
+      {
+        mustUpload = true;
+      }
+      AddFile(catalog, backupFile);
+    }
+    return Task.FromResult(mustUpload);
+  }
+
+  public async Task UploadSegmentFileAsync(
+      long generationId,
+      DiskSegmentFile file,
+      Stream source,
+      CancellationToken cancellationToken)
+  {
+    if (file == null)
+      throw new ArgumentNullException(nameof(file));
+    if (source == null)
+      throw new ArgumentNullException(nameof(source));
+
+    var backupFile = CreateCatalogFile(
+        file,
+        source.CanSeek ? source.Length : 0);
+    var path = GetFullPath(backupFile.BackupPath);
+
+    await WriteFileAtomicallyAsync(
+        path,
+        async destination =>
+        {
+          await source.CopyToAsync(destination, BufferSize, cancellationToken);
+        },
+        cancellationToken);
+
+    lock (SyncRoot)
+    {
+      AddFile(GetActiveGeneration(generationId), backupFile);
+    }
+  }
+
+  public async Task<ILiveBackupRecordWriter> OpenRecordWriterAsync(
+      long generationId,
+      LiveBackupRecordBatch batch,
+      CancellationToken cancellationToken)
+  {
+    if (batch == null)
+      throw new ArgumentNullException(nameof(batch));
+
+    cancellationToken.ThrowIfCancellationRequested();
+    var recordBatch = new LocalLiveBackupRecordBatch
+    {
+      BatchId = batch.BatchId,
+      BackupPath = GetRecordBatchBackupPath(batch.BatchId),
+      CompressionMethod = batch.CompressionMethod,
+      CompressionLevel = batch.CompressionLevel,
+      CompressionBlockSize = batch.CompressionBlockSize,
+      StartedAtUtc = DateTime.UtcNow.ToString("O")
+    };
+
+    var path = GetFullPath(recordBatch.BackupPath);
+    var tempPath = GetTemporaryPath(path);
+    var directory = Path.GetDirectoryName(path);
+    if (!string.IsNullOrWhiteSpace(directory))
+      Directory.CreateDirectory(directory);
+
+    FileStream destination = null;
+    LocalRecordBatchWriter result = null;
+    try
+    {
+      destination = new FileStream(
+          tempPath,
+          FileMode.Create,
+          FileAccess.Write,
+          FileShare.Read,
+          BufferSize,
+          FileOptions.Asynchronous);
+      LocalLiveBackupGenerationCatalog activeGeneration;
+      lock (SyncRoot)
+      {
+        activeGeneration = GetActiveGeneration(generationId);
+      }
+      activeGeneration.RecordBatch = recordBatch;
+      result = new LocalRecordBatchWriter(
+          destination,
+          batch,
+          recordBatch,
+          tempPath,
+          path);
+      destination = null; // result owns disposal of destination.
+      return result;
+    }
+    catch
+    {
+      await destination.DisposeAsync();
+      if (result != null) await result.DisposeAsync();
+      DeleteFileIfExists(tempPath);
+      throw;
+    }
+  }
+
+  public async Task CompleteGenerationAsync(
+      long generationId,
+      long lastOpIndex,
+      CancellationToken cancellationToken)
+  {
+    LocalLiveBackupGenerationCatalog catalog;
+    lock (SyncRoot)
+    {
+      catalog = GetActiveGeneration(generationId);
+      catalog.LastOpIndex = lastOpIndex;
+      ActiveGenerations.Remove(generationId);
+    }
+
+    await WriteGenerationAsync(catalog, cancellationToken);
+
+    lock (SyncRoot)
+    {
+      Manifest.CurrentGenerationId = catalog.GenerationId;
+      Manifest.UpdatedAtUtc = DateTime.UtcNow.ToString("O");
+    }
+    await WriteManifestAsync(cancellationToken);
+    ApplyRetention(cancellationToken);
+  }
+
+  void EnsureRootDirectories()
+  {
+    Directory.CreateDirectory(BackupDirectory);
+    Directory.CreateDirectory(GetFullPath(DataDirectory));
+    Directory.CreateDirectory(GetFullPath(RecordsDirectory));
+    Directory.CreateDirectory(GetFullPath(GenerationsDirectory));
+  }
+
+  void LoadManifestIfNeeded()
+  {
+    if (ManifestLoaded)
+      return;
+
+    var path = GetFullPath(ManifestFileName);
+    if (File.Exists(path))
+    {
+      var loaded = JsonSerializer.Deserialize<LocalDirectoryManifest>(
+          File.ReadAllText(path));
+      if (loaded != null)
+      {
+        Manifest.Version = loaded.Version;
+        Manifest.CreatedAtUtc = loaded.CreatedAtUtc;
+        Manifest.UpdatedAtUtc = loaded.UpdatedAtUtc;
+        Manifest.CurrentGenerationId = loaded.CurrentGenerationId;
+      }
+    }
+    LastGenerationId = Manifest.CurrentGenerationId;
+    ManifestLoaded = true;
+  }
+
+  async Task WriteGenerationAsync(
+      LocalLiveBackupGenerationCatalog catalog,
+      CancellationToken cancellationToken)
+  {
+    SortCatalog(catalog);
+    var path = GetFullPath(GetGenerationPath(catalog.GenerationId));
+    var bytes = JsonSerializer.SerializeToUtf8Bytes(
+        catalog,
+        IndentedJsonOptions);
+    await WriteFileAtomicallyAsync(
+        path,
+        destination => destination.WriteAsync(bytes, cancellationToken).AsTask(),
+        cancellationToken);
+  }
+
+  async Task WriteManifestAsync(CancellationToken cancellationToken)
+  {
+    var path = GetFullPath(ManifestFileName);
+    var bytes = JsonSerializer.SerializeToUtf8Bytes(
+        Manifest,
+        IndentedJsonOptions);
+    await WriteFileAtomicallyAsync(
+        path,
+        destination => destination.WriteAsync(bytes, cancellationToken).AsTask(),
+        cancellationToken);
+  }
+
+  async Task WriteFileAtomicallyAsync(
+      string path,
+      Func<Stream, Task> writeAsync,
+      CancellationToken cancellationToken)
+  {
+    var tempPath = GetTemporaryPath(path);
+    try
+    {
+      var directory = Path.GetDirectoryName(path);
+      if (!string.IsNullOrWhiteSpace(directory))
+        Directory.CreateDirectory(directory);
+
+      await using (var destination = new FileStream(
+          tempPath,
+          FileMode.Create,
+          FileAccess.Write,
+          FileShare.None,
+          BufferSize,
+          FileOptions.Asynchronous))
+      {
+        await writeAsync(destination);
+        await destination.FlushAsync(cancellationToken);
+      }
+      CommitTemporaryFile(tempPath, path);
+    }
+    catch
+    {
+      DeleteFileIfExists(tempPath);
+      throw;
+    }
+  }
+
+  static string GetTemporaryPath(string path)
+  {
+    return path + "." + Guid.NewGuid().ToString("N") + ".tmp";
+  }
+
+  static void CommitTemporaryFile(
+      string tempPath,
+      string path)
+  {
+    if (File.Exists(path))
+    {
+      File.Replace(tempPath, path, null);
+      return;
+    }
+    try
+    {
+      File.Move(tempPath, path);
+    }
+    catch (IOException) when (File.Exists(path))
+    {
+      File.Replace(tempPath, path, null);
+    }
+  }
+
+  static void DeleteFileIfExists(string path)
+  {
+    if (File.Exists(path))
+      File.Delete(path);
+  }
+
+  void ApplyRetention(CancellationToken cancellationToken)
+  {
+    // Retention is applied at the backup-path level, not at the generation level
+    // alone. We first read all generation catalogs and select the newest
+    // KeepLastGenerations catalogs as the retained set. Every file referenced by
+    // those retained catalogs is protected from deletion, including segment files,
+    // record batches, the manifest, and the retained generation catalog files.
+    //
+    // Older generations are then scanned for files to remove. A file from an older
+    // generation is deleted only if its backup path is not referenced by any
+    // retained generation. This is important for reused segment files: when
+    // UseSegmentAsync reuses an existing segment file, it still records that file
+    // in the new generation catalog. Therefore, even if the original older
+    // generation is removed, the physical segment file is preserved as long as a
+    // retained generation still references the same backup path.
+    cancellationToken.ThrowIfCancellationRequested();
+    if (!KeepLastGenerations.HasValue)
+      return;
+
+    var generations = ReadGenerationCatalogs()
+        .OrderByDescending(x => x.GenerationId)
+        .ToList();
+
+    var retained = generations
+        .Take(KeepLastGenerations.Value)
+        .ToList();
+    var retainedPaths = retained
+        .SelectMany(GetBackupPaths)
+        .Append(ManifestFileName)
+        .Concat(retained.Select(x => GetGenerationPath(x.GenerationId)))
+        .ToHashSet(StringComparer.Ordinal);
+
+    var deleted = generations
+        .Skip(KeepLastGenerations.Value)
+        .SelectMany(x => GetBackupPaths(x)
+            .Append(GetGenerationPath(x.GenerationId)))
+        .Where(x => !retainedPaths.Contains(x))
+        .Distinct(StringComparer.Ordinal)
+        .ToList();
+
+    foreach (var backupPath in deleted)
+      DeleteFile(backupPath, cancellationToken);
+  }
+
+  void DeleteFile(
+      string backupPath,
+      CancellationToken cancellationToken)
+  {
+    cancellationToken.ThrowIfCancellationRequested();
+    var path = GetFullPath(backupPath);
+    if (File.Exists(path))
+      File.Delete(path);
+  }
+
+  static string GetSegmentBackupPath(string fileName)
+  {
+    return DataDirectory + "/" + fileName;
+  }
+
+  static string GetRecordBatchBackupPath(long batchId)
+  {
+    return RecordsDirectory + "/" +
+        batchId.ToString("D20", CultureInfo.InvariantCulture) + ".bin";
+  }
+
+  static string GetGenerationPath(long generationId)
+  {
+    return GenerationsDirectory + "/" +
+        generationId.ToString("D20", CultureInfo.InvariantCulture) + ".json";
+  }
+
+  string GetFullPath(string relativePath)
+  {
+    var path = relativePath
+        .Replace('/', Path.DirectorySeparatorChar)
+        .Replace('\\', Path.DirectorySeparatorChar);
+    return Path.Combine(BackupDirectory, path);
+  }
+
+  List<LocalLiveBackupGenerationCatalog> ReadGenerationCatalogs()
+  {
+    var directory = GetFullPath(GenerationsDirectory);
+    if (!Directory.Exists(directory))
+      return new List<LocalLiveBackupGenerationCatalog>();
+
+    var result = new List<LocalLiveBackupGenerationCatalog>();
+    foreach (var path in Directory.GetFiles(directory, "*.json"))
+    {
+      var catalog = JsonSerializer.Deserialize<LocalLiveBackupGenerationCatalog>(
+          File.ReadAllText(path));
+      if (catalog != null)
+        result.Add(catalog);
+    }
+    return result;
+  }
+
+  LocalLiveBackupGenerationCatalog ReadGenerationCatalog(long generationId)
+  {
+    var path = GetFullPath(GetGenerationPath(generationId));
+    if (!File.Exists(path))
+      throw new FileNotFoundException(
+          "Local live backup generation catalog was not found.",
+          path);
+    return JsonSerializer.Deserialize<LocalLiveBackupGenerationCatalog>(
+        File.ReadAllText(path));
+  }
+
+  LocalLiveBackupGenerationCatalog GetActiveGeneration(long generationId)
+  {
+    if (ActiveGenerations.TryGetValue(generationId, out var catalog))
+      return catalog;
+    throw new InvalidOperationException(
+        "Live backup generation has not been started.");
+  }
+
+  static LocalLiveBackupFile CreateCatalogFile(
+      DiskSegmentFile file,
+      long byteLength = 0)
+  {
+    return new LocalLiveBackupFile
+    {
+      SegmentId = file.SegmentId,
+      Order = file.Order,
+      FileName = file.FileName,
+      BackupPath = GetSegmentBackupPath(file.FileName),
+      RecordCount = file.RecordCount,
+      ByteLength = byteLength,
+      CopiedAtUtc = DateTime.UtcNow.ToString("O")
+    };
+  }
+
+  static void AddSegmentId(
+      LocalLiveBackupGenerationCatalog catalog,
+      long segmentId)
+  {
+    if (segmentId <= 0)
+      return;
+    if (!catalog.SegmentIds.Contains(segmentId))
+      catalog.SegmentIds.Add(segmentId);
+  }
+
+  static void AddFile(
+      LocalLiveBackupGenerationCatalog catalog,
+      LocalLiveBackupFile file)
+  {
+    if (string.IsNullOrWhiteSpace(file.BackupPath))
+      return;
+
+    catalog.Files.RemoveAll(x =>
+        string.Equals(x.BackupPath, file.BackupPath, StringComparison.Ordinal));
+    catalog.Files.Add(file);
+  }
+
+  static IEnumerable<string> GetBackupPaths(
+      LocalLiveBackupGenerationCatalog catalog)
+  {
+    foreach (var file in catalog.Files)
+      if (!string.IsNullOrWhiteSpace(file.BackupPath))
+        yield return file.BackupPath;
+
+    if (!string.IsNullOrWhiteSpace(catalog.RecordBatch?.BackupPath))
+      yield return catalog.RecordBatch.BackupPath;
+  }
+
+  static void SortCatalog(LocalLiveBackupGenerationCatalog catalog)
+  {
+    catalog.Files = catalog.Files
+        .OrderBy(x => x.BackupPath, StringComparer.Ordinal)
+        .ToList();
+  }
+
+  static LiveBackupGeneration ToLiveBackupGeneration(
+      LocalLiveBackupGenerationCatalog catalog)
+  {
+    return new LiveBackupGeneration
+    {
+      GenerationId = catalog.GenerationId,
+      LastOpIndex = catalog.LastOpIndex,
+      SegmentIds = [.. catalog.SegmentIds],
+      Files = [.. catalog.Files
+          .Select(x => new LiveBackupFile
+          {
+            SegmentId = x.SegmentId,
+            Order = x.Order,
+            FileName = x.FileName,
+            RecordCount = x.RecordCount,
+            ByteLength = x.ByteLength
+          })],
+      RecordBatch = ToRecordBatch(catalog.RecordBatch)
+    };
+  }
+
+  static LiveBackupRecordBatch ToRecordBatch(
+      LocalLiveBackupRecordBatch batch)
+  {
+    if (batch == null || !batch.Completed)
+      return null;
+    return new LiveBackupRecordBatch
+    {
+      BatchId = batch.BatchId,
+      RecordCount = batch.RecordCount,
+      CompressionMethod = batch.CompressionMethod,
+      CompressionLevel = batch.CompressionLevel,
+      CompressionBlockSize = batch.CompressionBlockSize,
+      UncompressedLength = batch.UncompressedLength,
+      StoredLength = batch.StoredLength
+    };
+  }
+
+  sealed class LocalRecordBatchWriter : ILiveBackupRecordWriter
+  {
+    readonly ILiveBackupRecordWriter Writer;
+
+    readonly LiveBackupRecordBatch SourceBatch;
+
+    readonly LocalLiveBackupRecordBatch CatalogBatch;
+
+    readonly string TempPath;
+
+    readonly string DestinationPath;
+
+    long RecordCount;
+
+    public LocalRecordBatchWriter(
+        Stream destination,
+        LiveBackupRecordBatch sourceBatch,
+        LocalLiveBackupRecordBatch catalogBatch,
+        string tempPath,
+        string destinationPath)
+    {
+      Writer = new LiveBackupRecordBatchWriter(destination, sourceBatch);
+      SourceBatch = sourceBatch;
+      CatalogBatch = catalogBatch;
+      TempPath = tempPath;
+      DestinationPath = destinationPath;
+    }
+
+    public Task WriteAsync(
+        LiveBackupRecord record,
+        CancellationToken cancellationToken)
+    {
+      ++RecordCount;
+      return Writer.WriteAsync(record, cancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+      try
+      {
+        await Writer.DisposeAsync();
+        CommitTemporaryFile(TempPath, DestinationPath);
+        CatalogBatch.RecordCount = RecordCount;
+        CatalogBatch.UncompressedLength = SourceBatch.UncompressedLength;
+        CatalogBatch.StoredLength = SourceBatch.StoredLength;
+        CatalogBatch.CompletedAtUtc = DateTime.UtcNow.ToString("O");
+        CatalogBatch.Completed = true;
+      }
+      catch
+      {
+        DeleteFileIfExists(TempPath);
+        throw;
+      }
+    }
+  }
+  sealed class LocalDirectoryManifest
+  {
+    public int Version { get; set; } = 1;
+
+    public string CreatedAtUtc { get; set; } = DateTime.UtcNow.ToString("O");
+
+    public string UpdatedAtUtc { get; set; } = DateTime.UtcNow.ToString("O");
+
+    public long CurrentGenerationId { get; set; }
+  }
+}
+
+public sealed class LocalLiveBackupGenerationCatalog
+{
+  public long GenerationId { get; set; }
+
+  public long LastOpIndex { get; set; }
+
+  public string StartedAtUtc { get; set; }
+
+  public List<long> SegmentIds { get; set; } = new();
+
+  public List<LocalLiveBackupFile> Files { get; set; } = new();
+
+  public LocalLiveBackupRecordBatch RecordBatch { get; set; }
+}
+
+public sealed class LocalLiveBackupRecordBatch
+{
+  public long BatchId { get; set; }
+
+  public string BackupPath { get; set; }
+
+  public long RecordCount { get; set; }
+
+  public CompressionMethod CompressionMethod { get; set; }
+
+  public int CompressionLevel { get; set; }
+
+  public int CompressionBlockSize { get; set; }
+
+  public long UncompressedLength { get; set; }
+
+  public long StoredLength { get; set; }
+
+  public string StartedAtUtc { get; set; }
+
+  public string CompletedAtUtc { get; set; }
+
+  public bool Completed { get; set; }
+}
+
+public sealed class LocalLiveBackupFile
+{
+  public long SegmentId { get; set; }
+
+  public int Order { get; set; }
+
+  public string FileName { get; set; }
+
+  public string BackupPath { get; set; }
+
+  public long RecordCount { get; set; }
+
+  public long ByteLength { get; set; }
+
+  public string CopiedAtUtc { get; set; }
+}

--- a/src/ZoneTree/Collections/BTree/BTree.Read.cs
+++ b/src/ZoneTree/Collections/BTree/BTree.Read.cs
@@ -209,7 +209,7 @@ public sealed partial class BTree<TKey, TValue>
       leafs.Enqueue(leafRoot);
     else
       queue.Enqueue(newRoot);
-    while (queue.Any())
+    while (queue.Count > 0)
     {
       var node = queue.Dequeue();
       var children = node.Children;
@@ -228,7 +228,7 @@ public sealed partial class BTree<TKey, TValue>
     }
     var leaf = leafs.Dequeue();
     var first = leaf;
-    while (leafs.Any())
+    while (leafs.Count > 0)
     {
       var next = leafs.Dequeue();
       leaf.Next = next;
@@ -257,7 +257,7 @@ public sealed partial class BTree<TKey, TValue>
       leafs.Enqueue(leafRoot);
     else
       queue.Enqueue(root);
-    while (queue.Any())
+    while (queue.Count > 0)
     {
       var node = queue.Dequeue();
       var children = node.Children;
@@ -275,7 +275,7 @@ public sealed partial class BTree<TKey, TValue>
       }
     }
     var leaf = leafs.Dequeue();
-    while (leafs.Any())
+    while (leafs.Count > 0)
     {
       var next = leafs.Dequeue();
       if (leaf == next)

--- a/src/ZoneTree/Core/ZoneTree.Iterators.cs
+++ b/src/ZoneTree/Core/ZoneTree.Iterators.cs
@@ -53,6 +53,91 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
       }
   }
 
+  /// <summary>
+  /// Collects the immutable disk segment set and an in-memory-only iterator for
+  /// one live backup generation. Disk segments are attached for physical file
+  /// copy. The iterator excludes disk and bottom segments so in-memory records
+  /// can be streamed without scanning immutable disk data again.
+  /// </summary>
+  public BackupSegmentCollection CollectBackupSegments(
+      bool moveMutableSegmentForward,
+      bool includeInMemorySegments)
+  {
+    if (moveMutableSegmentForward && includeInMemorySegments)
+      MoveMutableSegmentForward();
+
+    BackupSegmentCollection result = null;
+    try
+    {
+      lock (ShortMergerLock)
+        lock (AtomicUpdateLock)
+        {
+          IDiskSegment<TKey, TValue> attachedDiskSegment = null;
+          var attachedBottomSegments = new List<IDiskSegment<TKey, TValue>>();
+          ZoneTreeIterator<TKey, TValue> inMemoryIterator = null;
+          var completed = false;
+          try
+          {
+            result = new BackupSegmentCollection();
+
+            var diskSegment = DiskSegment;
+            if (diskSegment is not NullDiskSegment<TKey, TValue>)
+            {
+              diskSegment.AttachIterator();
+              attachedDiskSegment = diskSegment;
+              result.DiskSegment = diskSegment;
+            }
+
+            var bottomSegments = BottomSegmentQueue.ToLastInFirstArray();
+            foreach (var bottom in bottomSegments)
+            {
+              bottom.AttachIterator();
+              attachedBottomSegments.Add(bottom);
+            }
+            result.BottomSegments = bottomSegments;
+
+            if (includeInMemorySegments)
+            {
+              inMemoryIterator = moveMutableSegmentForward
+                  ? (ZoneTreeIterator<TKey, TValue>)CreateReadOnlySegmentsIterator(
+                      autoRefresh: false,
+                      includeDeletedRecords: true)
+                  : (ZoneTreeIterator<TKey, TValue>)CreateInMemorySegmentsIterator(
+                      autoRefresh: false,
+                      includeDeletedRecords: true);
+              inMemoryIterator.Refresh();
+            }
+
+            result.InMemoryIterator = inMemoryIterator;
+            completed = true;
+          }
+          finally
+          {
+            if (!completed)
+            {
+              inMemoryIterator?.Dispose();
+              attachedDiskSegment?.DetachIterator();
+              foreach (var bottom in attachedBottomSegments)
+                bottom.DetachIterator();
+              result = null;
+            }
+          }
+        }
+
+      if (moveMutableSegmentForward && includeInMemorySegments)
+      {
+        var iterator = (ZoneTreeIterator<TKey, TValue>)result.InMemoryIterator;
+        iterator.WaitUntilReadOnlySegmentsBecomeFullyFrozen();
+      }
+      return result;
+    }
+    catch
+    {
+      result?.Dispose();
+      throw;
+    }
+  }
+
   public sealed class SegmentCollection
   {
     public IReadOnlyList<ISeekableIterator<TKey, TValue>> SeekableIterators { get; set; }
@@ -60,6 +145,45 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
     public IDiskSegment<TKey, TValue> DiskSegment { get; set; }
 
     public IReadOnlyList<IDiskSegment<TKey, TValue>> BottomSegments { get; set; }
+  }
+
+  public sealed class DiskSegmentCollection
+  {
+    public IDiskSegment<TKey, TValue> DiskSegment { get; set; }
+
+    public IReadOnlyList<IDiskSegment<TKey, TValue>> BottomSegments { get; set; }
+  }
+
+  public sealed class BackupSegmentCollection : IDisposable
+  {
+    bool IsDisposed;
+
+    public IDiskSegment<TKey, TValue> DiskSegment { get; set; }
+
+    public IReadOnlyList<IDiskSegment<TKey, TValue>> BottomSegments { get; set; }
+
+    public IZoneTreeIterator<TKey, TValue> InMemoryIterator { get; set; }
+
+    public void Dispose()
+    {
+      if (IsDisposed)
+        return;
+
+      InMemoryIterator?.Dispose();
+      InMemoryIterator = null;
+
+      DiskSegment?.DetachIterator();
+      DiskSegment = null;
+
+      if (BottomSegments != null)
+      {
+        foreach (var bottom in BottomSegments)
+          bottom?.DetachIterator();
+        BottomSegments = null;
+      }
+
+      IsDisposed = true;
+    }
   }
 
   public IZoneTreeIterator<TKey, TValue> CreateIterator(

--- a/src/ZoneTree/Core/ZoneTree.cs
+++ b/src/ZoneTree/Core/ZoneTree.cs
@@ -32,7 +32,7 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
 
   volatile SingleProducerSingleConsumerQueue<IDiskSegment<TKey, TValue>> BottomSegmentQueue = new();
 
-  readonly IIncrementalIdProvider IncrementalIdProvider = new IncrementalIdProvider();
+  readonly IncrementalIdProvider IncrementalIdProvider = new();
 
   readonly object AtomicUpdateLock = new();
 
@@ -131,6 +131,8 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
   public ISerializer<TKey> KeySerializer => Options.KeySerializer;
 
   public ISerializer<TValue> ValueSerializer => Options.ValueSerializer;
+
+  public long LastOpIndex => IncrementalIdProvider.LastId;
 
   public ZoneTree(ZoneTreeOptions<TKey, TValue> options)
   {

--- a/src/ZoneTree/Core/ZoneTreeLoader.cs
+++ b/src/ZoneTree/Core/ZoneTreeLoader.cs
@@ -275,12 +275,6 @@ public sealed class ZoneTreeLoader<TKey, TValue>
       DiskSegment = new NullDiskSegment<TKey, TValue>();
       return;
     }
-    if (Options.RandomAccessDeviceManager
-        .DeviceExists(segmentId, DiskSegmentConstants.MultiPartDiskSegmentCategory, false))
-    {
-      DiskSegment = new MultiPartDiskSegment<TKey, TValue>(segmentId, Options);
-      return;
-    }
     DiskSegment = DiskSegmentFactory.CreateDiskSegment(segmentId, Options);
   }
 
@@ -291,18 +285,8 @@ public sealed class ZoneTreeLoader<TKey, TValue>
 
     Parallel.ForEach(segments, (segmentId) =>
     {
-      if (Options.RandomAccessDeviceManager
-              .DeviceExists(segmentId,
-                  DiskSegmentConstants.MultiPartDiskSegmentCategory, false))
-      {
-        var ds = new MultiPartDiskSegment<TKey, TValue>(segmentId, Options);
-        map.AddOrUpdate(segmentId, ds, (_, _) => ds);
-      }
-      else
-      {
-        var ds = DiskSegmentFactory.CreateDiskSegment(segmentId, Options);
-        map.AddOrUpdate(segmentId, ds, (_, _) => ds);
-      }
+      var ds = DiskSegmentFactory.CreateDiskSegment(segmentId, Options);
+      map.AddOrUpdate(segmentId, ds, (_, _) => ds);
     });
     BottomSegments = segments.Select(x => map[x]).ToArray();
   }

--- a/src/ZoneTree/Segments/Disk/DiskSegment.cs
+++ b/src/ZoneTree/Segments/Disk/DiskSegment.cs
@@ -440,6 +440,43 @@ public abstract class DiskSegment<TKey, TValue> : IDiskSegment<TKey, TValue>
 
   public int GetPartCount() => 0;
 
+  public DiskSegmentFile[] GetFiles()
+  {
+    var files = new List<DiskSegmentFile>();
+    AddFileIfExists(files, DiskSegmentConstants.DataHeaderCategory);
+    AddFileIfExists(files, DiskSegmentConstants.DataCategory);
+    AddFileIfExists(files, DiskSegmentConstants.SparseArrayCategory);
+    return [.. files];
+  }
+
+  void AddFileIfExists(
+      List<DiskSegmentFile> files,
+      string category)
+  {
+    AddFileIfExists(files, category, false);
+    AddFileIfExists(files, category, true);
+  }
+
+  void AddFileIfExists(
+      List<DiskSegmentFile> files,
+      string category,
+      bool isCompressed)
+  {
+    var deviceManager = Options.RandomAccessDeviceManager;
+    if (!deviceManager.DeviceExists(SegmentId, category, isCompressed))
+      return;
+
+    var path = deviceManager.GetFilePath(SegmentId, category);
+    if (isCompressed)
+      path += ".z";
+
+    files.Add(new DiskSegmentFile(
+        SegmentId,
+        path,
+        System.IO.Path.GetFileName(path),
+        Length));
+  }
+
   abstract public void SetDefaultSparseArray(IReadOnlyList<SparseArrayEntry<TKey, TValue>> defaultSparseArray);
 
   public int ReleaseCircularKeyCacheRecords()

--- a/src/ZoneTree/Segments/Disk/DiskSegmentFactory.cs
+++ b/src/ZoneTree/Segments/Disk/DiskSegmentFactory.cs
@@ -2,9 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
 using ZoneTree.Options;
+using ZoneTree.Segments.MultiPart;
 using ZoneTree.Segments.DiskSegmentVariations;
 using ZoneTree.Segments.RandomAccess;
 
@@ -15,6 +14,14 @@ public static class DiskSegmentFactory
   public static IDiskSegment<TKey, TValue>
       CreateDiskSegment<TKey, TValue>(long segmentId, ZoneTreeOptions<TKey, TValue> options)
   {
+    if (options.RandomAccessDeviceManager.DeviceExists(
+        segmentId,
+        DiskSegmentConstants.MultiPartDiskSegmentCategory,
+        isCompressed: false))
+    {
+      return new MultiPartDiskSegment<TKey, TValue>(segmentId, options);
+    }
+
     var hasFixedSizeKey = !RuntimeHelpers.IsReferenceOrContainsReferences<TKey>();
     var hasFixedSizeValue = !RuntimeHelpers.IsReferenceOrContainsReferences<TValue>();
     if (hasFixedSizeKey && hasFixedSizeValue)
@@ -41,5 +48,36 @@ public static class DiskSegmentFactory
     if (hasFixedSizeValue)
       return new FixedSizeValueDiskSegment<TKey, TValue>(segmentId, options, dataHeaderDevice, dataDevice);
     return new VariableSizeDiskSegment<TKey, TValue>(segmentId, options, dataHeaderDevice, dataDevice);
+  }
+
+  public static IDiskSegment<TKey, TValue> CreateDiskSegment<TKey, TValue>(
+      DiskSegmentFile[] files,
+      ZoneTreeOptions<TKey, TValue> options)
+  {
+    if (files == null || files.Length == 0)
+      throw new ArgumentException("Disk segment files cannot be empty.", nameof(files));
+
+    var rootFile = files.FirstOrDefault(x =>
+        x.FileName.EndsWith(
+            DiskSegmentConstants.MultiPartDiskSegmentCategory,
+            StringComparison.Ordinal)) ?? files[0];
+
+    return CreateDiskSegment(rootFile.SegmentId, options, files);
+  }
+
+  public static IDiskSegment<TKey, TValue> CreateDiskSegment<TKey, TValue>(
+      long segmentId,
+      ZoneTreeOptions<TKey, TValue> options,
+      DiskSegmentFile[] files)
+  {
+    if (files == null || files.Length == 0)
+      throw new ArgumentException("Disk segment files cannot be empty.", nameof(files));
+
+    if (!files.Any(x => x.SegmentId == segmentId))
+      throw new ArgumentException(
+          $"Disk segment file is missing for segment {segmentId}.",
+          nameof(files));
+
+    return CreateDiskSegment(segmentId, options);
   }
 }

--- a/src/ZoneTree/Segments/Disk/DiskSegmentFile.cs
+++ b/src/ZoneTree/Segments/Disk/DiskSegmentFile.cs
@@ -1,0 +1,8 @@
+namespace ZoneTree.Segments.Disk;
+
+public sealed record DiskSegmentFile(
+    long SegmentId,
+    string Path,
+    string FileName,
+    long RecordCount,
+    int Order = -1);

--- a/src/ZoneTree/Segments/IDiskSegment.cs
+++ b/src/ZoneTree/Segments/IDiskSegment.cs
@@ -29,13 +29,13 @@ public interface IDiskSegment<TKey, TValue> : IReadOnlySegment<TKey, TValue>, II
 
   /// <summary>
   /// Increments the iterator reader counter
-  /// to ensure that disk segment stays alive 
+  /// to ensure that disk segment stays alive
   /// until all iterators call DetachIterator.
   /// </summary>
   void AttachIterator();
 
   /// <summary>
-  /// Decrements the iterator reader counter. 
+  /// Decrements the iterator reader counter.
   /// When there is no attached iterator remaining and
   /// the drop is already requested,
   /// calls Drop().
@@ -80,7 +80,7 @@ public interface IDiskSegment<TKey, TValue> : IReadOnlySegment<TKey, TValue>, II
 
   /// <summary>
   /// Exceptions occurs in delayed drops (eg: iterators delays segment drops)
-  /// are being reported to the IZoneTreeMaintenance interface events 
+  /// are being reported to the IZoneTreeMaintenance interface events
   /// through this delegate.
   /// This is for internal usage.
   /// </summary>
@@ -100,8 +100,14 @@ public interface IDiskSegment<TKey, TValue> : IReadOnlySegment<TKey, TValue>, II
   int GetPartCount();
 
   /// <summary>
+  /// Returns all physical files that belong to this disk segment.
+  /// Multipart segments include their descriptor and all part files.
+  /// </summary>
+  DiskSegmentFile[] GetFiles();
+
+  /// <summary>
   /// Drops all sectors of the segment except those in the specified exclusion list.
-  /// </summary> 
+  /// </summary>
   /// <param name="excludedPartIds">A set of part IDs to exclude from dropping.</param>
   void Drop(HashSet<long> excludedPartIds);
 

--- a/src/ZoneTree/Segments/MultiPart/MultiPartDiskSegment.cs
+++ b/src/ZoneTree/Segments/MultiPart/MultiPartDiskSegment.cs
@@ -606,6 +606,27 @@ public sealed class MultiPartDiskSegment<TKey, TValue> : IDiskSegment<TKey, TVal
 
   public int GetPartCount() => Parts.Count;
 
+  public DiskSegmentFile[] GetFiles()
+  {
+    var files = new List<DiskSegmentFile>();
+    var deviceManager = Options.RandomAccessDeviceManager;
+    var category = DiskSegmentConstants.MultiPartDiskSegmentCategory;
+    if (deviceManager.DeviceExists(SegmentId, category, false))
+    {
+      var path = deviceManager.GetFilePath(SegmentId, category);
+      files.Add(new DiskSegmentFile(
+          SegmentId,
+          path,
+          Path.GetFileName(path),
+          Length));
+    }
+
+    foreach (var part in Parts)
+      files.AddRange(part.GetFiles());
+
+    return [.. files];
+  }
+
   public void SetDefaultSparseArray(IReadOnlyList<SparseArrayEntry<TKey, TValue>> defaultSparseArray)
   {
     throw new NotSupportedException("SetDefaultSparseArray is not intended to be called for MultiPartDiskSegment");

--- a/src/ZoneTree/Segments/NullDisk/NullDiskSegment.cs
+++ b/src/ZoneTree/Segments/NullDisk/NullDiskSegment.cs
@@ -132,6 +132,11 @@ public sealed class NullDiskSegment<TKey, TValue> : IDiskSegment<TKey, TValue>
 
   public int GetPartCount() => 0;
 
+  public DiskSegmentFile[] GetFiles()
+  {
+    return [];
+  }
+
   public void SetDefaultSparseArray(IReadOnlyList<SparseArrayEntry<TKey, TValue>> defaultSparseArray)
   {
   }
@@ -156,4 +161,3 @@ public sealed class NullDiskSegment<TKey, TValue> : IDiskSegment<TKey, TValue>
     throw new IndexOutOfRangeException();
   }
 }
-

--- a/src/ZoneTree/Segments/RandomAccess/CompressedFileRandomAccessDevice.cs
+++ b/src/ZoneTree/Segments/RandomAccess/CompressedFileRandomAccessDevice.cs
@@ -127,7 +127,7 @@ public sealed class CompressedFileRandomAccessDevice : IRandomAccessDevice
     CompressionLevel = compressionLevel;
     var fileMode = writable ? FileMode.OpenOrCreate : FileMode.Open;
     var fileAccess = writable ? FileAccess.ReadWrite : FileAccess.Read;
-    var fileShare = writable ? FileShare.None : FileShare.Read;
+    var fileShare = FileShare.Read;
     FileStream = fileStreamProvider.CreateFileStream(filePath,
         fileMode,
         fileAccess,

--- a/src/ZoneTree/Segments/RandomAccess/FileRandomAccessDevice.cs
+++ b/src/ZoneTree/Segments/RandomAccess/FileRandomAccessDevice.cs
@@ -40,7 +40,7 @@ public sealed class FileRandomAccessDevice : IRandomAccessDevice
     Writable = writable;
     var fileMode = writable ? FileMode.OpenOrCreate : FileMode.Open;
     var fileAccess = writable ? FileAccess.ReadWrite : FileAccess.Read;
-    var fileShare = writable ? FileShare.None : FileShare.Read;
+    var fileShare = FileShare.Read;
     FileStream = fileStreamProvider.CreateFileStream(filePath,
         fileMode,
         fileAccess,

--- a/src/ZoneTree/ZoneTree.csproj
+++ b/src/ZoneTree/ZoneTree.csproj
@@ -5,6 +5,7 @@
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
     <NeutralLanguage>en-US</NeutralLanguage>
     <TargetFrameworks>net10.0;net9.0;net8.0;net7.0;net6.0</TargetFrameworks>
+    <LangVersion>14.0</LangVersion>
     <RepositoryUrl>https://github.com/koculu/ZoneTree</RepositoryUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/ZoneTree/ZoneTreeFactory.cs
+++ b/src/ZoneTree/ZoneTreeFactory.cs
@@ -10,6 +10,7 @@ using ZoneTree.Options;
 using ZoneTree.Logger;
 using ZoneTree.Segments.RandomAccess;
 using ZoneTree.PresetTypes;
+using ZoneTree.Backup;
 
 namespace ZoneTree;
 
@@ -406,6 +407,90 @@ public sealed class ZoneTreeFactory<TKey, TValue>
       throw new DatabaseNotFoundException();
     var zoneTree = loader.LoadZoneTree();
     return zoneTree;
+  }
+
+  /// <summary>
+  /// Restores the latest generation from a local live backup directory and opens
+  /// the restored ZoneTree.
+  /// </summary>
+  public async ValueTask<IZoneTree<TKey, TValue>> RestoreFromLatestLiveBackup(string backupDirectory)
+  {
+    return await RestoreFromLatestLiveBackup(
+        new LocalLiveBackupProvider(backupDirectory));
+  }
+
+  /// <summary>
+  /// Restores the latest generation from a local live backup directory and opens
+  /// the restored ZoneTree.
+  /// </summary>
+  public async ValueTask<IZoneTree<TKey, TValue>> RestoreFromLatestLiveBackup(
+      LocalLiveBackupOptions localBackupOptions)
+  {
+    return await RestoreFromLatestLiveBackup(
+        new LocalLiveBackupProvider(localBackupOptions));
+  }
+
+  /// <summary>
+  /// Restores the latest generation from a live backup source and opens the
+  /// restored ZoneTree.
+  /// </summary>
+  public async ValueTask<IZoneTree<TKey, TValue>> RestoreFromLatestLiveBackup(
+      ILiveBackupSource source)
+  {
+    return await RestoreLiveBackup(source, generationId: null);
+  }
+
+  /// <summary>
+  /// Restores a specific generation from a local live backup directory and opens
+  /// the restored ZoneTree.
+  /// </summary>
+  public async ValueTask<IZoneTree<TKey, TValue>> RestoreFromLiveBackupGeneration(
+      string backupDirectory,
+      long generationId)
+  {
+    return await RestoreFromLiveBackupGeneration(
+        new LocalLiveBackupProvider(backupDirectory),
+        generationId);
+  }
+
+  /// <summary>
+  /// Restores a specific generation from a local live backup directory and opens
+  /// the restored ZoneTree.
+  /// </summary>
+  public async ValueTask<IZoneTree<TKey, TValue>> RestoreFromLiveBackupGeneration(
+      LocalLiveBackupOptions localBackupOptions,
+      long generationId)
+  {
+    return await RestoreFromLiveBackupGeneration(
+        new LocalLiveBackupProvider(localBackupOptions),
+        generationId);
+  }
+
+  /// <summary>
+  /// Restores a specific generation from a live backup source and opens the
+  /// restored ZoneTree.
+  /// </summary>
+  public async ValueTask<IZoneTree<TKey, TValue>> RestoreFromLiveBackupGeneration(
+      ILiveBackupSource source,
+      long generationId)
+  {
+    return await RestoreLiveBackup(source, generationId);
+  }
+
+  async ValueTask<IZoneTree<TKey, TValue>> RestoreLiveBackup(
+      ILiveBackupSource source,
+      long? generationId)
+  {
+    FillMissingOptionsForKnownTypes();
+    InitWriteAheadLogProvider();
+    var restore = new LiveBackupRestore<TKey, TValue>(
+        Options,
+        source);
+    if (generationId.HasValue)
+      await restore.RestoreGeneration(generationId.Value);
+    else
+      await restore.RestoreLatest();
+    return Open();
   }
 
   /// <summary>


### PR DESCRIPTION
##  Summary

This PR adds first-class live backup support for ZoneTree. A live backup generation captures immutable disk segments and streamed in-memory records without changing the live ZoneTree state. Backup storage is abstracted so applications can write generations to local disk, object storage, remote services, or custom infrastructure.

## What Changed

- Added `LiveBackup<TKey, TValue>` for creating backup generations while ZoneTree remains online.
- Added `ILiveBackupStore` and `ILiveBackupSource` to separate backup writing from restore reading.
- Added `LocalLiveBackupProvider` as the built-in local directory implementation.
- Added manual and scheduled generation creation:
  - `CreateGeneration()`
  - `LiveBackupSchedule.Every(...)`
  - `LiveBackupSchedule.Daily(...)`
  - `LiveBackupSchedule.Weekly(...)`
- Added in-memory record backup through ZoneTree iterators.
- Added configurable in-memory backup mode:
  - live iteration
  - snapshot-style iteration by moving the mutable segment forward
- Added compressed record batch support for in-memory backup records.
- Added restore APIs on `ZoneTreeFactory`:
  - restore latest live backup generation
  - restore a specific generation
- Added disk segment file metadata through `DiskSegmentFile`.
- Added disk segment loading support from backup file lists.
- Added stable segment ordering for restore.
- Made live backup fail loudly when declared segment files are missing.
- Made local backup file publishing atomic with temporary files and final commit.
- Updated random access disk files to allow safe concurrent reads during backup.
- Updated backup documentation.
- Added regression and coverage tests for live backup, restore, scheduling, segment reuse, retention, failures, and disk segment factory loading.
- Fixed small analyzer warning in `BTree.Read.cs` by using `Count > 0` instead of `Any()`.

## Design Notes

- Disk segment files are copied as immutable physical files.
- In-memory records are written into backup record batches.
- Existing segment files can be reused by the backup store instead of uploaded again.
- Retention is handled by the backup store implementation.
- Restore reconstructs ZoneTree metadata, disk segment files, and frozen WAL data for backed-up in-memory records.
- Transactional ZoneTree live backup is intentionally not supported in this PR.

## Testing

- Added unit tests for the live backup and restore flow.
- Added disk segment factory tests for restoring segment files.