### PR TITLE
Replace zstdnet with zstdsharp.port and improve compression allocation.

### DIFF
--- a/src/ZoneTree/Backup/LiveBackupRecordBatchReader.cs
+++ b/src/ZoneTree/Backup/LiveBackupRecordBatchReader.cs
@@ -49,9 +49,10 @@ public sealed class LiveBackupRecordBatchReader : IDisposable
     if (!TryReadInt32(Source, out var compressedLength))
       throw new EndOfStreamException();
     var compressed = ReadBytes(Source, compressedLength);
-    var decompressed = DataCompression.Decompress(
+    var decompressed = DataCompression.DecompressFast(
         Batch.CompressionMethod,
-        compressed);
+        compressed,
+        uncompressedLength);
     if (decompressed.Length != uncompressedLength)
       throw new InvalidDataException("Invalid live backup compressed block length.");
     block = decompressed.ToArray();

--- a/src/ZoneTree/Backup/LiveBackupRecordBatchReader.cs
+++ b/src/ZoneTree/Backup/LiveBackupRecordBatchReader.cs
@@ -49,7 +49,7 @@ public sealed class LiveBackupRecordBatchReader : IDisposable
     if (!TryReadInt32(Source, out var compressedLength))
       throw new EndOfStreamException();
     var compressed = ReadBytes(Source, compressedLength);
-    var decompressed = DataCompression.DecompressFast(
+    var decompressed = DataCompression.Decompress(
         Batch.CompressionMethod,
         compressed,
         uncompressedLength);

--- a/src/ZoneTree/Backup/LiveBackupRecordBatchWriter.cs
+++ b/src/ZoneTree/Backup/LiveBackupRecordBatchWriter.cs
@@ -75,8 +75,7 @@ public sealed class LiveBackupRecordBatchWriter : ILiveBackupRecordWriter
         .Compress(
             Batch.CompressionMethod,
             Batch.CompressionLevel,
-            uncompressed)
-        .ToArray();
+            uncompressed);
     await WriteInt32Async(Destination, uncompressed.Length, cancellationToken);
     await WriteInt32Async(Destination, compressed.Length, cancellationToken);
     await Destination.WriteAsync(compressed, cancellationToken);

--- a/src/ZoneTree/Compression/BrotliDataCompression.cs
+++ b/src/ZoneTree/Compression/BrotliDataCompression.cs
@@ -1,5 +1,4 @@
 using System.IO.Compression;
-using ZoneTree.AbstractFileStream;
 
 namespace ZoneTree.Compression;
 
@@ -20,17 +19,6 @@ public static class BrotliDataCompression
       throw new InvalidDataException("Brotli compression failed.");
     }
     return compressed.AsMemory(0, compressedLength);
-  }
-
-  public static byte[] Decompress(Memory<byte> compressedBytes)
-  {
-    using var pin = compressedBytes.Pin();
-    using var msInput = compressedBytes.ToReadOnlyStream(pin);
-    using var msOutput = new MemoryStream();
-    using var gzs = new BrotliStream(msInput, CompressionMode.Decompress);
-    gzs.CopyTo(msOutput);
-    var decompressed = msOutput.ToArray();
-    return decompressed;
   }
 
   public static byte[] Decompress(Memory<byte> compressedBytes, int decompressedLength)

