### PR TITLE
Reworks `InMemoryFileStreamProvider` into a fast RAM-backed storage provider

### DIFF
--- a/docs/_nav.json
+++ b/docs/_nav.json
@@ -30,6 +30,7 @@
     "concepts/value-mutability.md",
     "storage/",
     "storage/disk-segments.md",
+    "storage/file-stream-providers.md",
     "storage/memory-usage.md",
     "storage/read-path-caching.md",
     "storage/compression.md",

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,6 +53,7 @@ For the storage model, start with [LSM Tree](concepts/lsm-tree.md). For ZoneTree
 
 * [Memory usage](storage/memory-usage.md)
 * [Disk segments](storage/disk-segments.md)
+* [File stream providers](storage/file-stream-providers.md)
 * [Read-path caching](storage/read-path-caching.md)
 * [Compression](storage/compression.md)
 * [Serializers and comparers](storage/serializers-and-comparers.md)

--- a/docs/storage/file-stream-providers.md
+++ b/docs/storage/file-stream-providers.md
@@ -1,0 +1,122 @@
+# File Stream Providers
+
+ZoneTree stores its physical files through `IFileStreamProvider`.
+
+The default provider is `LocalFileStreamProvider`, which stores WAL files, metadata files, and disk segment files on the local file system. Applications can provide a different implementation when opening a factory.
+
+```csharp
+using ZoneTree;
+using ZoneTree.AbstractFileStream;
+using ZoneTree.Options;
+
+var fileStreamProvider = new InMemoryFileStreamProvider();
+
+using var zoneTree = new ZoneTreeFactory<int, string>(fileStreamProvider)
+    .SetDataDirectory("data/session")
+    .ConfigureWriteAheadLogOptions(options =>
+    {
+        options.WriteAheadLogMode = WriteAheadLogMode.None;
+    })
+    .OpenOrCreate();
+```
+
+## What It Controls
+
+The file stream provider is the low-level file abstraction used by the default ZoneTree storage path.
+
+It is used by:
+
+* write-ahead logs,
+* metadata files,
+* random-access disk segment files,
+* temporary replacement files created during durable writes and WAL compaction.
+
+If you pass a provider to `ZoneTreeFactory<TKey, TValue>`, the default `WriteAheadLogProvider` and `RandomAccessDeviceManager` use that provider. Advanced applications can still replace those higher-level providers with `SetWriteAheadLogProvider` or `SetRandomAccessDeviceManager`.
+
+## Local File Provider
+
+`LocalFileStreamProvider` is the default. Use it for persistent databases, crash recovery, live backup, and normal production storage.
+
+It delegates to the local file system and is the right choice when data must survive process exit or machine restart.
+
+```csharp
+using var zoneTree = new ZoneTreeFactory<int, string>()
+    .SetDataDirectory("data/app")
+    .OpenOrCreate();
+```
+
+## In-Memory File Provider
+
+`InMemoryFileStreamProvider` runs ZoneTree's normal stream-based WAL, metadata, segment, and merge flow entirely in process memory.
+
+It is useful when you want ZoneTree's ordered storage engine behavior but do not need persistence.
+
+Good use cases:
+
+* fast tests that should not touch the local file system,
+* high-RAM machines running durability-optional workloads,
+* temporary indexing, sorting, staging, or deduplication,
+* data transfer and transformation pipelines where source data can be replayed,
+* cache-like or rebuildable datasets.
+
+It is not a durable provider. All data is lost when the provider instance is lost, the process exits, or the machine stops.
+
+```csharp
+using ZoneTree;
+using ZoneTree.AbstractFileStream;
+using ZoneTree.Options;
+
+var provider = new InMemoryFileStreamProvider();
+
+using var zoneTree = new ZoneTreeFactory<long, string>(provider)
+    .SetDataDirectory("transfer-job")
+    .ConfigureWriteAheadLogOptions(options =>
+    {
+        options.WriteAheadLogMode = WriteAheadLogMode.None;
+    })
+    .OpenOrCreate();
+```
+
+The provider stores large files in chunks so stream-based WAL and disk segment operations are not limited by the maximum size of a single `byte[]`. Small files use small chunks to avoid large allocations. `ReadAllBytes` remains a small-file convenience API and can throw when a file is too large to fit in one array.
+
+## WAL Choice
+
+For normal in-memory-provider workloads, prefer `WriteAheadLogMode.None`.
+
+With `InMemoryFileStreamProvider`, WAL files are also stored in process memory. They do not protect against process termination, machine restart, power loss, or losing the provider instance. In that setup, WAL usually adds memory use and serialization work without adding durability.
+
+Using a WAL with `InMemoryFileStreamProvider` is still useful for tests that specifically exercise WAL behavior, replay logic, WAL compaction, or recovery code while the provider instance is alive.
+
+Use a durable provider, such as `LocalFileStreamProvider`, when WAL durability matters.
+
+## Semantics
+
+`InMemoryFileStreamProvider` is optimized for ZoneTree's own stream usage, not for exact file-system emulation.
+
+Important behavior:
+
+* writes, truncates, and replacements are visible immediately,
+* `Replace` uses fast in-memory object handoff rather than copying large buffers,
+* `FileShare` is intentionally ignored,
+* open streams can keep referencing an old in-memory file object after delete or replace,
+* per-stream `Position` is not thread-safe,
+* data is scoped to the provider instance,
+* WAL files written through this provider are not durable.
+
+Use `InMemoryFileStreamProvider` only when those boundaries are acceptable.
+
+## Custom Providers
+
+Custom `IFileStreamProvider` implementations can redirect ZoneTree files into another storage environment.
+
+When implementing a provider, focus first on the operations ZoneTree uses heavily:
+
+* sequential WAL append and read,
+* random-access segment reads,
+* `SetLength`,
+* `Flush(bool)`,
+* `Replace`,
+* directory creation and recursive deletion,
+* small metadata reads through `ReadAllBytes` and `ReadAllText`.
+
+The default storage pipeline assumes stream operations are reliable and that replacement is atomic or at least consistent enough for the provider's durability model. If the provider is not durable, document that clearly and use it only for rebuildable workloads.

--- a/docs/storage/file-stream-providers.md
+++ b/docs/storage/file-stream-providers.md
@@ -1,65 +1,76 @@
 # File Stream Providers
 
-ZoneTree stores its physical files through `IFileStreamProvider`.
+ZoneTree writes physical storage through `IFileStreamProvider`.
 
-The default provider is `LocalFileStreamProvider`, which stores WAL files, metadata files, and disk segment files on the local file system. Applications can provide a different implementation when opening a factory.
+This abstraction lets the default ZoneTree storage pipeline open, read, write, replace, and delete files without being tied to one backing store.
+
+The default is `LocalFileStreamProvider`. It stores data on the local file system and is the right choice for normal persistent databases.
+
+## Where It Is Used
+
+The file stream provider is used by the default implementations for:
+
+* write-ahead log files,
+* metadata files,
+* disk segment files,
+* temporary files used during replacement and compaction.
+
+When you create a factory without passing a provider, ZoneTree uses `LocalFileStreamProvider`.
 
 ```csharp
 using ZoneTree;
-using ZoneTree.AbstractFileStream;
-using ZoneTree.Options;
 
-var fileStreamProvider = new InMemoryFileStreamProvider();
-
-using var zoneTree = new ZoneTreeFactory<int, string>(fileStreamProvider)
-    .SetDataDirectory("data/session")
-    .ConfigureWriteAheadLogOptions(options =>
-    {
-        options.WriteAheadLogMode = WriteAheadLogMode.None;
-    })
-    .OpenOrCreate();
-```
-
-## What It Controls
-
-The file stream provider is the low-level file abstraction used by the default ZoneTree storage path.
-
-It is used by:
-
-* write-ahead logs,
-* metadata files,
-* random-access disk segment files,
-* temporary replacement files created during durable writes and WAL compaction.
-
-If you pass a provider to `ZoneTreeFactory<TKey, TValue>`, the default `WriteAheadLogProvider` and `RandomAccessDeviceManager` use that provider. Advanced applications can still replace those higher-level providers with `SetWriteAheadLogProvider` or `SetRandomAccessDeviceManager`.
-
-## Local File Provider
-
-`LocalFileStreamProvider` is the default. Use it for persistent databases, crash recovery, live backup, and normal production storage.
-
-It delegates to the local file system and is the right choice when data must survive process exit or machine restart.
-
-```csharp
 using var zoneTree = new ZoneTreeFactory<int, string>()
     .SetDataDirectory("data/app")
     .OpenOrCreate();
 ```
 
