### PR TITLE
Set the default ZoneTree compression from LZ4 to Zstd fastest

### DIFF
--- a/docs/durability/backups.md
+++ b/docs/durability/backups.md
@@ -222,7 +222,7 @@ By default, live backup includes in-memory records:
 IncludeInMemoryRecords = true
 ```
 
-These records are serialized with the ZoneTree key and value serializers. Record batches are compressed by default with LZ4.
+These records are serialized with the ZoneTree key and value serializers. Record batches are compressed by default with Zstd level `0`.
 
 Use `Live` mode when you want the least intrusive backup pass:
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -50,13 +50,13 @@ ZoneTree defaults are designed as a practical general-purpose profile. Start wit
 | BTree leaf size | `128` |
 | WAL mode | `AsyncCompressed` |
 | WAL compression block size | `256 KB` |
-| WAL compression | `LZ4`, fastest level |
+| WAL compression | `Zstd`, level `0` |
 | Async compressed WAL empty queue poll interval | `100 ms` |
 | Sync compressed WAL tail writer | enabled |
 | Sync compressed WAL tail writer interval | `500 ms` |
 | Disk segment mode | `MultiPartDiskSegment` |
 | Disk segment compression block size | `4 MB` |
-| Disk segment compression | `LZ4`, fastest level |
+| Disk segment compression | `Zstd`, level `0` |
 | Multipart minimum record count | `1_500_000` records |
 | Multipart maximum record count | `3_000_000` records |
 | Key cache size | `1024` records |
@@ -73,7 +73,7 @@ ZoneTree defaults are designed as a practical general-purpose profile. Start wit
 | Live backup in-memory records | enabled |
 | Live backup in-memory mode | `Live` |
 | Live backup file transfer concurrency | `8` |
-| Live backup record batch compression | `LZ4`, fastest level |
+| Live backup record batch compression | `Zstd`, level `0` |
 | Live backup record batch compression block size | `1 MB` |
 | Console logger level | `Warning` |
 
@@ -105,7 +105,7 @@ Important options:
 | `KeyCacheRecordLifeTimeInMillisecond` | key cache record lifetime |
 | `ValueCacheRecordLifeTimeInMillisecond` | value cache record lifetime |
 
-The default disk profile uses multipart disk segments, `20_000_000` as the disk segment max item count, `1_500_000` to `3_000_000` records per multipart part, `4 MB` disk compression blocks, LZ4 fastest compression, `1024` sparse array step size, and `1024` key/value cache entries with `10 second` lifetimes.
+The default disk profile uses multipart disk segments, `20_000_000` as the disk segment max item count, `1_500_000` to `3_000_000` records per multipart part, `4 MB` disk compression blocks, Zstd level `0` compression, `1024` sparse array step size, and `1024` key/value cache entries with `10 second` lifetimes.
 
 The decompressed block cache is not configured by `DiskSegmentOptions`. Disk compression block size is configured here, but inactive decompressed block cleanup is controlled by the maintainer.
 
@@ -141,7 +141,7 @@ Important WAL options:
 
 Use sync modes when the application specifically needs synchronous WAL acknowledgment. Use `No WAL` only for cache, temporary, or intentionally rebuildable data.
 
-The default WAL profile uses async compressed WAL, `256 KB` compression blocks, LZ4 fastest compression, and a `100 ms` async empty-queue poll interval.
+The default WAL profile uses async compressed WAL, `256 KB` compression blocks, Zstd level `0` compression, and a `100 ms` async empty-queue poll interval.
 
 Incremental backup is disabled by default. Enable it only when you intentionally need WAL history preserved during WAL replacement or compaction.
 

--- a/docs/storage/compression.md
+++ b/docs/storage/compression.md
@@ -17,7 +17,7 @@ ZoneTree supports:
 * `Gzip`
 * `None`
 
-Compression levels are validated against the selected method. The default profile uses LZ4 fastest compression because it is a good general-purpose balance for storage-engine workloads.
+Compression levels are validated against the selected method. The default profile uses Zstd compression because it is a good general-purpose balance for storage-engine workloads.
 
 ## WAL Compression
 
@@ -26,8 +26,8 @@ The default WAL mode is `AsyncCompressed`.
 Default WAL compression:
 
 ```text
-method: LZ4
-level:  LZ4 fastest
+method: Zstd
+level:  Zstd0
 block:  256 KB
 ```
 
@@ -42,8 +42,8 @@ Disk segment compression is block-based random-access compression.
 Default disk compression:
 
 ```text