--- a/src/ZoneTree/Compression/BrotliDataCompression.cs
+++ b/src/ZoneTree/Compression/BrotliDataCompression.cs
@@ -5,17 +5,21 @@ namespace ZoneTree.Compression;
 
 public static class BrotliDataCompression
 {
+  const int DefaultWindow = 22;
+
   public static Memory<byte> Compress(Memory<byte> bytes, int level)
   {
-    // Brotli Optimum level is extremely slow.
-    // Changing the optimum level to fastest!
-    if (level == 0)
-      level = 1;
-    using var msOutput = new MemoryStream();
-    using var gzs = new BrotliStream(msOutput, (CompressionLevel)level, false);
-    gzs.Write(bytes.Span);
-    gzs.Flush();
-    return msOutput.ToArray();
+    var compressed = new byte[BrotliEncoder.GetMaxCompressedLength(bytes.Length)];
+    if (!BrotliEncoder.TryCompress(
+        bytes.Span,
+        compressed.AsSpan(),
+        out var compressedLength,
+        GetQuality(level),
+        DefaultWindow))
+    {
+      throw new InvalidDataException("Brotli compression failed.");
+    }
+    return compressed.AsMemory(0, compressedLength);
   }
 
   public static byte[] Decompress(Memory<byte> compressedBytes)
@@ -32,11 +36,26 @@ public static class BrotliDataCompression
   public static byte[] DecompressFast(Memory<byte> compressedBytes, int decompressedLength)
   {
     var decompressed = new byte[decompressedLength];
-    using var pin = compressedBytes.Pin();
-    using var msInput = compressedBytes.ToReadOnlyStream(pin);
-    using var msOutput = new MemoryStream(decompressed);
-    using var gzs = new BrotliStream(msInput, CompressionMode.Decompress);
-    gzs.CopyTo(msOutput);
+    if (!BrotliDecoder.TryDecompress(
+        compressedBytes.Span,
+        decompressed.AsSpan(),
+        out var bytesWritten) ||
+        bytesWritten != decompressedLength)
+    {
+      throw new InvalidDataException("Brotli decompression failed.");
+    }
     return decompressed;
+  }
+
+  static int GetQuality(int level)
+  {
+    return (CompressionLevel)level switch
+    {
+      CompressionLevel.NoCompression => 0,
+      CompressionLevel.SmallestSize => 11,
+      // Brotli Optimal is extremely slow.
+      // treat Optimal like Fastest.
+      _ => 1,
+    };
   }
 }

--- a/src/ZoneTree/Compression/BrotliDataCompression.cs
+++ b/src/ZoneTree/Compression/BrotliDataCompression.cs
@@ -33,7 +33,7 @@ public static class BrotliDataCompression
     return decompressed;
   }
 