+To use another provider, pass it to the factory constructor.
+
+```csharp
+using ZoneTree;
+using ZoneTree.AbstractFileStream;
+
+IFileStreamProvider fileStreamProvider = new LocalFileStreamProvider();
+
+using var zoneTree = new ZoneTreeFactory<int, string>(fileStreamProvider)
+    .SetDataDirectory("data/app")
+    .OpenOrCreate();
+```
+
+The factory uses that provider when it creates the default `WriteAheadLogProvider` and `RandomAccessDeviceManager`.
+
+Advanced applications can replace those higher-level components directly with `SetWriteAheadLogProvider` or `SetRandomAccessDeviceManager`.
+
+## Local File Provider
+
+`LocalFileStreamProvider` is the default provider.
+
+Use it for:
+
+* persistent databases,
+* crash recovery,
+* write-ahead log durability,
+* normal production storage,
+* live backup and restore.
+
+It delegates to the local file system, so data can survive process exit, machine restart, and application redeploys as long as the underlying storage is available.
+
 ## In-Memory File Provider
 
-`InMemoryFileStreamProvider` runs ZoneTree's normal stream-based WAL, metadata, segment, and merge flow entirely in process memory.
+`InMemoryFileStreamProvider` stores ZoneTree's physical files in process memory.
 
-It is useful when you want ZoneTree's ordered storage engine behavior but do not need persistence.
+It still runs ZoneTree's normal stream-based storage flow: metadata, WAL files, disk segment files, temporary files, and merge output are represented as files, but those files live inside the provider instance instead of on disk.
+
+Use it when you want ZoneTree's ordered storage engine behavior and do not need durability.
 
 Good use cases:
 
 * fast tests that should not touch the local file system,
-* high-RAM machines running durability-optional workloads,
+* high-RAM machines running durability-optional jobs,
 * temporary indexing, sorting, staging, or deduplication,
 * data transfer and transformation pipelines where source data can be replayed,
 * cache-like or rebuildable datasets.
-
-It is not a durable provider. All data is lost when the provider instance is lost, the process exits, or the machine stops.
 
 ```csharp
 using ZoneTree;
@@ -77,39 +88,77 @@ using var zoneTree = new ZoneTreeFactory<long, string>(provider)
     .OpenOrCreate();
 ```
 
-The provider stores large files in chunks so stream-based WAL and disk segment operations are not limited by the maximum size of a single `byte[]`. Small files use small chunks to avoid large allocations. `ReadAllBytes` remains a small-file convenience API and can throw when a file is too large to fit in one array.
-
-## WAL Choice
-
 For normal in-memory-provider workloads, prefer `WriteAheadLogMode.None`.
 
-With `InMemoryFileStreamProvider`, WAL files are also stored in process memory. They do not protect against process termination, machine restart, power loss, or losing the provider instance. In that setup, WAL usually adds memory use and serialization work without adding durability.
-
-Using a WAL with `InMemoryFileStreamProvider` is still useful for tests that specifically exercise WAL behavior, replay logic, WAL compaction, or recovery code while the provider instance is alive.
+With `InMemoryFileStreamProvider`, WAL files are also stored in process memory. They do not protect against process termination, machine restart, power loss, or losing the provider instance. Keeping WAL enabled can still be useful in tests that specifically exercise WAL behavior, replay logic, compaction, or recovery code while the provider instance is alive.
 
 Use a durable provider, such as `LocalFileStreamProvider`, when WAL durability matters.
 
-## Semantics
+## In-Memory Semantics
 
-`InMemoryFileStreamProvider` is optimized for ZoneTree's own stream usage, not for exact file-system emulation.
+`InMemoryFileStreamProvider` is optimized for ZoneTree's own stream usage, not exact file-system emulation.
 
 Important behavior:
 
+* data is scoped to the provider instance,
+* all data is lost when that instance is lost,
 * writes, truncates, and replacements are visible immediately,
+* large files use chunked backing storage,
+* small files avoid large chunk allocation,
+* `ReadAllBytes` is a small-file convenience API and may throw for very large files,
 * `Replace` uses fast in-memory object handoff rather than copying large buffers,
 * `FileShare` is intentionally ignored,
 * open streams can keep referencing an old in-memory file object after delete or replace,
-* per-stream `Position` is not thread-safe,
-* data is scoped to the provider instance,
-* WAL files written through this provider are not durable.
+* per-stream `Position` is not thread-safe.
 
-Use `InMemoryFileStreamProvider` only when those boundaries are acceptable.
+Use this provider only when those boundaries are acceptable.
 
 ## Custom Providers
 
-Custom `IFileStreamProvider` implementations can redirect ZoneTree files into another storage environment.
+Implement `IFileStreamProvider` when ZoneTree files need to live somewhere other than the local file system or the built-in in-memory provider.
 
-When implementing a provider, focus first on the operations ZoneTree uses heavily:
+Examples include:
+
+* encrypted local storage,
+* test harnesses with fault injection,
+* remote object stores with local buffering,
+* custom storage services,
+* embedded environments with their own file abstraction.
+
+A custom provider must return `IFileStream` instances and implement file operations such as existence checks, directory creation, deletion, replacement, and small metadata reads.
+
+```csharp
+using ZoneTree.AbstractFileStream;
+
+public sealed class MyFileStreamProvider : IFileStreamProvider
+{
+    public IFileStream CreateFileStream(
+        string path,
+        FileMode mode,
+        FileAccess access,
+        FileShare share,
+        int bufferSize = 4096,
+        FileOptions options = FileOptions.None)
+    {
+        // Return an IFileStream backed by your storage layer.
+        throw new NotImplementedException();
+    }
+
+    // Implement the remaining IFileStreamProvider members.
+}
+```
+
+Then pass the provider to the factory:
+
+```csharp
+var provider = new MyFileStreamProvider();
+
+using var zoneTree = new ZoneTreeFactory<int, string>(provider)
+    .SetDataDirectory("tenant-a")
+    .OpenOrCreate();
+```
+
+Focus first on the operations ZoneTree uses heavily:
 
 * sequential WAL append and read,
 * random-access segment reads,
@@ -119,4 +168,4 @@ When implementing a provider, focus first on the operations ZoneTree uses heavil
 * directory creation and recursive deletion,
 * small metadata reads through `ReadAllBytes` and `ReadAllText`.
 
-The default storage pipeline assumes stream operations are reliable and that replacement is atomic or at least consistent enough for the provider's durability model. If the provider is not durable, document that clearly and use it only for rebuildable workloads.
+The provider's durability model should be clear. If replacement or flush is not durable, document that and use the provider only for rebuildable workloads.

--- a/src/Playground/Program.cs
+++ b/src/Playground/Program.cs
@@ -52,8 +52,8 @@ if (testCase == 3)
         (CompressionMethod.None, 0),
   };
 