-method: LZ4
-level:  LZ4 fastest
+method: Zstd
+level:  Zstd0
 block:  4 MB
 ```
 
@@ -111,8 +111,8 @@ using var zoneTree = new ZoneTreeFactory<int, string>()
     .SetDataDirectory("data/app")
     .ConfigureWriteAheadLogOptions(options =>
     {
-        options.CompressionMethod = CompressionMethod.LZ4;
-        options.CompressionLevel = CompressionLevels.LZ4Fastest;
+        options.CompressionMethod = CompressionMethod.Zstd;
+        options.CompressionLevel = CompressionLevels.Zstd0;
         options.CompressionBlockSize = 256 * 1024;
     })
     .OpenOrCreate();
@@ -127,8 +127,8 @@ using var zoneTree = new ZoneTreeFactory<int, string>()
     .SetDataDirectory("data/app")
     .ConfigureDiskSegmentOptions(options =>
     {
-        options.CompressionMethod = CompressionMethod.LZ4;
-        options.CompressionLevel = CompressionLevels.LZ4Fastest;
+        options.CompressionMethod = CompressionMethod.Zstd;
+        options.CompressionLevel = CompressionLevels.Zstd0;
         options.CompressionBlockSize = 4 * 1024 * 1024;
     })
     .OpenOrCreate();

--- a/docs/tuning/disk-segments.md
+++ b/docs/tuning/disk-segments.md
@@ -82,7 +82,7 @@ For variable-length values such as strings and byte arrays, ZoneTree uses layout
 
 `CompressionBlockSize` affects disk compression and random-access behavior.
 
-The default disk compression block size is `4 MB`, using LZ4 fastest compression.
+The default disk compression block size is `4 MB`, using Zstd level `0` compression.
 
 Larger blocks often compress better but can make small random reads more expensive. Smaller blocks can improve random read granularity but may reduce compression ratio.
 

--- a/src/ZoneTree.UnitTests/DefaultCompressionTests.cs
+++ b/src/ZoneTree.UnitTests/DefaultCompressionTests.cs
@@ -1,0 +1,34 @@
+using ZoneTree.Backup;
+using ZoneTree.Options;
+
+namespace ZoneTree.UnitTests;
+
+public sealed class DefaultCompressionTests
+{
+  [Test]
+  public void DiskSegmentCompressionDefaultsToZstd()
+  {
+    var options = new DiskSegmentOptions();
+
+    Assert.That(options.CompressionMethod, Is.EqualTo(CompressionMethod.Zstd));
+    Assert.That(options.CompressionLevel, Is.EqualTo(CompressionLevels.Zstd0));
+  }
+
+  [Test]
+  public void WriteAheadLogCompressionDefaultsToZstd()
+  {
+    var options = new WriteAheadLogOptions();
+
+    Assert.That(options.CompressionMethod, Is.EqualTo(CompressionMethod.Zstd));
+    Assert.That(options.CompressionLevel, Is.EqualTo(CompressionLevels.Zstd0));
+  }
+
+  [Test]
+  public void LiveBackupRecordBatchCompressionDefaultsToZstd()
+  {
+    var options = new LiveBackupCompressionOptions();
+
+    Assert.That(options.Method, Is.EqualTo(CompressionMethod.Zstd));
+    Assert.That(options.Level, Is.EqualTo(CompressionLevels.Zstd0));
+  }
+}

--- a/src/ZoneTree.UnitTests/LiveBackupTests.cs
+++ b/src/ZoneTree.UnitTests/LiveBackupTests.cs
@@ -69,7 +69,7 @@ public sealed class LiveBackupTests
     Assert.That(recordBatch, Is.Not.Null);
     Assert.That(recordBatch.Completed, Is.True);
     Assert.That(recordBatch.RecordCount, Is.EqualTo(10));
-    Assert.That(recordBatch.CompressionMethod, Is.EqualTo(CompressionMethod.LZ4));
+    Assert.That(recordBatch.CompressionMethod, Is.EqualTo(CompressionMethod.Zstd));
     Assert.That(recordBatch.UncompressedLength, Is.GreaterThan(0));
     Assert.That(recordBatch.StoredLength, Is.GreaterThan(0));
     Assert.That(

--- a/src/ZoneTree/Backup/LiveBackupOptions.cs
+++ b/src/ZoneTree/Backup/LiveBackupOptions.cs
@@ -72,9 +72,9 @@ public enum LiveBackupInMemoryMode
 
 public sealed class LiveBackupCompressionOptions
 {
-  public const CompressionMethod DefaultMethod = CompressionMethod.LZ4;
+  public const CompressionMethod DefaultMethod = CompressionMethod.Zstd;
 
-  public const int DefaultLevel = CompressionLevels.LZ4Fastest;
+  public const int DefaultLevel = CompressionLevels.Zstd0;
 
   public const int DefaultBlockSize = 1024 * 1024;
 

--- a/src/ZoneTree/Options/DiskSegmentDefaultValues.cs
+++ b/src/ZoneTree/Options/DiskSegmentDefaultValues.cs
@@ -6,9 +6,9 @@ public static class DiskSegmentDefaultValues
 
   public static readonly int CompressionBlockSize = 4 * 1024 * 1024;
 
-  public static readonly CompressionMethod CompressionMethod = CompressionMethod.LZ4;
+  public static readonly CompressionMethod CompressionMethod = CompressionMethod.Zstd;
 
-  public static readonly int CompressionLevel = CompressionLevels.LZ4Fastest;
+  public static readonly int CompressionLevel = CompressionLevels.Zstd0;
 
   public static readonly int MaximumRecordCount = 3_000_000;
 

--- a/src/ZoneTree/Options/DiskSegmentOptions.cs
+++ b/src/ZoneTree/Options/DiskSegmentOptions.cs
@@ -20,13 +20,13 @@ public sealed class DiskSegmentOptions
 
   /// <summary>
   /// Gets or sets the compression method used if compression is enabled.
-  /// Default value is <see cref="CompressionMethod.LZ4"/>.
+  /// Default value is <see cref="CompressionMethod.Zstd"/>.
   /// </summary>
   public CompressionMethod CompressionMethod { get; set; } = DiskSegmentDefaultValues.CompressionMethod;
 
   /// <summary>
   /// Gets or sets the compression level for the selected compression method.
-  /// Default value is <see cref="CompressionLevels.LZ4Fastest"/>.
+  /// Default value is <see cref="CompressionLevels.Zstd0"/>.
   /// </summary>
   public int CompressionLevel { get; set; } = DiskSegmentDefaultValues.CompressionLevel;
 

--- a/src/ZoneTree/Options/WriteAheadLogDefaultValues.cs
+++ b/src/ZoneTree/Options/WriteAheadLogDefaultValues.cs
@@ -6,9 +6,9 @@ public static class WriteAheadLogDefaultValues
 
   public static readonly int CompressionBlockSize = 1024 * 32 * 8;
 
-  public static readonly CompressionMethod CompressionMethod = CompressionMethod.LZ4;
+  public static readonly CompressionMethod CompressionMethod = CompressionMethod.Zstd;
 
-  public static readonly int CompressionLevel = CompressionLevels.LZ4Fastest;
+  public static readonly int CompressionLevel = CompressionLevels.Zstd0;
 
   public static readonly bool SyncCompressedModeEnableTailWriterJob = true;
 

--- a/src/ZoneTree/Options/WriteAheadLogOptions.cs
+++ b/src/ZoneTree/Options/WriteAheadLogOptions.cs
@@ -31,13 +31,13 @@ public sealed class WriteAheadLogOptions
 
   /// <summary>
   /// The compression method for the WALs with compression enabled.
-  /// Default is LZ4.
+  /// Default is Zstd.
   /// </summary>
   public CompressionMethod CompressionMethod { get; set; } = WriteAheadLogDefaultValues.CompressionMethod;
 
   /// <summary>
   /// The compression level of the selected compression method.
-  /// Default is <see cref="CompressionLevels.LZ4Fastest"/>.
+  /// Default is <see cref="CompressionLevels.Zstd0"/>.
   /// </summary>
   public int CompressionLevel { get; set; } = WriteAheadLogDefaultValues.CompressionLevel;
 

--- a/src/ZoneTree/Segments/Disk/DiskSegmentCreator.cs
+++ b/src/ZoneTree/Segments/Disk/DiskSegmentCreator.cs
@@ -41,6 +41,12 @@ public sealed class DiskSegmentCreator<TKey, TValue> : IDiskSegmentCreator<TKey,
 
   TValue LastValue;
 
+  bool IsReadOnlyDiskSegmentCreated;
+
+  bool IsDropped;
+
+  bool IsDisposed;
+
   public DiskSegmentCreator(
       ZoneTreeOptions<TKey, TValue> options,
       IIncrementalIdProvider incrementalIdProvider
@@ -49,34 +55,42 @@ public sealed class DiskSegmentCreator<TKey, TValue> : IDiskSegmentCreator<TKey,
     SegmentId = incrementalIdProvider.NextId();
     KeySerializer = options.KeySerializer;
     ValueSerializer = options.ValueSerializer;
+    Options = options;
     var randomDeviceManager = options.RandomAccessDeviceManager;
 
     HasFixedSizeKey = !RuntimeHelpers.IsReferenceOrContainsReferences<TKey>();
     HasFixedSizeValue = !RuntimeHelpers.IsReferenceOrContainsReferences<TValue>();
     HasFixedSizeKeyAndValue = HasFixedSizeKey && HasFixedSizeValue;
     var diskOptions = options.DiskSegmentOptions;
-    if (!HasFixedSizeKeyAndValue)
-      DataHeaderDevice = randomDeviceManager
+    try
+    {
+      if (!HasFixedSizeKeyAndValue)
+        DataHeaderDevice = randomDeviceManager
+            .CreateWritableDevice(
+                SegmentId,
+                DiskSegmentConstants.DataHeaderCategory,
+                isCompressed: true,
+                diskOptions.CompressionBlockSize,
+                deleteIfExists: true,
+                backupIfDelete: false,
+                diskOptions.CompressionMethod,
+                diskOptions.CompressionLevel);
+      DataDevice = randomDeviceManager
           .CreateWritableDevice(
               SegmentId,
-              DiskSegmentConstants.DataHeaderCategory,
+              DiskSegmentConstants.DataCategory,
               isCompressed: true,
               diskOptions.CompressionBlockSize,
               deleteIfExists: true,
               backupIfDelete: false,
               diskOptions.CompressionMethod,
               diskOptions.CompressionLevel);
-    DataDevice = randomDeviceManager
-        .CreateWritableDevice(
-            SegmentId,
-            DiskSegmentConstants.DataCategory,
-            isCompressed: true,
-            diskOptions.CompressionBlockSize,
-            deleteIfExists: true,
-            backupIfDelete: false,
-            diskOptions.CompressionMethod,
-            diskOptions.CompressionLevel);
-    Options = options;
+    }
+    catch
+    {
+      Dispose();
+      throw;
+    }
     DefaultSparseArrayStepSize = options.DiskSegmentOptions.DefaultSparseArrayStepSize;
   }
 
@@ -140,6 +154,8 @@ public sealed class DiskSegmentCreator<TKey, TValue> : IDiskSegmentCreator<TKey,
 
   public IDiskSegment<TKey, TValue> CreateReadOnlyDiskSegment()
   {
+    ThrowIfNotWritable();
+
     var isSparseArrayNotEmpty = DefaultSparseArray.Count > 0;
     if (isSparseArrayNotEmpty &&
         DefaultSparseArrayStepSize > 0 &&
@@ -158,15 +174,30 @@ public sealed class DiskSegmentCreator<TKey, TValue> : IDiskSegmentCreator<TKey,
       diskSegment.SetDefaultSparseArray(DefaultSparseArray);
     DataHeaderDevice = null;
     DataDevice = null;
+    IsReadOnlyDiskSegmentCreated = true;
     return diskSegment;
   }
 
   public void DropDiskSegment()
   {
+    if (IsDropped)
+      return;
+    if (IsReadOnlyDiskSegmentCreated)
+      throw new InvalidOperationException(
+          "Cannot drop a disk segment creator after ownership has been transferred.");
+    ObjectDisposedException.ThrowIf(
+        IsDisposed,
+        this);
+
     Close();
     if (!HasFixedSizeKeyAndValue)
-      DataHeaderDevice.Delete();
-    DataDevice.Delete();
+    {
+      DataHeaderDevice?.Delete();
+      DataHeaderDevice = null;
+    }
+    DataDevice?.Delete();
+    DataDevice = null;
+    IsDropped = true;
   }
 
   void Close()
@@ -178,13 +209,32 @@ public sealed class DiskSegmentCreator<TKey, TValue> : IDiskSegmentCreator<TKey,
 
   public void Dispose()
   {
+    if (IsReadOnlyDiskSegmentCreated || IsDropped || IsDisposed)
+      return;
+
     if (!HasFixedSizeKeyAndValue)
       DataHeaderDevice?.Dispose();
     DataDevice?.Dispose();
+    DataHeaderDevice = null;
+    DataDevice = null;
+    IsDisposed = true;
   }
 
   public void Append(IDiskSegment<TKey, TValue> part, TKey key1, TKey key2, TValue value1, TValue value2)
   {
     throw new NotSupportedException("This method should be called on MultiDiskSegmentCreator.");
+  }
+
+  void ThrowIfNotWritable()
+  {
+    if (IsReadOnlyDiskSegmentCreated)
+      throw new InvalidOperationException(
+          "The disk segment creator has already transferred ownership.");
+    ObjectDisposedException.ThrowIf(
+        IsDropped,
+        this);
+    ObjectDisposedException.ThrowIf(
+        IsDisposed,
+        this);
   }
 }

--- a/src/ZoneTree/Segments/MultiPart/MultiPartDiskSegment.cs
+++ b/src/ZoneTree/Segments/MultiPart/MultiPartDiskSegment.cs
@@ -3,7 +3,6 @@ using System.Buffers;
 using ZoneTree.AbstractFileStream;
 using ZoneTree.Collections;
 using ZoneTree.Comparers;
-using ZoneTree.Compression;
 using ZoneTree.Exceptions;
 using ZoneTree.Options;
 using ZoneTree.Segments.Block;
@@ -16,10 +15,10 @@ namespace ZoneTree.Segments.MultiPart;
 public sealed class MultiPartDiskSegment<TKey, TValue> : IDiskSegment<TKey, TValue>
 {
   public const CompressionMethod MultiPartHeaderCompressionMethod
-      = CompressionMethod.LZ4;
+      = MultiPartMetadataCodec.CurrentCompressionMethod;
 
   public const int MultiPartHeaderCompressionLevel
-      = CompressionLevels.LZ4Fastest;
+      = MultiPartMetadataCodec.CurrentCompressionLevel;
 
   public long SegmentId { get; }
 
@@ -35,7 +34,7 @@ public sealed class MultiPartDiskSegment<TKey, TValue> : IDiskSegment<TKey, TVal
 
   bool IsDropped;
 
-  readonly object DropLock = new();
+  readonly Lock DropLock = new();
 
   readonly IReadOnlyList<IDiskSegment<TKey, TValue>> Parts;
 
@@ -83,8 +82,7 @@ public sealed class MultiPartDiskSegment<TKey, TValue> : IDiskSegment<TKey, TVal
 
     var len = (int)diskSegmentListDevice.Length;
     var compressedBytes = diskSegmentListDevice.GetBytes(0, len);
-    var bytes = DataCompression
-        .Decompress(MultiPartHeaderCompressionMethod, compressedBytes);
+    var bytes = MultiPartMetadataCodec.Decode(compressedBytes);
     using var pin = bytes.Pin();
     using var ms = bytes.ToReadOnlyStream(pin);
     using var br = new BinaryReader(ms);
@@ -116,7 +114,7 @@ public sealed class MultiPartDiskSegment<TKey, TValue> : IDiskSegment<TKey, TVal
 
     var len = (int)diskSegmentListDevice.Length;
     var compressedBytes = diskSegmentListDevice.GetBytes(0, len);
-    var bytes = DataCompression.Decompress(MultiPartHeaderCompressionMethod, compressedBytes);
+    var bytes = MultiPartMetadataCodec.Decode(compressedBytes);
 
     using var pin = bytes.Pin();
     using var ms = bytes.ToReadOnlyStream(pin);

--- a/src/ZoneTree/Segments/MultiPart/MultiPartDiskSegmentCreator.cs
+++ b/src/ZoneTree/Segments/MultiPart/MultiPartDiskSegmentCreator.cs
@@ -1,4 +1,3 @@
-using ZoneTree.Compression;
 using ZoneTree.Core;
 using ZoneTree.Options;
 using ZoneTree.Segments.Disk;
@@ -18,11 +17,7 @@ public sealed class MultiPartDiskSegmentCreator<TKey, TValue> : IDiskSegmentCrea
 
   readonly IIncrementalIdProvider IncrementalIdProvider;
 
-#pragma warning disable CA2213 // Dispose is required in case of drop and handled by parts drops.
-
   DiskSegmentCreator<TKey, TValue> NextCreator;
-
-#pragma warning restore CA2213
 
   readonly int DiskSegmentMaximumRecordCount;
 
@@ -39,6 +34,12 @@ public sealed class MultiPartDiskSegmentCreator<TKey, TValue> : IDiskSegmentCrea
   TKey LastAppendedKey;
 
   TValue LastAppendedValue;
+
+  bool IsReadOnlyDiskSegmentCreated;
+
+  bool IsDropped;
+
+  bool IsDisposed;
 
   public HashSet<long> AppendedPartSegmentIds { get; } = new();
 
@@ -130,6 +131,8 @@ public sealed class MultiPartDiskSegmentCreator<TKey, TValue> : IDiskSegmentCrea
 
   public IDiskSegment<TKey, TValue> CreateReadOnlyDiskSegment()
   {
+    ThrowIfNotWritable();
+
     if (NextCreator.Length == 0)
     {
       NextCreator.DropDiskSegment();
@@ -152,6 +155,7 @@ public sealed class MultiPartDiskSegmentCreator<TKey, TValue> : IDiskSegmentCrea
         Parts,
         PartKeys.ToArray(),
         PartValues.ToArray());
+    IsReadOnlyDiskSegmentCreated = true;
     return diskSegment;
   }
 
@@ -177,8 +181,7 @@ public sealed class MultiPartDiskSegmentCreator<TKey, TValue> : IDiskSegmentCrea
                 backupIfDelete: false,
                 compressionMethod,
                 compressionLevel);
-    var compressedBytes = DataCompression
-        .Compress(compressionMethod, compressionLevel, ms.ToArray());
+    var compressedBytes = MultiPartMetadataCodec.Encode(ms.ToArray());
     multiDevice.AppendBytesReturnPosition(compressedBytes);
     Options.RandomAccessDeviceManager
         .RemoveWritableDevice(SegmentId, DiskSegmentConstants.MultiPartDiskSegmentCategory);
@@ -234,6 +237,15 @@ public sealed class MultiPartDiskSegmentCreator<TKey, TValue> : IDiskSegmentCrea
 
   public void DropDiskSegment()
   {
+    if (IsDropped)
+      return;
+    ObjectDisposedException.ThrowIf(
+        IsDisposed,
+        this);
+    if (IsReadOnlyDiskSegmentCreated)
+      throw new InvalidOperationException(
+          "Cannot drop a disk segment creator after ownership has been transferred.");
+
     foreach (var part in Parts)
     {
       if (AppendedPartSegmentIds.Contains(part.SegmentId))
@@ -250,6 +262,7 @@ public sealed class MultiPartDiskSegmentCreator<TKey, TValue> : IDiskSegmentCrea
         DiskSegmentConstants.MultiPartDiskSegmentCategory,
         isCompressed: false))
     {
+      IsDropped = true;
       return;
     }
 
@@ -265,9 +278,36 @@ public sealed class MultiPartDiskSegmentCreator<TKey, TValue> : IDiskSegmentCrea
     randomAccessDeviceManager.RemoveReadOnlyDevice(
         SegmentId,
         DiskSegmentConstants.MultiPartDiskSegmentCategory);
+    IsDropped = true;
   }
 
   public void Dispose()
   {
+    if (IsReadOnlyDiskSegmentCreated || IsDropped || IsDisposed)
+      return;
+
+    foreach (var part in Parts)
+    {
+      if (AppendedPartSegmentIds.Contains(part.SegmentId))
+        continue;
+      part.Dispose();
+    }
+
+    NextCreator?.Dispose();
+    NextCreator = null;
+    IsDisposed = true;
+  }
+
+  void ThrowIfNotWritable()
+  {
+    if (IsReadOnlyDiskSegmentCreated)
+      throw new InvalidOperationException(
+          "The disk segment creator has already transferred ownership.");
+    ObjectDisposedException.ThrowIf(
+        IsDropped,
+        this);
+    ObjectDisposedException.ThrowIf(
+        IsDisposed,
+        this);
   }
 }

--- a/src/ZoneTree/Segments/MultiPart/MultiPartMetadataCodec.cs
+++ b/src/ZoneTree/Segments/MultiPart/MultiPartMetadataCodec.cs
@@ -1,0 +1,95 @@
+using System.Buffers.Binary;
+using ZoneTree.Compression;
+using ZoneTree.Options;
+
+namespace ZoneTree.Segments.MultiPart;
+
+internal static class MultiPartMetadataCodec
+{
+  internal const CompressionMethod CurrentCompressionMethod = CompressionMethod.Zstd;
+
+  internal const int CurrentCompressionLevel = CompressionLevels.Zstd0;
+
+  const int MagicSize = 16;
+
+  const byte Version = 1;
+
+  const int PrefixSize =
+      MagicSize + sizeof(byte) + sizeof(byte) + sizeof(int) + sizeof(int);
+
+  static ReadOnlySpan<byte> Magic => "ZoneTreeMPH-v001"u8;
+
+  public static Memory<byte> Encode(Memory<byte> bytes)
+  {
+    var payload = DataCompression.Compress(
+        CurrentCompressionMethod,
+        CurrentCompressionLevel,
+        bytes);
+
+    var result = new byte[PrefixSize + payload.Length];
+    var span = result.AsSpan();
+    Magic.CopyTo(span);
+
+    var offset = MagicSize;
+    span[offset++] = Version;
+    span[offset++] = (byte)CurrentCompressionMethod;
+    BinaryPrimitives.WriteInt32LittleEndian(
+        span.Slice(offset, sizeof(int)),
+        CurrentCompressionLevel);
+    offset += sizeof(int);
+    BinaryPrimitives.WriteInt32LittleEndian(
+        span.Slice(offset, sizeof(int)),
+        payload.Length);
+    offset += sizeof(int);
+    payload.Span.CopyTo(span[offset..]);
+    return result;
+  }
+
+  public static Memory<byte> Decode(Memory<byte> bytes)
+  {
+    if (!HasEnvelope(bytes))
+      return DataCompression.Decompress(CompressionMethod.LZ4, bytes);
+
+    var (method, payload) = ReadEnvelope(bytes);
+    return DataCompression.Decompress(method, payload);
+  }
+
+  static bool HasEnvelope(Memory<byte> bytes)
+  {
+    if (bytes.Length < MagicSize)
+      return false;
+
+    return bytes.Span[..MagicSize].SequenceEqual(Magic);
+  }
+
+  static (CompressionMethod method, Memory<byte> payload) ReadEnvelope(
+      Memory<byte> bytes)
+  {
+    if (bytes.Length < PrefixSize)
+      throw new InvalidDataException("Multipart metadata envelope is incomplete.");
+
+    var span = bytes.Span;
+    var offset = MagicSize;
+    var version = span[offset++];
+    if (version != Version)
+      throw new InvalidDataException(
+          $"Unsupported multipart metadata envelope version: {version}.");
+
+    var method = (CompressionMethod)span[offset++];
+    var level = BinaryPrimitives.ReadInt32LittleEndian(
+        span.Slice(offset, sizeof(int)));
+    offset += sizeof(int);
+    if (!CompressionLevels.IsValid(method, level))
+      throw new InvalidDataException(
+          $"Invalid multipart metadata compression profile: {method}, level {level}.");
+
+    var payloadLength = BinaryPrimitives.ReadInt32LittleEndian(
+        span.Slice(offset, sizeof(int)));
+    offset += sizeof(int);
+    if (payloadLength < 0 || payloadLength != span.Length - offset)
+      throw new InvalidDataException(
+          "Multipart metadata envelope payload length is invalid.");
+
+    return (method, bytes.Slice(offset, payloadLength));
+  }
+}


### PR DESCRIPTION
## Summary

Switches the default ZoneTree compression from LZ4 to Zstd fastest mode (`Zstd0`) for disk segments, WAL, live backup, and multipart metadata.

## Changes

- Default disk segment compression is now `CompressionMethod.Zstd` with `CompressionLevels.Zstd0`.
- Default WAL compression is now `CompressionMethod.Zstd` with `CompressionLevels.Zstd0`.
- Default live backup compression is now `CompressionMethod.Zstd` with `CompressionLevels.Zstd0`.
- Multipart metadata now uses a versioned magic header so new metadata can record its compression method while legacy LZ4 metadata remains readable.
- Extracted multipart metadata encoding/decoding into `MultiPartMetadataCodec`.
- Hardened disk segment creator disposal/drop ownership handling.
- Updated docs and default compression tests.

## Compatibility

Existing WAL files and disk segments remain compatible because their compression methods are stored in metadata. Legacy multipart metadata without the new magic header is read as LZ4.