-  public static byte[] DecompressFast(Memory<byte> compressedBytes, int decompressedLength)
+  public static byte[] Decompress(Memory<byte> compressedBytes, int decompressedLength)
   {
     var decompressed = new byte[decompressedLength];
     if (!BrotliDecoder.TryDecompress(

--- a/src/ZoneTree/Compression/DataCompression.cs
+++ b/src/ZoneTree/Compression/DataCompression.cs
@@ -18,28 +18,14 @@ public static class DataCompression
   }
 
   public static Memory<byte> Decompress(
-      CompressionMethod method, Memory<byte> compressedBytes)
-  {
-    return method switch
-    {
-      CompressionMethod.LZ4 => LZ4DataCompression.Decompress(compressedBytes),
-      CompressionMethod.Zstd => ZstdDataCompression.Decompress(compressedBytes),
-      CompressionMethod.Brotli => BrotliDataCompression.Decompress(compressedBytes),
-      CompressionMethod.Gzip => GZipDataCompression.Decompress(compressedBytes),
-      CompressionMethod.None => compressedBytes,
-      _ => throw new ArgumentOutOfRangeException(nameof(method)),
-    };
-  }
-
-  public static Memory<byte> DecompressFast(
       CompressionMethod method, Memory<byte> compressedBytes, int decompressedLength)
   {
     return method switch
     {
-      CompressionMethod.LZ4 => LZ4DataCompression.DecompressFast(compressedBytes, decompressedLength),
-      CompressionMethod.Zstd => ZstdDataCompression.DecompressFast(compressedBytes, decompressedLength),
-      CompressionMethod.Brotli => BrotliDataCompression.DecompressFast(compressedBytes, decompressedLength),
-      CompressionMethod.Gzip => GZipDataCompression.DecompressFast(compressedBytes, decompressedLength),
+      CompressionMethod.LZ4 => LZ4DataCompression.Decompress(compressedBytes, decompressedLength),
+      CompressionMethod.Zstd => ZstdDataCompression.Decompress(compressedBytes, decompressedLength),
+      CompressionMethod.Brotli => BrotliDataCompression.Decompress(compressedBytes, decompressedLength),
+      CompressionMethod.Gzip => GZipDataCompression.Decompress(compressedBytes, decompressedLength),
       CompressionMethod.None => compressedBytes.ToArray(),
       _ => throw new ArgumentOutOfRangeException(nameof(method)),
     };

--- a/src/ZoneTree/Compression/GZipDataCompression.cs
+++ b/src/ZoneTree/Compression/GZipDataCompression.cs
@@ -7,10 +7,11 @@ public static class GZipDataCompression
 {
   public static Memory<byte> Compress(Memory<byte> bytes, int level)
   {
-    using var msOutput = new MemoryStream();
-    using var gzs = new GZipStream(msOutput, (CompressionLevel)level, false);
-    gzs.Write(bytes.Span);
-    gzs.Flush();
+    using var msOutput = new MemoryStream(bytes.Length);
+    using (var gzs = new GZipStream(msOutput, (CompressionLevel)level, true))
+    {
+      gzs.Write(bytes.Span);
+    }
     return msOutput.ToArray();
   }
 
@@ -18,7 +19,7 @@ public static class GZipDataCompression
   {
     using var pin = compressedBytes.Pin();
     using var msInput = compressedBytes.ToReadOnlyStream(pin);
-    using var msOutput = new MemoryStream();
+    using var msOutput = new MemoryStream(compressedBytes.Length);
     using var gzs = new GZipStream(msInput, CompressionMode.Decompress);
     gzs.CopyTo(msOutput);
     var decompressed = msOutput.ToArray();
@@ -30,7 +31,7 @@ public static class GZipDataCompression
     var decompressed = new byte[decompressedLength];
     using var pin = compressedBytes.Pin();
     using var msInput = compressedBytes.ToReadOnlyStream(pin);
-    using var msOutput = new MemoryStream(decompressed);
+    using var msOutput = new MemoryStream(decompressed, true);
     using var gzs = new GZipStream(msInput, CompressionMode.Decompress);
     gzs.CopyTo(msOutput);
     return decompressed;

--- a/src/ZoneTree/Compression/GZipDataCompression.cs
+++ b/src/ZoneTree/Compression/GZipDataCompression.cs
@@ -26,7 +26,7 @@ public static class GZipDataCompression
     return decompressed;
   }
 
-  public static byte[] DecompressFast(Memory<byte> compressedBytes, int decompressedLength)
+  public static byte[] Decompress(Memory<byte> compressedBytes, int decompressedLength)
   {
     var decompressed = new byte[decompressedLength];
     using var pin = compressedBytes.Pin();

--- a/src/ZoneTree/Compression/GZipDataCompression.cs
+++ b/src/ZoneTree/Compression/GZipDataCompression.cs
@@ -15,17 +15,6 @@ public static class GZipDataCompression
     return msOutput.ToArray();
   }
 
-  public static byte[] Decompress(Memory<byte> compressedBytes)
-  {
-    using var pin = compressedBytes.Pin();
-    using var msInput = compressedBytes.ToReadOnlyStream(pin);
-    using var msOutput = new MemoryStream(compressedBytes.Length);
-    using var gzs = new GZipStream(msInput, CompressionMode.Decompress);
-    gzs.CopyTo(msOutput);
-    var decompressed = msOutput.ToArray();
-    return decompressed;
-  }
-
   public static byte[] Decompress(Memory<byte> compressedBytes, int decompressedLength)
   {
     var decompressed = new byte[decompressedLength];

--- a/src/ZoneTree/Compression/LZ4DataCompression.cs
+++ b/src/ZoneTree/Compression/LZ4DataCompression.cs
@@ -14,10 +14,15 @@ public static class LZ4DataCompression
     return LZ4Pickler.Unpickle(compressedBytes.Span);
   }
 
-  public static byte[] DecompressFast(Memory<byte> compressedBytes, int decompressedLength)
+  public static byte[] Decompress(Memory<byte> compressedBytes, int decompressedLength)
   {
     var bytes = new byte[decompressedLength];
     LZ4Pickler.Unpickle(compressedBytes.Span, bytes);
     return bytes;
+  }
+
+  public static int GetDecompressedLength(Memory<byte> compressedBytes)
+  {
+    return checked((int)LZ4Pickler.UnpickledSize(compressedBytes.Span));
   }
 }

--- a/src/ZoneTree/Compression/LZ4DataCompression.cs
+++ b/src/ZoneTree/Compression/LZ4DataCompression.cs
@@ -9,11 +9,6 @@ public static class LZ4DataCompression
     return LZ4Pickler.Pickle(bytes.Span, (LZ4Level)level);
   }
 
-  public static byte[] Decompress(Memory<byte> compressedBytes)
-  {
-    return LZ4Pickler.Unpickle(compressedBytes.Span);
-  }
-
   public static byte[] Decompress(Memory<byte> compressedBytes, int decompressedLength)
   {
     var bytes = new byte[decompressedLength];
@@ -23,6 +18,6 @@ public static class LZ4DataCompression
 
   public static int GetDecompressedLength(Memory<byte> compressedBytes)
   {
-    return checked((int)LZ4Pickler.UnpickledSize(compressedBytes.Span));
+    return checked(LZ4Pickler.UnpickledSize(compressedBytes.Span));
   }
 }

--- a/src/ZoneTree/Compression/ZstdDataCompression.cs
+++ b/src/ZoneTree/Compression/ZstdDataCompression.cs
@@ -18,13 +18,6 @@ public static class ZstdDataCompression
     return compressed.AsMemory(0, compressedLength);
   }
 
-  public static byte[] Decompress(Memory<byte> compressedBytes)
-  {
-    var decompressedLength = checked((int)Decompressor
-        .GetDecompressedSize(compressedBytes.Span));
-    return Decompress(compressedBytes, decompressedLength);
-  }
-
   public static byte[] Decompress(Memory<byte> compressedBytes, int decompressedLength)
   {
     var decompressed = new byte[decompressedLength];

--- a/src/ZoneTree/Compression/ZstdDataCompression.cs
+++ b/src/ZoneTree/Compression/ZstdDataCompression.cs
@@ -1,4 +1,4 @@
-using ZstdNet;
+using ZstdSharp;
 
 namespace ZoneTree.Compression;
 
@@ -6,8 +6,7 @@ public static class ZstdDataCompression
 {
   public static Memory<byte> Compress(Memory<byte> bytes, int level)
   {
-    using var options = new CompressionOptions(level);
-    using var compressor = new Compressor(options);
+    using var compressor = new Compressor(level);
     return compressor.Wrap(bytes.Span).ToArray();
   }
 
@@ -21,7 +20,7 @@ public static class ZstdDataCompression
   {
     var decompressed = new byte[decompressedLength];
     using var decompressor = new Decompressor();
-    decompressor.Unwrap(compressedBytes.Span, decompressed, 0);
+    decompressor.Unwrap(compressedBytes.Span, decompressed.AsSpan());
     return decompressed;
   }
 }

--- a/src/ZoneTree/Compression/ZstdDataCompression.cs
+++ b/src/ZoneTree/Compression/ZstdDataCompression.cs
@@ -22,10 +22,10 @@ public static class ZstdDataCompression
   {
     var decompressedLength = checked((int)Decompressor
         .GetDecompressedSize(compressedBytes.Span));
-    return DecompressFast(compressedBytes, decompressedLength);
+    return Decompress(compressedBytes, decompressedLength);
   }
 
-  public static byte[] DecompressFast(Memory<byte> compressedBytes, int decompressedLength)
+  public static byte[] Decompress(Memory<byte> compressedBytes, int decompressedLength)
   {
     var decompressed = new byte[decompressedLength];
     var decompressor = GetDecompressor();

--- a/src/ZoneTree/Compression/ZstdDataCompression.cs
+++ b/src/ZoneTree/Compression/ZstdDataCompression.cs
@@ -4,23 +4,56 @@ namespace ZoneTree.Compression;
 
 public static class ZstdDataCompression
 {
+  [ThreadStatic]
+  static Compressor ThreadCompressor;
+
+  [ThreadStatic]
+  static Decompressor ThreadDecompressor;
+
   public static Memory<byte> Compress(Memory<byte> bytes, int level)
   {
-    using var compressor = new Compressor(level);
-    return compressor.Wrap(bytes.Span).ToArray();
+    var compressor = GetCompressor(level);
+    var compressed = new byte[Compressor.GetCompressBound(bytes.Length)];
+    var compressedLength = compressor.Wrap(bytes.Span, compressed.AsSpan());
+    return compressed.AsMemory(0, compressedLength);
   }
 
   public static byte[] Decompress(Memory<byte> compressedBytes)
   {
-    using var decompressor = new Decompressor();
-    return decompressor.Unwrap(compressedBytes.Span).ToArray();
+    var decompressedLength = checked((int)Decompressor
+        .GetDecompressedSize(compressedBytes.Span));
+    return DecompressFast(compressedBytes, decompressedLength);
   }
 
   public static byte[] DecompressFast(Memory<byte> compressedBytes, int decompressedLength)
   {
     var decompressed = new byte[decompressedLength];
-    using var decompressor = new Decompressor();
+    var decompressor = GetDecompressor();
     decompressor.Unwrap(compressedBytes.Span, decompressed.AsSpan());
     return decompressed;
+  }
+
+  static Compressor GetCompressor(int level)
+  {
+    var compressor = ThreadCompressor;
+    if (compressor == null)
+    {
+      compressor = new Compressor(level);
+      ThreadCompressor = compressor;
+      return compressor;
+    }
+    compressor.Level = level;
+    return compressor;
+  }
+
+  static Decompressor GetDecompressor()
+  {
+    var decompressor = ThreadDecompressor;
+    if (decompressor == null)
+    {
+      decompressor = new Decompressor();
+      ThreadDecompressor = decompressor;
+    }
+    return decompressor;
   }
 }

--- a/src/ZoneTree/Segments/Block/DecompressedBlock.cs
+++ b/src/ZoneTree/Segments/Block/DecompressedBlock.cs
@@ -84,7 +84,7 @@ public sealed class DecompressedBlock
       int decompressedLength)
   {
     var decompressed = DataCompression
-        .DecompressFast(method, compressedBytes, decompressedLength);
+        .Decompress(method, compressedBytes, decompressedLength);
     return new DecompressedBlock(blockIndex, decompressed, method, compressionLevel);
   }
 

--- a/src/ZoneTree/Segments/MultiPart/MultiPartMetadataCodec.cs
+++ b/src/ZoneTree/Segments/MultiPart/MultiPartMetadataCodec.cs
@@ -62,10 +62,12 @@ internal static class MultiPartMetadataCodec
   public static Memory<byte> Decode(Memory<byte> bytes)
   {
     if (!HasEnvelope(bytes))
-      return DataCompression.Decompress(CompressionMethod.LZ4, bytes);
+      return LZ4DataCompression.Decompress(
+          bytes,
+          LZ4DataCompression.GetDecompressedLength(bytes));
 
     var envelope = ReadEnvelope(bytes);
-    return DataCompression.DecompressFast(
+    return DataCompression.Decompress(
         envelope.Method,
         envelope.Payload,
         envelope.DecompressedLength);

--- a/src/ZoneTree/Segments/MultiPart/MultiPartMetadataCodec.cs
+++ b/src/ZoneTree/Segments/MultiPart/MultiPartMetadataCodec.cs
@@ -15,9 +15,19 @@ internal static class MultiPartMetadataCodec
   const byte Version = 1;
 
   const int PrefixSize =
-      MagicSize + sizeof(byte) + sizeof(byte) + sizeof(int) + sizeof(int);
+      MagicSize +
+      sizeof(byte) +
+      sizeof(byte) +
+      sizeof(int) +
+      sizeof(int) +
+      sizeof(int);
 
   static ReadOnlySpan<byte> Magic => "ZoneTreeMPH-v001"u8;
+
+  readonly record struct Envelope(
+      CompressionMethod Method,
+      Memory<byte> Payload,
+      int DecompressedLength);
 
   public static Memory<byte> Encode(Memory<byte> bytes)
   {
@@ -41,6 +51,10 @@ internal static class MultiPartMetadataCodec
         span.Slice(offset, sizeof(int)),
         payload.Length);
     offset += sizeof(int);
+    BinaryPrimitives.WriteInt32LittleEndian(
+        span.Slice(offset, sizeof(int)),
+        bytes.Length);
+    offset += sizeof(int);
     payload.Span.CopyTo(span[offset..]);
     return result;
   }
@@ -50,8 +64,11 @@ internal static class MultiPartMetadataCodec
     if (!HasEnvelope(bytes))
       return DataCompression.Decompress(CompressionMethod.LZ4, bytes);
 
-    var (method, payload) = ReadEnvelope(bytes);
-    return DataCompression.Decompress(method, payload);
+    var envelope = ReadEnvelope(bytes);
+    return DataCompression.DecompressFast(
+        envelope.Method,
+        envelope.Payload,
+        envelope.DecompressedLength);
   }
 
   static bool HasEnvelope(Memory<byte> bytes)
@@ -62,8 +79,7 @@ internal static class MultiPartMetadataCodec
     return bytes.Span[..MagicSize].SequenceEqual(Magic);
   }
 
-  static (CompressionMethod method, Memory<byte> payload) ReadEnvelope(
-      Memory<byte> bytes)
+  static Envelope ReadEnvelope(Memory<byte> bytes)
   {
     if (bytes.Length < PrefixSize)
       throw new InvalidDataException("Multipart metadata envelope is incomplete.");
@@ -86,10 +102,19 @@ internal static class MultiPartMetadataCodec
     var payloadLength = BinaryPrimitives.ReadInt32LittleEndian(
         span.Slice(offset, sizeof(int)));
     offset += sizeof(int);
+    var decompressedLength = BinaryPrimitives.ReadInt32LittleEndian(
+        span.Slice(offset, sizeof(int)));
+    offset += sizeof(int);
     if (payloadLength < 0 || payloadLength != span.Length - offset)
       throw new InvalidDataException(
           "Multipart metadata envelope payload length is invalid.");
+    if (decompressedLength < 0)
+      throw new InvalidDataException(
+          "Multipart metadata envelope decompressed length is invalid.");
 
-    return (method, bytes.Slice(offset, payloadLength));
+    return new Envelope(
+        method,
+        bytes.Slice(offset, payloadLength),
+        decompressedLength);
   }
 }

--- a/src/ZoneTree/ZoneTree.csproj
+++ b/src/ZoneTree/ZoneTree.csproj
@@ -46,6 +46,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="ZstdNet" Version="1.5.7" />
+    <PackageReference Include="ZstdSharp.Port" Version="0.8.8" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

Improves ZoneTree compression internals after switching the default compression path to Zstd.

## Changes

- Replaced `ZstdNet` with `ZstdSharp.Port` to avoid native runtime dependency issues.
- Optimized Zstd compression by reusing per-thread contexts and avoiding an extra compression copy.
- Renamed known-length decompression API to `Decompress(...)` and removed unknown-length generic decompression.
- Removed unused unknown-length codec decompression overloads.
- Optimized Brotli with span-based `BrotliEncoder` / `BrotliDecoder` APIs.
- Improved GZip compression finalization and buffer sizing.
- Updated live backup and multipart metadata to use known-length decompression.
- Added decompressed length to multipart metadata envelopes.
- Kept legacy multipart metadata compatible using LZ4 pickled-size discovery.