-  test2.Count = test1.Count = 5_000_000;
-  test2.WALMode = test1.WALMode = WriteAheadLogMode.None;
+  test2.Count = test1.Count = 10_000_000;
+  test2.WALMode = test1.WALMode = WriteAheadLogMode.AsyncCompressed;
 
   b.NewSection("int-int insert");
   foreach (var (method, level) in methods)

--- a/src/ZoneTree.UnitTests/InMemoryFileStreamProviderTests.cs
+++ b/src/ZoneTree.UnitTests/InMemoryFileStreamProviderTests.cs
@@ -77,6 +77,23 @@ public sealed class InMemoryFileStreamProviderTests
   }
 
   [Test]
+  public void SetLengthClearsBytesWhenReExtending()
+  {
+    var provider = new InMemoryFileStreamProvider();
+    using var stream = provider.CreateFileStream(
+        "test.bin",
+        FileMode.Create,
+        FileAccess.ReadWrite,
+        FileShare.None);
+    stream.Write(new byte[] { 1, 2, 3, 4 });
+
+    stream.SetLength(2);
+    stream.SetLength(4);
+
+    Assert.That(provider.ReadAllBytes("test.bin"), Is.EqualTo(new byte[] { 1, 2, 0, 0 }));
+  }
+
+  [Test]
   public void SparseWriteFillsGapWithZeroBytes()
   {
     var provider = new InMemoryFileStreamProvider();
@@ -90,6 +107,108 @@ public sealed class InMemoryFileStreamProviderTests
     stream.WriteByte(9);
 
     Assert.That(provider.ReadAllBytes("test.bin"), Is.EqualTo(new byte[] { 0, 0, 0, 9 }));
+  }
+
+  [Test]
+  public void SparseWriteAfterTruncateClearsGapWithZeroBytes()
+  {
+    var provider = new InMemoryFileStreamProvider();
+    using var stream = provider.CreateFileStream(
+        "test.bin",
+        FileMode.Create,
+        FileAccess.ReadWrite,
+        FileShare.None);
+    stream.Write(new byte[] { 1, 2, 3, 4 });
+    stream.SetLength(1);
+
+    stream.Position = 3;
+    stream.WriteByte(9);
+
+    Assert.That(provider.ReadAllBytes("test.bin"), Is.EqualTo(new byte[] { 1, 0, 0, 9 }));
+  }
+
+  [Test]
+  public void ReadAndWriteCanCrossSmallChunkBoundaryBeforePromotion()
+  {
+    const int smallChunkSize = 4 * 1024;
+    var provider = new InMemoryFileStreamProvider();
+    using var stream = provider.CreateFileStream(
+        "test.bin",
+        FileMode.Create,
+        FileAccess.ReadWrite,
+        FileShare.None);
+    var expected = new byte[] { 1, 2, 3, 4 };
+
+    stream.Position = smallChunkSize - 2;
+    stream.Write(expected);
+    stream.Position = smallChunkSize - 2;
+    var actual = new byte[expected.Length];
+    stream.ReadFaster(actual, 0, actual.Length);
+
+    Assert.That(stream.Length, Is.EqualTo(smallChunkSize + 2));
+    Assert.That(actual, Is.EqualTo(expected));
+  }
+
+  [Test]
+  public void ReadAndWriteCanCrossLargeChunkBoundaryAfterPromotion()
+  {
+    const int chunkSize = 8 * 1024 * 1024;
+    var provider = new InMemoryFileStreamProvider();
+    using var stream = provider.CreateFileStream(
+        "test.bin",
+        FileMode.Create,
+        FileAccess.ReadWrite,
+        FileShare.None);
+    var expected = new byte[] { 1, 2, 3, 4 };
+
+    stream.Position = chunkSize - 2;
+    stream.Write(expected);
+    stream.Position = chunkSize - 2;
+    var actual = new byte[expected.Length];
+    stream.ReadFaster(actual, 0, actual.Length);
+
+    Assert.That(stream.Length, Is.EqualTo(chunkSize + 2));
+    Assert.That(actual, Is.EqualTo(expected));
+  }
+
+  [Test]
+  public void PromotionKeepsExistingSmallChunkContent()
+  {
+    const int largeChunkThreshold = 1024 * 1024;
+    var provider = new InMemoryFileStreamProvider();
+    using var stream = provider.CreateFileStream(
+        "test.bin",
+        FileMode.Create,
+        FileAccess.ReadWrite,
+        FileShare.None);
+    stream.Write(new byte[] { 1, 2, 3 });
+
+    stream.Position = largeChunkThreshold + 1;
+    stream.WriteByte(4);
+
+    Assert.That(stream.Length, Is.EqualTo(largeChunkThreshold + 2));
+    Assert.That(provider.ReadAllBytes("test.bin")[..3], Is.EqualTo(new byte[] { 1, 2, 3 }));
+    stream.Position = largeChunkThreshold + 1;
+    Assert.That(stream.ReadByte(), Is.EqualTo(4));
+  }
+
+  [Test]
+  public void SetLengthZeroAfterPromotionResetsToSmallFileBehavior()
+  {
+    const int largeChunkThreshold = 1024 * 1024;
+    var provider = new InMemoryFileStreamProvider();
+    using var stream = provider.CreateFileStream(
+        "test.bin",
+        FileMode.Create,
+        FileAccess.ReadWrite,
+        FileShare.None);
+    stream.Position = largeChunkThreshold + 1;
+    stream.WriteByte(7);
+
+    stream.SetLength(0);
+    stream.Write(new byte[] { 1, 2, 3 });
+
+    Assert.That(provider.ReadAllBytes("test.bin"), Is.EqualTo(new byte[] { 1, 2, 3 }));
   }
 
   [Test]

--- a/src/ZoneTree.UnitTests/InMemoryFileStreamProviderTests.cs
+++ b/src/ZoneTree.UnitTests/InMemoryFileStreamProviderTests.cs
@@ -8,6 +8,307 @@ namespace ZoneTree.UnitTests;
 public sealed class InMemoryFileStreamProviderTests
 {
   [Test]
+  public void WritesAreVisibleBeforeStreamIsDisposed()
+  {
+    var provider = new InMemoryFileStreamProvider();
+    var stream = provider.CreateFileStream(
+        "test.bin",
+        FileMode.OpenOrCreate,
+        FileAccess.ReadWrite,
+        FileShare.None);
+    var bytes = new byte[] { 1, 2, 3 };
+
+    stream.Write(bytes, 0, bytes.Length);
+    stream.Flush(true);
+
+    Assert.That(provider.ReadAllBytes("test.bin"), Is.EqualTo(bytes));
+    stream.Dispose();
+  }
+
+  [Test]
+  public void DisposingDeletedStreamDoesNotRestoreFile()
+  {
+    var provider = new InMemoryFileStreamProvider();
+    var stream = provider.CreateFileStream(
+        "test.bin",
+        FileMode.Create,
+        FileAccess.ReadWrite,
+        FileShare.None);
+    stream.WriteByte(1);
+
+    provider.DeleteFile("test.bin");
+    stream.Dispose();
+
+    Assert.That(provider.FileExists("test.bin"), Is.False);
+  }
+
+  [Test]
+  public void SetLengthImmediatelyChangesProviderContent()
+  {
+    var provider = new InMemoryFileStreamProvider();
+    using var stream = provider.CreateFileStream(
+        "test.bin",
+        FileMode.Create,
+        FileAccess.ReadWrite,
+        FileShare.None);
+    var bytes = new byte[] { 1, 2, 3, 4 };
+    stream.Write(bytes, 0, bytes.Length);
+
+    stream.SetLength(2);
+
+    Assert.That(provider.ReadAllBytes("test.bin"), Is.EqualTo(new byte[] { 1, 2 }));
+  }
+
+  [Test]
+  public void SetLengthExtendsWithZeroBytes()
+  {
+    var provider = new InMemoryFileStreamProvider();
+    using var stream = provider.CreateFileStream(
+        "test.bin",
+        FileMode.Create,
+        FileAccess.ReadWrite,
+        FileShare.None);
+    stream.WriteByte(7);
+
+    stream.SetLength(4);
+
+    Assert.That(provider.ReadAllBytes("test.bin"), Is.EqualTo(new byte[] { 7, 0, 0, 0 }));
+    Assert.That(stream.Length, Is.EqualTo(4));
+  }
+
+  [Test]
+  public void SparseWriteFillsGapWithZeroBytes()
+  {
+    var provider = new InMemoryFileStreamProvider();
+    using var stream = provider.CreateFileStream(
+        "test.bin",
+        FileMode.Create,
+        FileAccess.ReadWrite,
+        FileShare.None);
+
+    stream.Position = 3;
+    stream.WriteByte(9);
+
+    Assert.That(provider.ReadAllBytes("test.bin"), Is.EqualTo(new byte[] { 0, 0, 0, 9 }));
+  }
+
+  [Test]
+  public void AppendAlwaysWritesAtEnd()
+  {
+    var provider = new InMemoryFileStreamProvider();
+    WriteFile(provider, "test.bin", new byte[] { 1, 2 });
+    using var stream = provider.CreateFileStream(
+        "test.bin",
+        FileMode.Append,
+        FileAccess.Write,
+        FileShare.None);
+
+    stream.Position = 0;
+    stream.WriteByte(3);
+
+    Assert.That(provider.ReadAllBytes("test.bin"), Is.EqualTo(new byte[] { 1, 2, 3 }));
+  }
+
+  [Test]
+  public void ReadFasterReadsExactLengthOrThrows()
+  {
+    var provider = new InMemoryFileStreamProvider();
+    WriteFile(provider, "test.bin", new byte[] { 1, 2, 3 });
+    using var stream = provider.CreateFileStream(
+        "test.bin",
+        FileMode.Open,
+        FileAccess.Read,
+        FileShare.None);
+    var buffer = new byte[4];
+
+    Assert.That(stream.ReadFaster(buffer, 0, 3), Is.EqualTo(3));
+    Assert.That(buffer.Take(3).ToArray(), Is.EqualTo(new byte[] { 1, 2, 3 }));
+    Assert.Throws<EndOfStreamException>(() => stream.ReadFaster(buffer, 0, 1));
+  }
+
+  [Test]
+  public async Task AsyncReadAndWriteUseSharedProviderMemory()
+  {
+    var provider = new InMemoryFileStreamProvider();
+    await using (var stream = provider.CreateFileStream(
+        "test.bin",
+        FileMode.Create,
+        FileAccess.ReadWrite,
+        FileShare.None))
+    {
+      await stream.WriteAsync(new byte[] { 1, 2 }, 0, 2);
+      await stream.WriteAsync(new byte[] { 3 });
+    }
+
+    await using var readStream = provider.CreateFileStream(
+        "test.bin",
+        FileMode.Open,
+        FileAccess.Read,
+        FileShare.None);
+    var buffer = new byte[3];
+
+    Assert.That(await readStream.ReadAsync(buffer, 0, buffer.Length), Is.EqualTo(3));
+    Assert.That(buffer, Is.EqualTo(new byte[] { 1, 2, 3 }));
+  }
+
+  [Test]
+  public void ReplaceMovesSourceToDestinationAndBacksUpOldDestination()
+  {
+    var provider = new InMemoryFileStreamProvider();
+    WriteFile(provider, "target.bin", new byte[] { 1, 2 });
+    WriteFile(provider, "tmp.bin", new byte[] { 3, 4 });
+
+    provider.Replace("tmp.bin", "target.bin", "backup.bin");
+
+    Assert.That(provider.FileExists("tmp.bin"), Is.False);
+    Assert.That(provider.ReadAllBytes("target.bin"), Is.EqualTo(new byte[] { 3, 4 }));
+    Assert.That(provider.ReadAllBytes("backup.bin"), Is.EqualTo(new byte[] { 1, 2 }));
+  }
+
+  [Test]
+  public void ReplaceBackupKeepsPreviousDestination()
+  {
+    var provider = new InMemoryFileStreamProvider();
+    WriteFile(provider, "target.bin", new byte[] { 1 });
+    WriteFile(provider, "tmp.bin", new byte[] { 2 });
+
+    provider.Replace("tmp.bin", "target.bin", "backup.bin");
+
+    Assert.That(provider.ReadAllBytes("backup.bin"), Is.EqualTo(new byte[] { 1 }));
+    Assert.That(provider.ReadAllBytes("target.bin"), Is.EqualTo(new byte[] { 2 }));
+  }
+
+  [Test]
+  public void ReplaceRequiresSourceFile()
+  {
+    var provider = new InMemoryFileStreamProvider();
+
+    Assert.Throws<FileNotFoundException>(() => provider.Replace(
+        "missing.bin",
+        "target.bin",
+        null));
+  }
+
+  [Test]
+  public void CreateNewFailsWhenFileAlreadyExists()
+  {
+    var provider = new InMemoryFileStreamProvider();
+    WriteFile(provider, "test.bin", new byte[] { 1 });
+
+    Assert.Throws<IOException>(() => provider.CreateFileStream(
+        "test.bin",
+        FileMode.CreateNew,
+        FileAccess.Write,
+        FileShare.None));
+  }
+
+  [Test]
+  public void TruncateRequiresExistingFileAndClearsImmediately()
+  {
+    var provider = new InMemoryFileStreamProvider();
+    WriteFile(provider, "test.bin", new byte[] { 1, 2 });
+
+    using var stream = provider.CreateFileStream(
+        "test.bin",
+        FileMode.Truncate,
+        FileAccess.Write,
+        FileShare.None);
+
+    Assert.That(stream.Length, Is.EqualTo(0));
+    Assert.That(provider.ReadAllBytes("test.bin"), Is.Empty);
+    Assert.Throws<FileNotFoundException>(() => provider.CreateFileStream(
+        "missing.bin",
+        FileMode.Truncate,
+        FileAccess.Write,
+        FileShare.None));
+  }
+
+  [Test]
+  public void ReadOnlyAndWriteOnlyAccessAreEnforced()
+  {
+    var provider = new InMemoryFileStreamProvider();
+    WriteFile(provider, "test.bin", new byte[] { 1 });
+
+    using var readOnly = provider.CreateFileStream(
+        "test.bin",
+        FileMode.Open,
+        FileAccess.Read,
+        FileShare.None);
+    using var writeOnly = provider.CreateFileStream(
+        "test.bin",
+        FileMode.Open,
+        FileAccess.Write,
+        FileShare.None);
+
+    Assert.Throws<NotSupportedException>(() => readOnly.WriteByte(2));
+    Assert.Throws<NotSupportedException>(() => writeOnly.ReadByte());
+  }
+
+  [Test]
+  public void DisposedStreamRejectsOperations()
+  {
+    var provider = new InMemoryFileStreamProvider();
+    var stream = provider.CreateFileStream(
+        "test.bin",
+        FileMode.Create,
+        FileAccess.ReadWrite,
+        FileShare.None);
+
+    stream.Dispose();
+
+    Assert.Throws<ObjectDisposedException>(() => _ = stream.Length);
+    Assert.Throws<ObjectDisposedException>(() => stream.WriteByte(1));
+    Assert.That(stream.CanRead, Is.False);
+    Assert.That(stream.CanWrite, Is.False);
+    Assert.That(stream.CanSeek, Is.False);
+  }
+
+  [Test]
+  public void RecursiveDirectoryDeleteUsesPathSegments()
+  {
+    var provider = new InMemoryFileStreamProvider();
+    WriteFile(provider, "data/file.bin", new byte[] { 1 });
+    WriteFile(provider, "database/file.bin", new byte[] { 2 });
+
+    provider.DeleteDirectory("data", true);
+
+    Assert.That(provider.FileExists("data/file.bin"), Is.False);
+    Assert.That(provider.FileExists("database/file.bin"), Is.True);
+  }
+
+  [Test]
+  public void PathsAreNormalizedAcrossSeparators()
+  {
+    var provider = new InMemoryFileStreamProvider();
+    WriteFile(provider, "data\\nested//file.bin", new byte[] { 1 });
+
+    Assert.That(provider.FileExists("data/nested/file.bin"), Is.True);
+    Assert.That(provider.ReadAllBytes("data/nested\\file.bin"), Is.EqualTo(new byte[] { 1 }));
+  }
+
+  [Test]
+  public void NonRecursiveDirectoryDeleteRejectsNonEmptyDirectory()
+  {
+    var provider = new InMemoryFileStreamProvider();
+    WriteFile(provider, "data/file.bin", new byte[] { 1 });
+
+    Assert.Throws<IOException>(() => provider.DeleteDirectory("data", false));
+    Assert.That(provider.FileExists("data/file.bin"), Is.True);
+  }
+
+  [Test]
+  public void GetDirectoriesReturnsImmediateChildrenOnly()
+  {
+    var provider = new InMemoryFileStreamProvider();
+    provider.CreateDirectory("data/a/b");
+    provider.CreateDirectory("data/c");
+
+    Assert.That(
+        provider.GetDirectories("data").Order().ToArray(),
+        Is.EqualTo(new[] { "data/a", "data/c" }));
+  }
+
+  [Test]
   public void WalWithInMemoryProvider()
   {
     var serializer = new UnicodeStringSerializer();
@@ -24,5 +325,18 @@ public sealed class InMemoryFileStreamProviderTests
     Assert.That(result.Keys[0], Is.EqualTo("hello"));
     Assert.That(result.Values[0], Is.EqualTo("world"));
     wal.Drop();
+  }
+
+  static void WriteFile(
+      InMemoryFileStreamProvider provider,
+      string path,
+      byte[] bytes)
+  {
+    using var stream = provider.CreateFileStream(
+        path,
+        FileMode.Create,
+        FileAccess.ReadWrite,
+        FileShare.None);
+    stream.Write(bytes, 0, bytes.Length);
   }
 }

--- a/src/ZoneTree/AbstractFileStream/InMemoryFile.cs
+++ b/src/ZoneTree/AbstractFileStream/InMemoryFile.cs
@@ -2,9 +2,17 @@ namespace ZoneTree.AbstractFileStream;
 
 internal sealed class InMemoryFile
 {
+  internal const int SmallChunkSize = 4 * 1024;
+
+  internal const int LargeChunkSize = 8 * 1024 * 1024;
+
+  internal const int LargeChunkThreshold = 1024 * 1024;
+
   public readonly Lock SyncRoot = new();
 
-  byte[] Buffer = [];
+  readonly List<byte[]> Chunks = [];
+
+  int ChunkSize = SmallChunkSize;
 
   long Length;
 
@@ -23,20 +31,49 @@ internal sealed class InMemoryFile
       if (position >= Length)
         return 0;
       var count = (int)Math.Min(destination.Length, Length - position);
-      Buffer.AsSpan((int)position, count).CopyTo(destination);
+      var remaining = count;
+      var destinationOffset = 0;
+      while (remaining > 0)
+      {
+        var chunkIndex = GetChunkIndex(position);
+        var chunkOffset = GetChunkOffset(position);
+        var copyLength = Math.Min(remaining, ChunkSize - chunkOffset);
+        Chunks[chunkIndex]
+            .AsSpan(chunkOffset, copyLength)
+            .CopyTo(destination.Slice(destinationOffset, copyLength));
+        position += copyLength;
+        destinationOffset += copyLength;
+        remaining -= copyLength;
+      }
       return count;
     }
   }
 
   public void Write(long position, ReadOnlySpan<byte> source)
   {
+    if (source.Length == 0)
+      return;
+
     lock (SyncRoot)
     {
       var end = checked(position + source.Length);
       EnsureCapacity(end);
       if (position > Length)
-        Array.Clear(Buffer, (int)Length, (int)(position - Length));
-      source.CopyTo(Buffer.AsSpan((int)position));
+        ClearRange(Length, position - Length);
+      var remaining = source.Length;
+      var sourceOffset = 0;
+      while (remaining > 0)
+      {
+        var chunkIndex = GetChunkIndex(position);
+        var chunkOffset = GetChunkOffset(position);
+        var copyLength = Math.Min(remaining, ChunkSize - chunkOffset);
+        source
+            .Slice(sourceOffset, copyLength)
+            .CopyTo(Chunks[chunkIndex].AsSpan(chunkOffset, copyLength));
+        position += copyLength;
+        sourceOffset += copyLength;
+        remaining -= copyLength;
+      }
       if (end > Length)
         Length = end;
     }
@@ -49,8 +86,11 @@ internal sealed class InMemoryFile
     {
       EnsureCapacity(value);
       if (value > Length)
-        Array.Clear(Buffer, (int)Length, (int)(value - Length));
+        ClearRange(Length, value - Length);
       Length = value;
+      TrimExtraChunks();
+      if (Length == 0 && ChunkSize != SmallChunkSize)
+        ResetToSmallChunks();
     }
   }
 
@@ -58,32 +98,104 @@ internal sealed class InMemoryFile
   {
     lock (SyncRoot)
     {
+      if (Length > Array.MaxLength)
+        throw new IOException("In-memory file is too large to read into a single byte array.");
       var copy = new byte[(int)Length];
-      Buffer.AsSpan(0, (int)Length).CopyTo(copy);
+      var written = 0;
+      var remaining = copy.Length;
+      for (var i = 0; remaining > 0; ++i)
+      {
+        var copyLength = Math.Min(remaining, ChunkSize);
+        Chunks[i].AsSpan(0, copyLength).CopyTo(copy.AsSpan(written, copyLength));
+        written += copyLength;
+        remaining -= copyLength;
+      }
       return copy;
     }
   }
 
   void EnsureCapacity(long capacity)
   {
-    if (capacity > Array.MaxLength)
-      throw new IOException("In-memory file is too large.");
-
-    if (Buffer.LongLength >= capacity)
+    if (capacity == 0)
       return;
 
-    var newCapacity = Buffer.Length == 0 ? 256 : Buffer.Length;
-    while (newCapacity < capacity)
+    if (ChunkSize == SmallChunkSize && capacity > LargeChunkThreshold)
+      PromoteToLargeChunks();
+
+    var requiredChunks = GetRequiredChunkCount(capacity);
+    while (Chunks.Count < requiredChunks)
     {
-      var nextCapacity = newCapacity * 2L;
-      newCapacity = (int)Math.Min(nextCapacity, Array.MaxLength);
-      if (newCapacity == Array.MaxLength)
-        break;
+      Chunks.Add(new byte[ChunkSize]);
     }
-
-    if (newCapacity < capacity)
-      throw new IOException("In-memory file is too large.");
-
-    Array.Resize(ref Buffer, newCapacity);
   }
+
+  void ClearRange(long position, long length)
+  {
+    while (length > 0)
+    {
+      var chunkIndex = GetChunkIndex(position);
+      var chunkOffset = GetChunkOffset(position);
+      var clearLength = (int)Math.Min(length, ChunkSize - chunkOffset);
+      Array.Clear(Chunks[chunkIndex], chunkOffset, clearLength);
+      position += clearLength;
+      length -= clearLength;
+    }
+  }
+
+  void TrimExtraChunks()
+  {
+    var requiredChunks = GetRequiredChunkCount(Length);
+    if (Chunks.Count > requiredChunks)
+      Chunks.RemoveRange(requiredChunks, Chunks.Count - requiredChunks);
+  }
+
+  void PromoteToLargeChunks()
+  {
+    var oldChunks = Chunks.ToArray();
+    var oldChunkSize = ChunkSize;
+    Chunks.Clear();
+    ChunkSize = LargeChunkSize;
+    EnsureCapacity(Length);
+
+    var position = 0L;
+    foreach (var oldChunk in oldChunks)
+    {
+      var remaining = (int)Math.Min(oldChunkSize, Length - position);
+      if (remaining <= 0)
+        break;
+      var oldChunkOffset = 0;
+      while (remaining > 0)
+      {
+        var newChunkIndex = GetChunkIndex(position);
+        var newChunkOffset = GetChunkOffset(position);
+        var copyLength = Math.Min(remaining, ChunkSize - newChunkOffset);
+        oldChunk
+            .AsSpan(oldChunkOffset, copyLength)
+            .CopyTo(Chunks[newChunkIndex].AsSpan(newChunkOffset, copyLength));
+        oldChunkOffset += copyLength;
+        position += copyLength;
+        remaining -= copyLength;
+      }
+    }
+  }
+
+  void ResetToSmallChunks()
+  {
+    Chunks.Clear();
+    ChunkSize = SmallChunkSize;
+  }
+
+  int GetRequiredChunkCount(long capacity)
+  {
+    if (capacity == 0)
+      return 0;
+    var requiredChunks = checked((capacity + ChunkSize - 1) / ChunkSize);
+    if (requiredChunks > int.MaxValue)
+      throw new IOException("In-memory file is too large.");
+    return (int)requiredChunks;
+  }
+
+  int GetChunkIndex(long position) => (int)(position / ChunkSize);
+
+  int GetChunkOffset(long position) => (int)(position % ChunkSize);
 }

--- a/src/ZoneTree/AbstractFileStream/InMemoryFile.cs
+++ b/src/ZoneTree/AbstractFileStream/InMemoryFile.cs
@@ -1,0 +1,89 @@
+namespace ZoneTree.AbstractFileStream;
+
+internal sealed class InMemoryFile
+{
+  public readonly Lock SyncRoot = new();
+
+  byte[] Buffer = [];
+
+  long Length;
+
+  public long GetLength()
+  {
+    lock (SyncRoot)
+    {
+      return Length;
+    }
+  }
+
+  public int Read(long position, Span<byte> destination)
+  {
+    lock (SyncRoot)
+    {
+      if (position >= Length)
+        return 0;
+      var count = (int)Math.Min(destination.Length, Length - position);
+      Buffer.AsSpan((int)position, count).CopyTo(destination);
+      return count;
+    }
+  }
+
+  public void Write(long position, ReadOnlySpan<byte> source)
+  {
+    lock (SyncRoot)
+    {
+      var end = checked(position + source.Length);
+      EnsureCapacity(end);
+      if (position > Length)
+        Array.Clear(Buffer, (int)Length, (int)(position - Length));
+      source.CopyTo(Buffer.AsSpan((int)position));
+      if (end > Length)
+        Length = end;
+    }
+  }
+
+  public void SetLength(long value)
+  {
+    ArgumentOutOfRangeException.ThrowIfNegative(value);
+    lock (SyncRoot)
+    {
+      EnsureCapacity(value);
+      if (value > Length)
+        Array.Clear(Buffer, (int)Length, (int)(value - Length));
+      Length = value;
+    }
+  }
+
+  public byte[] ToArray()
+  {
+    lock (SyncRoot)
+    {
+      var copy = new byte[(int)Length];
+      Buffer.AsSpan(0, (int)Length).CopyTo(copy);
+      return copy;
+    }
+  }
+
+  void EnsureCapacity(long capacity)
+  {
+    if (capacity > Array.MaxLength)
+      throw new IOException("In-memory file is too large.");
+
+    if (Buffer.LongLength >= capacity)
+      return;
+
+    var newCapacity = Buffer.Length == 0 ? 256 : Buffer.Length;
+    while (newCapacity < capacity)
+    {
+      var nextCapacity = newCapacity * 2L;
+      newCapacity = (int)Math.Min(nextCapacity, Array.MaxLength);
+      if (newCapacity == Array.MaxLength)
+        break;
+    }
+
+    if (newCapacity < capacity)
+      throw new IOException("In-memory file is too large.");
+
+    Array.Resize(ref Buffer, newCapacity);
+  }
+}

--- a/src/ZoneTree/AbstractFileStream/InMemoryFileStream.cs
+++ b/src/ZoneTree/AbstractFileStream/InMemoryFileStream.cs
@@ -1,37 +1,90 @@
-using System;
-using System.IO;
-
 namespace ZoneTree.AbstractFileStream;
 
-public sealed class InMemoryFileStream : MemoryStream, IFileStream
+public sealed class InMemoryFileStream : Stream, IFileStream
 {
-  readonly InMemoryFileStreamProvider Provider;
+  readonly InMemoryFile File;
+
+  readonly FileAccess Access;
+
+  readonly bool AppendMode;
+
+  long _position;
+
+  bool IsDisposed;
 
   public string FilePath { get; }
 
-  public InMemoryFileStream(
-      InMemoryFileStreamProvider provider,
+  internal InMemoryFileStream(
       string path,
-      byte[] buffer)
+      InMemoryFile file,
+      FileAccess access,
+      bool appendMode)
   {
-    Provider = provider;
     FilePath = path;
-    if (buffer.Length > 0)
-      Write(buffer, 0, buffer.Length);
-    Position = 0;
+    File = file;
+    Access = access;
+    AppendMode = appendMode;
   }
 
-  public void Flush(bool flushToDisk)
+  public override bool CanRead => !IsDisposed && (Access & FileAccess.Read) != 0;
+
+  public override bool CanSeek => !IsDisposed;
+
+  public override bool CanWrite => !IsDisposed && (Access & FileAccess.Write) != 0;
+
+  public override long Length
   {
-    Flush();
+    get
+    {
+      ThrowIfDisposed();
+      return File.GetLength();
+    }
+  }
+
+  public override long Position
+  {
+    get
+    {
+      ThrowIfDisposed();
+      return _position;
+    }
+    set
+    {
+      ThrowIfDisposed();
+      ArgumentOutOfRangeException.ThrowIfNegative(value);
+      _position = value;
+    }
+  }
+
+  public override void Flush()
+  {
+    ThrowIfDisposed();
+  }
+
+  public void Flush(bool flushToDisk) => Flush();
+
+  public override int Read(byte[] buffer, int offset, int count)
+  {
+    ValidateArrayArguments(buffer, offset, count);
+    return Read(buffer.AsSpan(offset, count));
+  }
+
+  public override int Read(Span<byte> buffer)
+  {
+    ThrowIfDisposed();
+    ThrowIfCannotRead();
+    var read = File.Read(_position, buffer);
+    _position += read;
+    return read;
   }
 
   public int ReadFaster(byte[] buffer, int offset, int count)
   {
-    int totalRead = 0;
+    ValidateArrayArguments(buffer, offset, count);
+    var totalRead = 0;
     while (totalRead < count)
     {
-      int read = Read(buffer, offset + totalRead, count - totalRead);
+      var read = Read(buffer, offset + totalRead, count - totalRead);
       if (read == 0)
         throw new EndOfStreamException();
       totalRead += read;
@@ -39,14 +92,129 @@ public sealed class InMemoryFileStream : MemoryStream, IFileStream
     return totalRead;
   }
 
+  public override ValueTask<int> ReadAsync(
+      Memory<byte> buffer,
+      CancellationToken cancellationToken = default)
+  {
+    cancellationToken.ThrowIfCancellationRequested();
+    return ValueTask.FromResult(Read(buffer.Span));
+  }
+
+  public override Task<int> ReadAsync(
+      byte[] buffer,
+      int offset,
+      int count,
+      CancellationToken cancellationToken)
+  {
+    cancellationToken.ThrowIfCancellationRequested();
+    return Task.FromResult(Read(buffer, offset, count));
+  }
+
+  public override int ReadByte()
+  {
+    Span<byte> buffer = stackalloc byte[1];
+    return Read(buffer) == 0 ? -1 : buffer[0];
+  }
+
+  public override long Seek(long offset, SeekOrigin origin)
+  {
+    ThrowIfDisposed();
+    var position = origin switch
+    {
+      SeekOrigin.Begin => offset,
+      SeekOrigin.Current => _position + offset,
+      SeekOrigin.End => Length + offset,
+      _ => throw new ArgumentOutOfRangeException(nameof(origin), origin, null)
+    };
+    if (position < 0)
+      throw new IOException("An attempt was made to move the position before the beginning of the stream.");
+    _position = position;
+    return _position;
+  }
+
+  public override void SetLength(long value)
+  {
+    ThrowIfDisposed();
+    ThrowIfCannotWrite();
+    File.SetLength(value);
+    if (_position > value)
+      _position = value;
+  }
+
+  public override void Write(byte[] buffer, int offset, int count)
+  {
+    ValidateArrayArguments(buffer, offset, count);
+    Write(buffer.AsSpan(offset, count));
+  }
+
+  public override void Write(ReadOnlySpan<byte> buffer)
+  {
+    ThrowIfDisposed();
+    ThrowIfCannotWrite();
+    if (AppendMode)
+      _position = Length;
+    File.Write(_position, buffer);
+    _position += buffer.Length;
+  }
+
+  public override Task WriteAsync(
+      byte[] buffer,
+      int offset,
+      int count,
+      CancellationToken cancellationToken)
+  {
+    cancellationToken.ThrowIfCancellationRequested();
+    Write(buffer, offset, count);
+    return Task.CompletedTask;
+  }
+
+  public override ValueTask WriteAsync(
+      ReadOnlyMemory<byte> buffer,
+      CancellationToken cancellationToken = default)
+  {
+    cancellationToken.ThrowIfCancellationRequested();
+    Write(buffer.Span);
+    return ValueTask.CompletedTask;
+  }
+
+  public override void WriteByte(byte value)
+  {
+    Span<byte> buffer = stackalloc byte[1];
+    buffer[0] = value;
+    Write(buffer);
+  }
+
   public Stream ToStream() => this;
 
   protected override void Dispose(bool disposing)
   {
-    if (disposing)
-    {
-      Provider.UpdateFile(FilePath, ToArray());
-    }
+    IsDisposed = true;
     base.Dispose(disposing);
+  }
+
+  static void ValidateArrayArguments(byte[] buffer, int offset, int count)
+  {
+    ArgumentNullException.ThrowIfNull(buffer);
+    ArgumentOutOfRangeException.ThrowIfNegative(offset);
+    ArgumentOutOfRangeException.ThrowIfNegative(count);
+    if (buffer.Length - offset < count)
+      throw new ArgumentException("Offset and count exceed the buffer length.");
+  }
+
+  void ThrowIfCannotRead()
+  {
+    if (!CanRead)
+      throw new NotSupportedException("Stream does not support reading.");
+  }
+
+  void ThrowIfCannotWrite()
+  {
+    if (!CanWrite)
+      throw new NotSupportedException("Stream does not support writing.");
+  }
+
+  void ThrowIfDisposed()
+  {
+    ObjectDisposedException.ThrowIf(IsDisposed, this);
   }
 }

--- a/src/ZoneTree/AbstractFileStream/InMemoryFileStreamProvider.cs
+++ b/src/ZoneTree/AbstractFileStream/InMemoryFileStreamProvider.cs
@@ -4,10 +4,9 @@ namespace ZoneTree.AbstractFileStream;
 
 public sealed class InMemoryFileStreamProvider : IFileStreamProvider
 {
-  readonly Dictionary<string, byte[]> Files = [];
+  readonly Dictionary<string, InMemoryFile> Files = [];
 
   readonly HashSet<string> Directories = [];
-
 
   readonly Lock SyncRoot = new();
 
@@ -19,81 +18,178 @@ public sealed class InMemoryFileStreamProvider : IFileStreamProvider
       int bufferSize = 4096,
       FileOptions options = FileOptions.None)
   {
+    path = NormalizePath(path);
     lock (SyncRoot)
     {
-      if (!Files.ContainsKey(path))
+      var fileExists = Files.TryGetValue(path, out var file);
+      switch (mode)
       {
-        if (mode == FileMode.Open)
-          throw new FileNotFoundException(path);
-        Files[path] = Array.Empty<byte>();
+        case FileMode.CreateNew:
+          ThrowIfNoWriteAccess(access, mode);
+          if (fileExists)
+            throw new IOException($"File {path} already exists.");
+          file = CreateFile(path);
+          break;
+        case FileMode.Create:
+          ThrowIfNoWriteAccess(access, mode);
+          file = fileExists ? ClearFile(file) : CreateFile(path);
+          break;
+        case FileMode.Open:
+          if (!fileExists)
+            throw new FileNotFoundException(path);
+          break;
+        case FileMode.OpenOrCreate:
+          if (!fileExists)
+            ThrowIfNoWriteAccess(access, mode);
+          if (!fileExists)
+            file = CreateFile(path);
+          break;
+        case FileMode.Truncate:
+          if (!fileExists)
+            throw new FileNotFoundException(path);
+          ThrowIfNoWriteAccess(access, mode);
+          file.SetLength(0);
+          break;
+        case FileMode.Append:
+          if (access != FileAccess.Write)
+            throw new ArgumentException("FileMode.Append requires FileAccess.Write.", nameof(access));
+          if (!fileExists)
+            file = CreateFile(path);
+          break;
+        default:
+          throw new ArgumentOutOfRangeException(nameof(mode), mode, null);
       }
-      else if (mode == FileMode.CreateNew)
-      {
-        throw new IOException($"File {path} already exists.");
-      }
-      else if (mode == FileMode.Create)
-      {
-        Files[path] = Array.Empty<byte>();
-      }
-      else if (mode == FileMode.Truncate)
-      {
-        Files[path] = Array.Empty<byte>();
-      }
-      var bytes = Files[path];
-      var stream = new InMemoryFileStream(this, path, bytes);
+
+      var stream = new InMemoryFileStream(path, file, access, mode == FileMode.Append);
       if (mode == FileMode.Append)
         stream.Seek(0, SeekOrigin.End);
       return stream;
     }
   }
 
+  static void ThrowIfNoWriteAccess(FileAccess access, FileMode mode)
+  {
+    if ((access & FileAccess.Write) == 0)
+      throw new ArgumentException($"{mode} requires write access.", nameof(access));
+  }
+
+  InMemoryFile CreateFile(string path)
+  {
+    EnsureParentDirectories(path);
+    var file = new InMemoryFile();
+    Files[path] = file;
+    return file;
+  }
+
+  static InMemoryFile ClearFile(InMemoryFile file)
+  {
+    file.SetLength(0);
+    return file;
+  }
+
+  void EnsureParentDirectories(string path)
+  {
+    var parent = GetParentDirectory(path);
+    if (parent.Length == 0)
+      return;
+
+    var parts = parent.Split('/');
+    var current = "";
+    foreach (var part in parts)
+    {
+      current = current.Length == 0 ? part : current + "/" + part;
+      Directories.Add(current);
+    }
+  }
+
+  static string GetParentDirectory(string path)
+  {
+    var index = path.LastIndexOf('/');
+    return index <= 0 ? "" : path[..index];
+  }
+
+  static bool IsDescendant(string path, string parent)
+  {
+    return path.Length > parent.Length &&
+           path.StartsWith(parent, StringComparison.Ordinal) &&
+           path[parent.Length] == '/';
+  }
+
+  static string NormalizePath(string path)
+  {
+    ArgumentNullException.ThrowIfNull(path);
+    path = path.Replace('\\', '/');
+    while (path.Contains("//", StringComparison.Ordinal))
+      path = path.Replace("//", "/", StringComparison.Ordinal);
+    return path.Length > 1 ? path.TrimEnd('/') : path;
+  }
+
   public bool FileExists(string path)
   {
+    path = NormalizePath(path);
     lock (SyncRoot) return Files.ContainsKey(path);
   }
 
   public bool DirectoryExists(string path)
   {
+    path = NormalizePath(path);
     lock (SyncRoot) return Directories.Contains(path);
   }
 
   public void CreateDirectory(string path)
   {
-    lock (SyncRoot) Directories.Add(path);
+    path = NormalizePath(path);
+    lock (SyncRoot)
+    {
+      if (path.Length == 0)
+        return;
+      EnsureParentDirectories(path + "/file");
+      Directories.Add(path);
+    }
   }
 
   public void DeleteFile(string path)
   {
+    path = NormalizePath(path);
     lock (SyncRoot) Files.Remove(path);
   }
 
   public void DeleteDirectory(string path, bool recursive)
   {
+    path = NormalizePath(path);
     lock (SyncRoot)
     {
+      if (!recursive &&
+          (Files.Keys.Any(x => GetParentDirectory(x) == path) ||
+           Directories.Any(x => IsDescendant(x, path))))
+      {
+        throw new IOException($"Directory {path} is not empty.");
+      }
+
       Directories.Remove(path);
       if (recursive)
       {
-        var toRemove = Files.Keys.Where(x => x.StartsWith(path, StringComparison.Ordinal)).ToList();
-        foreach (var f in toRemove)
-          Files.Remove(f);
+        foreach (var file in Files.Keys.Where(x => IsDescendant(x, path)).ToArray())
+          Files.Remove(file);
+        foreach (var directory in Directories.Where(x => IsDescendant(x, path)).ToArray())
+          Directories.Remove(directory);
       }
     }
   }
 
   public string ReadAllText(string path)
   {
-    lock (SyncRoot) return Encoding.UTF8.GetString(Files[path]);
+    return Encoding.UTF8.GetString(ReadAllBytes(path));
   }
 
   public byte[] ReadAllBytes(string path)
   {
+    path = NormalizePath(path);
     lock (SyncRoot)
     {
-      var b = Files[path];
-      var copy = new byte[b.Length];
-      Buffer.BlockCopy(b, 0, copy, 0, b.Length);
-      return copy;
+      if (!Files.TryGetValue(path, out var file))
+        throw new FileNotFoundException(path);
+      return file.ToArray();
     }
   }
 
@@ -102,18 +198,26 @@ public sealed class InMemoryFileStreamProvider : IFileStreamProvider
       string destinationFileName,
       string destinationBackupFileName)
   {
+    sourceFileName = NormalizePath(sourceFileName);
+    destinationFileName = NormalizePath(destinationFileName);
+    destinationBackupFileName = destinationBackupFileName == null
+        ? null
+        : NormalizePath(destinationBackupFileName);
+
     lock (SyncRoot)
     {
+      if (!Files.TryGetValue(sourceFileName, out var source))
+        throw new FileNotFoundException(sourceFileName);
+
       if (destinationBackupFileName != null &&
-          Files.TryGetValue(destinationFileName, out var destinationBytes))
+          Files.TryGetValue(destinationFileName, out var destination))
       {
-        Files[destinationBackupFileName] = destinationBytes;
+        EnsureParentDirectories(destinationBackupFileName);
+        Files[destinationBackupFileName] = destination;
       }
 
-      Files[destinationFileName] = Files.TryGetValue(sourceFileName, out var sourceBytes)
-        ? sourceBytes
-        : [];
-
+      EnsureParentDirectories(destinationFileName);
+      Files[destinationFileName] = source;
       Files.Remove(sourceFileName);
     }
   }
@@ -125,22 +229,17 @@ public sealed class InMemoryFileStreamProvider : IFileStreamProvider
 
   public IReadOnlyList<string> GetDirectories(string path)
   {
+    path = NormalizePath(path);
     lock (SyncRoot)
     {
-      return Directories.Where(x => x.StartsWith(path, StringComparison.Ordinal)).ToArray();
+      return Directories
+          .Where(x => GetParentDirectory(x) == path)
+          .ToArray();
     }
   }
 
   public string CombinePaths(string path1, string path2)
   {
-    return Path.Combine(path1, path2);
-  }
-
-  internal void UpdateFile(string path, byte[] data)
-  {
-    lock (SyncRoot)
-    {
-      Files[path] = data;
-    }
+    return NormalizePath(Path.Combine(path1, path2));
   }
 }

--- a/src/ZoneTree/AbstractFileStream/InMemoryFileStreamProvider.cs
+++ b/src/ZoneTree/AbstractFileStream/InMemoryFileStreamProvider.cs
@@ -2,6 +2,14 @@ using System.Text;
 
 namespace ZoneTree.AbstractFileStream;
 
+/// <summary>
+/// Provides fast, in-process, RAM-backed file streams for ZoneTree workflows.
+/// This provider is optimized for WAL, segment, metadata, and merge operations
+/// that use stream-based access. It is not durable, does not emulate every
+/// filesystem behavior, and intentionally ignores <see cref="FileShare"/>.
+/// Large files are stored in chunks, while <see cref="ReadAllBytes"/> remains a
+/// small-file convenience API and may throw when a file cannot fit in one array.
+/// </summary>
 public sealed class InMemoryFileStreamProvider : IFileStreamProvider
 {
   readonly Dictionary<string, InMemoryFile> Files = [];

--- a/src/ZoneTree/Directory.Build.props
+++ b/src/ZoneTree/Directory.Build.props
@@ -5,8 +5,8 @@
     <Authors>Ahmed Yasin Koculu</Authors>
     <PackageId>ZoneTree</PackageId>
     <Title>ZoneTree</Title>
-    <ProductVersion>1.8.9.0</ProductVersion>
-    <Version>1.8.9.0</Version>
+    <ProductVersion>1.9.0.0</ProductVersion>
+    <Version>1.9.0.0</Version>
     <AssemblyTitle>ZoneTree</AssemblyTitle>
     <Description>ZoneTree is a persistent, high-performance, transactional, ACID-compliant ordered key-value database and LSM-tree storage engine for .NET.</Description>
     <Summary>


### PR DESCRIPTION
## Summary

Reworks `InMemoryFileStreamProvider` into a fast RAM-backed storage provider for ZoneTree’s stream-based WAL/segment/merge flow.

Instead of wrapping copied `MemoryStream` instances and persisting changes only on dispose, streams now operate directly on shared provider-owned in-memory files. This makes writes, truncates, reads, and replacements immediately visible while avoiding large copy-back costs.

## Changes

- Added `InMemoryFile` as the shared backing storage object.
- Replaced copied `MemoryStream` behavior with a custom `InMemoryFileStream`.
- Made stream operations write directly into provider-owned memory.
- Added tiered chunk storage: small chunks for small files, large chunks for bigger WAL/segment files.
- Made `Replace` use O(1) in-memory object handoff instead of cloning bytes.
- Added lightweight path normalization and safer recursive directory deletion.
- Enforced basic `FileAccess` and relevant `FileMode` behavior.
- Documented configurable file stream providers and the intended `InMemoryFileStreamProvider` use cases.
- Added focused tests for append, async read/write, sparse writes, truncation, replace behavior, disposed streams, path normalization, directory handling, chunk boundaries, `ReadFaster`, and WAL usage.