### PR TITLE
Add disk iterator prefetch support

### DIFF
--- a/src/ZoneTree.UnitTests/ExceptionlessTransactionTests.cs
+++ b/src/ZoneTree.UnitTests/ExceptionlessTransactionTests.cs
@@ -91,12 +91,12 @@ public sealed class ExceptionlessTransactionTests
           .Do((tx) => zoneTree.UpsertNoThrow(tx, 3, 9))
           .Do((tx) =>
           {
-          if (zoneTree.TryGetNoThrow(tx, 3, out var value).IsAborted)
-            return TransactionResult.Aborted();
-          if (zoneTree.UpsertNoThrow(tx, 3, 9).IsAborted)
-            return TransactionResult.Aborted();
-          return TransactionResult.Success();
-        })
+            if (zoneTree.TryGetNoThrow(tx, 3, out var value).IsAborted)
+              return TransactionResult.Aborted();
+            if (zoneTree.UpsertNoThrow(tx, 3, 9).IsAborted)
+              return TransactionResult.Aborted();
+            return TransactionResult.Success();
+          })
           .SetRetryCountForPendingTransactions(100)
           .SetRetryCountForAbortedTransactions(10);
       await transaction.CommitAsync();

--- a/src/ZoneTree.UnitTests/IteratorTests.cs
+++ b/src/ZoneTree.UnitTests/IteratorTests.cs
@@ -479,6 +479,67 @@ public sealed class IteratorTests
     zoneTree.Maintenance.Drop();
   }
 
+  [TestCase(DiskSegmentMode.SingleDiskSegment)]
+  [TestCase(DiskSegmentMode.MultiPartDiskSegment)]
+  public void PrefetchingDiskIteratorScansFixedSizeKeyAndValueSegment(DiskSegmentMode diskSegmentMode)
+  {
+    AssertPrefetchingDiskIteratorScans(
+        "FixedSizeKeyAndValue",
+        diskSegmentMode,
+        i => i,
+        i => i * 10,
+        factory => factory.DisableDeletion(),
+        Comparer<int>.Default);
+  }
+
+  [TestCase(DiskSegmentMode.SingleDiskSegment)]
+  [TestCase(DiskSegmentMode.MultiPartDiskSegment)]
+  public void PrefetchingDiskIteratorScansFixedSizeKeySegment(DiskSegmentMode diskSegmentMode)
+  {
+    AssertPrefetchingDiskIteratorScans(
+        "FixedSizeKey",
+        diskSegmentMode,
+        i => i,
+        i => "value-" + i.ToString("D4"),
+        factory => factory
+            .DisableDeletion()
+            .SetValueSerializer(new Utf8StringSerializer()),
+        Comparer<int>.Default);
+  }
+
+  [TestCase(DiskSegmentMode.SingleDiskSegment)]
+  [TestCase(DiskSegmentMode.MultiPartDiskSegment)]
+  public void PrefetchingDiskIteratorScansFixedSizeValueSegment(DiskSegmentMode diskSegmentMode)
+  {
+    AssertPrefetchingDiskIteratorScans(
+        "FixedSizeValue",
+        diskSegmentMode,
+        i => "key-" + i.ToString("D4"),
+        i => i * 10,
+        factory => factory
+            .DisableDeletion()
+            .SetComparer(new StringOrdinalComparerAscending())
+            .SetKeySerializer(new Utf8StringSerializer()),
+        StringComparer.Ordinal);
+  }
+
+  [TestCase(DiskSegmentMode.SingleDiskSegment)]
+  [TestCase(DiskSegmentMode.MultiPartDiskSegment)]
+  public void PrefetchingDiskIteratorScansVariableSizeSegment(DiskSegmentMode diskSegmentMode)
+  {
+    AssertPrefetchingDiskIteratorScans(
+        "VariableSize",
+        diskSegmentMode,
+        i => "key-" + i.ToString("D4"),
+        i => "value-" + i.ToString("D4"),
+        factory => factory
+            .DisableDeletion()
+            .SetComparer(new StringOrdinalComparerAscending())
+            .SetKeySerializer(new Utf8StringSerializer())
+            .SetValueSerializer(new Utf8StringSerializer()),
+        StringComparer.Ordinal);
+  }
+
   [TestCase(true, DiskSegmentMode.SingleDiskSegment, 0, 0)]
   [TestCase(false, DiskSegmentMode.SingleDiskSegment, 0, 0)]
   [TestCase(true, DiskSegmentMode.MultiPartDiskSegment, 0, 0)]
@@ -553,6 +614,94 @@ public sealed class IteratorTests
     }
     list.Sort((a, b) => string.Compare(a.Item1, b.Item1, StringComparison.CurrentCulture));
     return list;
+  }
+
+  static void AssertPrefetchingDiskIteratorScans<TKey, TValue>(
+      string name,
+      DiskSegmentMode diskSegmentMode,
+      Func<int, TKey> keyFactory,
+      Func<int, TValue> valueFactory,
+      Func<ZoneTreeFactory<TKey, TValue>, ZoneTreeFactory<TKey, TValue>> configureFactory,
+      IComparer<TKey> expectedComparer)
+  {
+    var dataPath = "data/PrefetchingDiskIteratorScans" + name + diskSegmentMode;
+    if (Directory.Exists(dataPath))
+      Directory.Delete(dataPath, true);
+
+    const int recordCount = 37;
+    var expected = new List<KeyValuePair<TKey, TValue>>(recordCount);
+
+    using var zoneTree = configureFactory(new ZoneTreeFactory<TKey, TValue>())
+        .Configure(options => options.AllowUnsafeOptionValues = true)
+        .SetMutableSegmentMaxItemCount(5)
+        .SetDataDirectory(dataPath)
+        .SetWriteAheadLogDirectory(dataPath)
+        .ConfigureWriteAheadLogOptions(options =>
+            options.WriteAheadLogMode = WriteAheadLogMode.None)
+        .ConfigureDiskSegmentOptions(options =>
+        {
+          options.DiskSegmentMode = diskSegmentMode;
+          if (diskSegmentMode == DiskSegmentMode.MultiPartDiskSegment)
+          {
+            options.MinimumRecordCount = 3;
+            options.MaximumRecordCount = 5;
+          }
+        })
+        .OpenOrCreate();
+
+    for (var i = 0; i < recordCount; ++i)
+    {
+      var key = keyFactory(i);
+      var value = valueFactory(i);
+      expected.Add(KeyValuePair.Create(key, value));
+      zoneTree.Upsert(key, value);
+    }
+
+    zoneTree.Maintenance.MoveMutableSegmentForward();
+    zoneTree.Maintenance.StartMergeOperation().Join();
+    expected.Sort((x, y) => expectedComparer.Compare(x.Key, y.Key));
+
+    var iteratorOptions = new IteratorOptions
+    {
+      IteratorType = IteratorType.NoRefresh,
+      DiskSegmentPrefetchSize = 3
+    };
+
+    using (var iterator = zoneTree.CreateIterator(iteratorOptions))
+    {
+      for (var i = 0; i < expected.Count; ++i)
+      {
+        Assert.That(iterator.Next(), Is.True);
+        Assert.That(iterator.CurrentKey, Is.EqualTo(expected[i].Key));
+        Assert.That(iterator.CurrentValue, Is.EqualTo(expected[i].Value));
+      }
+      Assert.That(iterator.Next(), Is.False);
+    }
+
+    using (var iterator = zoneTree.CreateIterator(iteratorOptions))
+    {
+      iterator.Seek(expected[10].Key);
+      for (var i = 10; i < expected.Count; ++i)
+      {
+        Assert.That(iterator.Next(), Is.True);
+        Assert.That(iterator.CurrentKey, Is.EqualTo(expected[i].Key));
+        Assert.That(iterator.CurrentValue, Is.EqualTo(expected[i].Value));
+      }
+      Assert.That(iterator.Next(), Is.False);
+    }
+
+    using (var reverseIterator = zoneTree.CreateReverseIterator(iteratorOptions))
+    {
+      for (var i = expected.Count - 1; i >= 0; --i)
+      {
+        Assert.That(reverseIterator.Next(), Is.True);
+        Assert.That(reverseIterator.CurrentKey, Is.EqualTo(expected[i].Key));
+        Assert.That(reverseIterator.CurrentValue, Is.EqualTo(expected[i].Value));
+      }
+      Assert.That(reverseIterator.Next(), Is.False);
+    }
+
+    zoneTree.Maintenance.Drop();
   }
 
   [TestCase(true, DiskSegmentMode.SingleDiskSegment, 0, 0)]

--- a/src/ZoneTree.UnitTests/IteratorTests.cs
+++ b/src/ZoneTree.UnitTests/IteratorTests.cs
@@ -258,9 +258,9 @@ public sealed class IteratorTests
     {
       Parallel.For(0, insertCount, (x) =>
           {
-          var key = random.Next();
-          zoneTree.Upsert(key, key + key);
-        });
+            var key = random.Next();
+            zoneTree.Upsert(key, key + key);
+          });
     });
     Parallel.For(0, iteratorCount, (x) =>
     {
@@ -311,9 +311,9 @@ public sealed class IteratorTests
     {
       Parallel.For(0, insertCount, (x) =>
           {
-          var key = random.Next(0, 100_000);
-          zoneTree.Upsert(key, key + key);
-        });
+            var key = random.Next(0, 100_000);
+            zoneTree.Upsert(key, key + key);
+          });
     });
     Parallel.For(0, iteratorCount, (x) =>
     {
@@ -370,8 +370,8 @@ public sealed class IteratorTests
     {
       Parallel.For(0, insertCount, (x) =>
           {
-          zoneTree.Upsert(x, x + x);
-        });
+            zoneTree.Upsert(x, x + x);
+          });
     });
     Parallel.For(0, iteratorCount, (x) =>
     {

--- a/src/ZoneTree.UnitTests/ReplicatorTests.cs
+++ b/src/ZoneTree.UnitTests/ReplicatorTests.cs
@@ -37,9 +37,9 @@ public sealed class ReplicatorTests
         var opIndex = zoneTree.Upsert(key, value);
         Task.Run(() =>
               {
-            replicator.OnUpsert(key, value, opIndex);
-            Interlocked.Increment(ref replicated);
-          });
+                replicator.OnUpsert(key, value, opIndex);
+                Interlocked.Increment(ref replicated);
+              });
       });
       while (replicated < recordCount) Task.Delay(500).Wait();
       maintainer1.EvictToDisk();
@@ -116,9 +116,9 @@ public sealed class ReplicatorTests
           var opIndex = zoneTree.Upsert(key, value);
           Task.Run(() =>
                   {
-              replicator.OnUpsert(key, value, opIndex);
-              Interlocked.Increment(ref replicated);
-            });
+                    replicator.OnUpsert(key, value, opIndex);
+                    Interlocked.Increment(ref replicated);
+                  });
         });
         while (replicated < recordCount) Task.Delay(500).Wait();
         maintainer1.EvictToDisk();

--- a/src/ZoneTree.UnitTests/SafeBplusTreeTests.cs
+++ b/src/ZoneTree.UnitTests/SafeBplusTreeTests.cs
@@ -146,17 +146,17 @@ public sealed class SafeBTreeTests
     {
       Parallel.For(0, insertCount, (x) =>
           {
-          var key = random.Next();
-          tree.AddOrUpdate(key,
-                  void (ref int value) =>
-                  {
-                  value = key + key;
-                },
-                  void (ref int value) =>
-                  {
-                  value = key + key;
-                }, out _);
-        });
+            var key = random.Next();
+            tree.AddOrUpdate(key,
+                    void (ref int value) =>
+                    {
+                      value = key + key;
+                    },
+                    void (ref int value) =>
+                    {
+                      value = key + key;
+                    }, out _);
+          });
     });
     Thread.Sleep(100);
     Parallel.For(0, iteratorCount, (x) =>
@@ -199,17 +199,17 @@ public sealed class SafeBTreeTests
     {
       Parallel.For(0, insertCount, (x) =>
           {
-          var key = random.Next();
-          tree.AddOrUpdate(key,
-                  void (ref int x) =>
-                  {
-                  x = key + key;
-                },
-                  void (ref int y) =>
-                  {
-                  y = key + key;
-                }, out _);
-        });
+            var key = random.Next();
+            tree.AddOrUpdate(key,
+                    void (ref int x) =>
+                    {
+                      x = key + key;
+                    },
+                    void (ref int y) =>
+                    {
+                      y = key + key;
+                    }, out _);
+          });
     });
     Parallel.For(0, iteratorCount, (x) =>
     {
@@ -258,9 +258,9 @@ public sealed class SafeBTreeTests
     {
       Parallel.For(0, insertCount, (x) =>
           {
-          var key = random.Next(0, 100000);
-          tree.Upsert(key, key + key, out _);
-        });
+            var key = random.Next(0, 100000);
+            tree.Upsert(key, key + key, out _);
+          });
     });
 
     Parallel.For(0, iteratorCount, (x) =>
@@ -302,9 +302,9 @@ public sealed class SafeBTreeTests
     {
       Parallel.For(0, insertCount, (x) =>
           {
-          var key = random.Next(0, 100000);
-          tree.Upsert(key, key + key, out _);
-        });
+            var key = random.Next(0, 100000);
+            tree.Upsert(key, key + key, out _);
+          });
     });
 
     Parallel.For(0, iteratorCount, (x) =>

--- a/src/ZoneTree/Collections/PrefetchingSeekableIterator.cs
+++ b/src/ZoneTree/Collections/PrefetchingSeekableIterator.cs
@@ -1,0 +1,164 @@
+using ZoneTree.Segments.Block;
+
+namespace ZoneTree.Collections;
+
+public delegate int ReadEntriesDelegate<TKey, TValue>(
+    long startIndex,
+    int count,
+    TKey[] keys,
+    TValue[] values,
+    int destinationIndex,
+    BlockPin blockPin);
+
+public sealed class PrefetchingSeekableIterator<TKey, TValue> : ISeekableIterator<TKey, TValue>
+{
+  readonly IIndexedReader<TKey, TValue> IndexedReader;
+
+  readonly ReadEntriesDelegate<TKey, TValue> ReadEntries;
+
+  readonly long Length;
+
+  readonly int PrefetchSize;
+
+  readonly BlockPin blockPin = new();
+
+  readonly TKey[] keys;
+
+  readonly TValue[] values;
+
+  long position = -1;
+
+  long bufferStart = -1;
+
+  int bufferLength;
+
+  bool fillBackwards;
+
+  public TKey CurrentKey
+  {
+    get
+    {
+      EnsureHasCurrent();
+      EnsureBufferContainsPosition();
+      return keys[(int)(position - bufferStart)];
+    }
+  }
+
+  public TValue CurrentValue
+  {
+    get
+    {
+      EnsureHasCurrent();
+      EnsureBufferContainsPosition();
+      return values[(int)(position - bufferStart)];
+    }
+  }
+
+  public bool HasCurrent => position >= 0 && position < Length;
+
+  public bool IsBeginningOfAPart => IndexedReader.IsBeginningOfAPart(position);
+
+  public bool IsEndOfAPart => IndexedReader.IsEndOfAPart(position);
+
+  /// <summary>
+  /// All Indexed Readers are always fully frozen.
+  /// </summary>
+  public bool IsFullyFrozen => true;
+
+  public PrefetchingSeekableIterator(
+      IIndexedReader<TKey, TValue> indexedReader,
+      ReadEntriesDelegate<TKey, TValue> readEntries,
+      int prefetchSize,
+      bool contributeToTheBlockCache = false)
+  {
+    IndexedReader = indexedReader;
+    ReadEntries = readEntries;
+    Length = indexedReader.Length;
+    PrefetchSize = prefetchSize;
+    keys = new TKey[prefetchSize];
+    values = new TValue[prefetchSize];
+    blockPin.ContributeToTheBlockCache = contributeToTheBlockCache;
+  }
+
+  public bool Next()
+  {
+    if (position >= Length - 1)
+      return false;
+    ++position;
+    fillBackwards = false;
+    return true;
+  }
+
+  public bool Prev()
+  {
+    if (position < 1)
+      return false;
+    --position;
+    fillBackwards = true;
+    return true;
+  }
+
+  public bool SeekBegin()
+  {
+    position = 0;
+    fillBackwards = false;
+    return HasCurrent;
+  }
+
+  public bool SeekEnd()
+  {
+    position = Length - 1;
+    fillBackwards = true;
+    return HasCurrent;
+  }
+
+  public bool SeekToLastSmallerOrEqualElement(in TKey key)
+  {
+    position = IndexedReader.GetLastSmallerOrEqualPosition(key);
+    fillBackwards = true;
+    return HasCurrent;
+  }
+
+  public bool SeekToFirstGreaterOrEqualElement(in TKey key)
+  {
+    position = IndexedReader.GetFirstGreaterOrEqualPosition(key);
+    fillBackwards = false;
+    return HasCurrent;
+  }
+
+  public void Skip(long offset)
+  {
+    position += offset;
+    fillBackwards = offset < 0;
+  }
+
+  public int GetPartIndex() => IndexedReader.GetPartIndex(position);
+
+  void EnsureHasCurrent()
+  {
+    if (!HasCurrent)
+      throw new IndexOutOfRangeException("Iterator is not in a valid position. Have you forgotten to call Next() or Prev()?");
+  }
+
+  void EnsureBufferContainsPosition()
+  {
+    if (position >= bufferStart && position < bufferStart + bufferLength)
+      return;
+
+    var start = fillBackwards
+        ? Math.Max(0, position - PrefetchSize + 1)
+        : position;
+    var count = (int)Math.Min(PrefetchSize, Length - start);
+    bufferLength = ReadEntries(
+        start,
+        count,
+        keys,
+        values,
+        0,
+        blockPin);
+    bufferStart = start;
+
+    if (position < bufferStart || position >= bufferStart + bufferLength)
+      throw new IndexOutOfRangeException("Iterator is not in a valid position.");
+  }
+}

--- a/src/ZoneTree/Core/ZoneTree.Iterators.cs
+++ b/src/ZoneTree/Core/ZoneTree.Iterators.cs
@@ -1,4 +1,5 @@
 using ZoneTree.Collections;
+using ZoneTree.Options;
 using ZoneTree.Segments;
 using ZoneTree.Segments.NullDisk;
 
@@ -10,7 +11,8 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
       bool includeMutableSegment,
       bool includeDiskSegment,
       bool includeBottomSegments,
-      bool contributeToTheBlockCache)
+      bool contributeToTheBlockCache,
+      int diskSegmentPrefetchSize)
   {
     lock (ShortMergerLock)
       lock (AtomicUpdateLock)
@@ -35,7 +37,9 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
           {
             diskSegment.AttachIterator();
             result.DiskSegment = diskSegment;
-            seekableIterators.Add(diskSegment.GetSeekableIterator(contributeToTheBlockCache));
+            seekableIterators.Add(diskSegment.GetSeekableIterator(
+                contributeToTheBlockCache,
+                diskSegmentPrefetchSize));
           }
         }
 
@@ -45,7 +49,9 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
           foreach (var bottom in bottomSegments)
           {
             bottom.AttachIterator();
-            seekableIterators.Add(bottom.GetSeekableIterator(contributeToTheBlockCache));
+            seekableIterators.Add(bottom.GetSeekableIterator(
+                contributeToTheBlockCache,
+                diskSegmentPrefetchSize));
           }
           result.BottomSegments = bottomSegments;
         }
@@ -189,6 +195,32 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
   public IZoneTreeIterator<TKey, TValue> CreateIterator(
       IteratorType iteratorType, bool includeDeletedRecords, bool contributeToTheBlockCache)
   {
+    return CreateIterator(
+        iteratorType,
+        includeDeletedRecords,
+        contributeToTheBlockCache,
+        IteratorDefaultValues.DiskSegmentPrefetchSize);
+  }
+
+  public IZoneTreeIterator<TKey, TValue> CreateIterator(
+      IteratorType iteratorType,
+      bool includeDeletedRecords,
+      bool contributeToTheBlockCache,
+      int diskSegmentPrefetchSize)
+  {
+    return CreateIterator(new IteratorOptions
+    {
+      IteratorType = iteratorType,
+      IncludeDeletedRecords = includeDeletedRecords,
+      ContributeToTheBlockCache = contributeToTheBlockCache,
+      DiskSegmentPrefetchSize = diskSegmentPrefetchSize
+    });
+  }
+
+  public IZoneTreeIterator<TKey, TValue> CreateIterator(IteratorOptions iteratorOptions)
+  {
+    ArgumentNullException.ThrowIfNull(iteratorOptions);
+    var iteratorType = iteratorOptions.IteratorType;
     var includeMutableSegment = iteratorType is not IteratorType.Snapshot and
         not IteratorType.ReadOnlyRegion;
 
@@ -198,11 +230,12 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
         MinHeapEntryComparer,
         autoRefresh: iteratorType == IteratorType.AutoRefresh,
         isReverseIterator: false,
-        includeDeletedRecords,
+        iteratorOptions.IncludeDeletedRecords,
         includeMutableSegment: includeMutableSegment,
         includeDiskSegment: true,
-        includeBottomSegments: true);
-    iterator.ContributeToTheBlockCache = contributeToTheBlockCache;
+        includeBottomSegments: true,
+        iteratorOptions.DiskSegmentPrefetchSize);
+    iterator.ContributeToTheBlockCache = iteratorOptions.ContributeToTheBlockCache;
 
     if (iteratorType == IteratorType.Snapshot)
     {
@@ -221,6 +254,32 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
   public IZoneTreeIterator<TKey, TValue> CreateReverseIterator(
       IteratorType iteratorType, bool includeDeletedRecords, bool contributeToTheBlockCache)
   {
+    return CreateReverseIterator(
+        iteratorType,
+        includeDeletedRecords,
+        contributeToTheBlockCache,
+        IteratorDefaultValues.DiskSegmentPrefetchSize);
+  }
+
+  public IZoneTreeIterator<TKey, TValue> CreateReverseIterator(
+      IteratorType iteratorType,
+      bool includeDeletedRecords,
+      bool contributeToTheBlockCache,
+      int diskSegmentPrefetchSize)
+  {
+    return CreateReverseIterator(new IteratorOptions
+    {
+      IteratorType = iteratorType,
+      IncludeDeletedRecords = includeDeletedRecords,
+      ContributeToTheBlockCache = contributeToTheBlockCache,
+      DiskSegmentPrefetchSize = diskSegmentPrefetchSize
+    });
+  }
+
+  public IZoneTreeIterator<TKey, TValue> CreateReverseIterator(IteratorOptions iteratorOptions)
+  {
+    ArgumentNullException.ThrowIfNull(iteratorOptions);
+    var iteratorType = iteratorOptions.IteratorType;
     var includeMutableSegment = iteratorType is not IteratorType.Snapshot and
         not IteratorType.ReadOnlyRegion;
 
@@ -230,12 +289,13 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
         MaxHeapEntryComparer,
         autoRefresh: iteratorType == IteratorType.AutoRefresh,
         isReverseIterator: true,
-        includeDeletedRecords,
+        iteratorOptions.IncludeDeletedRecords,
         includeMutableSegment: includeMutableSegment,
         includeDiskSegment: true,
-        includeBottomSegments: true);
+        includeBottomSegments: true,
+        iteratorOptions.DiskSegmentPrefetchSize);
 
-    iterator.ContributeToTheBlockCache = contributeToTheBlockCache;
+    iterator.ContributeToTheBlockCache = iteratorOptions.ContributeToTheBlockCache;
 
     if (iteratorType == IteratorType.Snapshot)
     {
@@ -267,7 +327,8 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
         includeDeletedRecords,
         includeMutableSegment: false,
         includeDiskSegment: false,
-        includeBottomSegments: false);
+        includeBottomSegments: false,
+        diskSegmentPrefetchSize: 0);
     return iterator;
   }
 
@@ -290,7 +351,8 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
         includeDeletedRecords,
         includeMutableSegment: true,
         includeDiskSegment: false,
-        includeBottomSegments: false);
+        includeBottomSegments: false,
+        diskSegmentPrefetchSize: 0);
     return iterator;
   }
 }

--- a/src/ZoneTree/Core/ZoneTreeIterator.cs
+++ b/src/ZoneTree/Core/ZoneTreeIterator.cs
@@ -32,6 +32,8 @@ public sealed class ZoneTreeIterator<TKey, TValue> : IZoneTreeIterator<TKey, TVa
 
   readonly bool IncludeBottomSegments;
 
+  readonly int DiskSegmentPrefetchSize;
+
   int Length;
 
   bool HasPrev;
@@ -85,7 +87,8 @@ public sealed class ZoneTreeIterator<TKey, TValue> : IZoneTreeIterator<TKey, TVa
       bool includeDeletedRecords,
       bool includeMutableSegment,
       bool includeDiskSegment,
-      bool includeBottomSegments)
+      bool includeBottomSegments,
+      int diskSegmentPrefetchSize)
   {
     IsDeleted = options.IsDeleted;
     Comparer = options.Comparer;
@@ -96,6 +99,7 @@ public sealed class ZoneTreeIterator<TKey, TValue> : IZoneTreeIterator<TKey, TVa
     IncludeDeletedRecords = includeDeletedRecords;
     IncludeMutableSegment = includeMutableSegment;
     IncludeDiskSegment = includeDiskSegment;
+    DiskSegmentPrefetchSize = diskSegmentPrefetchSize;
     if (autoRefresh)
       ZoneTree.OnMutableSegmentMovedForward += OnZoneTreeMutableSegmentMovedForward;
     ZoneTree.OnZoneTreeIsDisposing += OnZoneTreeIsDisposing;
@@ -246,7 +250,8 @@ public sealed class ZoneTreeIterator<TKey, TValue> : IZoneTreeIterator<TKey, TVa
             IncludeMutableSegment,
             IncludeDiskSegment,
             IncludeBottomSegments,
-            ContributeToTheBlockCache);
+            ContributeToTheBlockCache,
+            DiskSegmentPrefetchSize);
     DiskSegment = segments.DiskSegment;
     BottomSegments = segments.BottomSegments;
     SeekableIterators = segments.SeekableIterators;

--- a/src/ZoneTree/Directory.Build.props
+++ b/src/ZoneTree/Directory.Build.props
@@ -5,8 +5,8 @@
     <Authors>Ahmed Yasin Koculu</Authors>
     <PackageId>ZoneTree</PackageId>
     <Title>ZoneTree</Title>
-    <ProductVersion>1.9.3.0</ProductVersion>
-    <Version>1.9.3.0</Version>
+    <ProductVersion>1.9.4.0</ProductVersion>
+    <Version>1.9.4.0</Version>
     <AssemblyTitle>ZoneTree</AssemblyTitle>
     <Description>ZoneTree is a persistent, high-performance, transactional, ACID-compliant ordered key-value database and LSM-tree storage engine for .NET.</Description>
     <Summary>

--- a/src/ZoneTree/IZoneTree.cs
+++ b/src/ZoneTree/IZoneTree.cs
@@ -264,6 +264,32 @@ public interface IZoneTree<TKey, TValue> : IDisposable
       bool contributeToTheBlockCache = false);
 
   /// <summary>
+  /// Creates an iterator that enables scanning of the entire database.
+  /// </summary>
+  /// <param name="iteratorType">Defines iterator type.</param>
+  /// <param name="includeDeletedRecords">if true the iterator retrieves
+  /// the deleted and normal records.</param>
+  /// <param name="contributeToTheBlockCache">if true the iterator disk segment reads
+  /// contributes to the block cache.</param>
+  /// <param name="diskSegmentPrefetchSize">The number of sequential disk-segment
+  /// records the iterator may prefetch at once. Values less than two disable
+  /// prefetching.</param>
+  /// <returns>ZoneTree Iterator</returns>
+  IZoneTreeIterator<TKey, TValue> CreateIterator(
+      IteratorType iteratorType,
+      bool includeDeletedRecords,
+      bool contributeToTheBlockCache,
+      int diskSegmentPrefetchSize);
+
+  /// <summary>
+  /// Creates an iterator that enables scanning of the entire database.
+  /// </summary>
+  /// <param name="iteratorOptions">Runtime iterator options.</param>
+  /// <returns>ZoneTree Iterator</returns>
+  IZoneTreeIterator<TKey, TValue> CreateIterator(
+      IteratorOptions iteratorOptions);
+
+  /// <summary>
   /// Creates a reverse iterator that enables scanning of the entire database.
   /// </summary>
   ///
@@ -283,6 +309,32 @@ public interface IZoneTree<TKey, TValue> : IDisposable
       IteratorType iteratorType = IteratorType.AutoRefresh,
       bool includeDeletedRecords = false,
       bool contributeToTheBlockCache = false);
+
+  /// <summary>
+  /// Creates a reverse iterator that enables scanning of the entire database.
+  /// </summary>
+  /// <param name="iteratorType">Defines iterator type.</param>
+  /// <param name="includeDeletedRecords">if true the iterator retrieves
+  /// the deleted and normal records.</param>
+  /// <param name="contributeToTheBlockCache">if true the iterator disk segment reads
+  /// contributes to the block cache.</param>
+  /// <param name="diskSegmentPrefetchSize">The number of sequential disk-segment
+  /// records the iterator may prefetch at once. Values less than two disable
+  /// prefetching.</param>
+  /// <returns>ZoneTree Iterator</returns>
+  IZoneTreeIterator<TKey, TValue> CreateReverseIterator(
+      IteratorType iteratorType,
+      bool includeDeletedRecords,
+      bool contributeToTheBlockCache,
+      int diskSegmentPrefetchSize);
+
+  /// <summary>
+  /// Creates a reverse iterator that enables scanning of the entire database.
+  /// </summary>
+  /// <param name="iteratorOptions">Runtime iterator options.</param>
+  /// <returns>ZoneTree Iterator</returns>
+  IZoneTreeIterator<TKey, TValue> CreateReverseIterator(
+      IteratorOptions iteratorOptions);
 
   /// <summary>
   /// Returns maintenance object belongs to this ZoneTree.

--- a/src/ZoneTree/IteratorOptions.cs
+++ b/src/ZoneTree/IteratorOptions.cs
@@ -1,0 +1,34 @@
+using ZoneTree.Options;
+
+namespace ZoneTree;
+
+/// <summary>
+/// Configures runtime iterator behavior.
+/// </summary>
+public sealed class IteratorOptions
+{
+  /// <summary>
+  /// Defines iterator refresh and snapshot behavior.
+  /// Default value is <see cref="IteratorType.AutoRefresh"/>.
+  /// </summary>
+  public IteratorType IteratorType { get; set; } = IteratorType.AutoRefresh;
+
+  /// <summary>
+  /// If true, deleted records are included in iteration.
+  /// </summary>
+  public bool IncludeDeletedRecords { get; set; }
+
+  /// <summary>
+  /// If true, disk segment reads performed by the iterator contribute to the
+  /// block cache.
+  /// </summary>
+  public bool ContributeToTheBlockCache { get; set; }
+
+  /// <summary>
+  /// Gets or sets the number of sequential disk-segment records the iterator
+  /// may prefetch at once. Values less than two disable prefetching.
+  /// Default value is 0.
+  /// </summary>
+  public int DiskSegmentPrefetchSize { get; set; } =
+      IteratorDefaultValues.DiskSegmentPrefetchSize;
+}

--- a/src/ZoneTree/Options/IteratorDefaultValues.cs
+++ b/src/ZoneTree/Options/IteratorDefaultValues.cs
@@ -1,0 +1,6 @@
+namespace ZoneTree.Options;
+
+public static class IteratorDefaultValues
+{
+  public static readonly int DiskSegmentPrefetchSize;
+}

--- a/src/ZoneTree/Segments/Disk/DiskSegment.cs
+++ b/src/ZoneTree/Segments/Disk/DiskSegment.cs
@@ -373,7 +373,23 @@ public abstract class DiskSegment<TKey, TValue> : IDiskSegment<TKey, TValue>
 
   public ISeekableIterator<TKey, TValue> GetSeekableIterator(bool contributeToTheBlockCache)
   {
-    return new SeekableIterator<TKey, TValue>(this, contributeToTheBlockCache);
+    return GetSeekableIterator(
+        contributeToTheBlockCache,
+        IteratorDefaultValues.DiskSegmentPrefetchSize);
+  }
+
+  public ISeekableIterator<TKey, TValue> GetSeekableIterator(
+      bool contributeToTheBlockCache,
+      int prefetchSize)
+  {
+    if (prefetchSize < 2)
+      return new SeekableIterator<TKey, TValue>(this, contributeToTheBlockCache);
+
+    return new PrefetchingSeekableIterator<TKey, TValue>(
+          this,
+          ReadEntries,
+          prefetchSize,
+          contributeToTheBlockCache);
   }
 
   public long GetLastSmallerOrEqualPosition(in TKey key)
@@ -498,4 +514,12 @@ public abstract class DiskSegment<TKey, TValue> : IDiskSegment<TKey, TValue>
   {
     return ReadValue(index, blockPin);
   }
+
+  public abstract int ReadEntries(
+      long startIndex,
+      int count,
+      TKey[] keys,
+      TValue[] values,
+      int destinationIndex,
+      BlockPin blockPin);
 }

--- a/src/ZoneTree/Segments/DiskSegmentVariations/FixedSizeKeyAndValueDiskSegment.cs
+++ b/src/ZoneTree/Segments/DiskSegmentVariations/FixedSizeKeyAndValueDiskSegment.cs
@@ -180,6 +180,52 @@ public sealed class FixedSizeKeyAndValueDiskSegment<TKey, TValue> : DiskSegment<
     }
   }
 
+  public override int ReadEntries(
+      long startIndex,
+      int count,
+      TKey[] keys,
+      TValue[] values,
+      int destinationIndex,
+      BlockPin blockPin)
+  {
+    if (startIndex < 0 || startIndex >= Length || count <= 0)
+      return 0;
+    count = (int)Math.Min(count, Length - startIndex);
+
+    try
+    {
+      Interlocked.Increment(ref ReadCount);
+      if (IsDropping)
+      {
+        throw new DiskSegmentIsDroppingException();
+      }
+
+      var itemSize = KeySize + ValueSize;
+      var pin1 = blockPin?.ToSingleBlockPin(1);
+      var bytes = DataDevice.GetBytes(
+          itemSize * startIndex,
+          itemSize * count,
+          pin1);
+
+      for (var i = 0; i < count; ++i)
+      {
+        var sourceOffset = i * itemSize;
+        var targetIndex = destinationIndex + i;
+        keys[targetIndex] = KeySerializer.Deserialize(
+            bytes.Slice(sourceOffset, KeySize));
+        values[targetIndex] = ValueSerializer.Deserialize(
+            bytes.Slice(sourceOffset + KeySize, ValueSize));
+      }
+
+      blockPin?.SetDevice1(pin1.Device);
+      return count;
+    }
+    finally
+    {
+      Interlocked.Decrement(ref ReadCount);
+    }
+  }
+
   protected override void DeleteDevices()
   {
     DataDevice?.Delete();

--- a/src/ZoneTree/Segments/DiskSegmentVariations/FixedSizeKeyDiskSegment.cs
+++ b/src/ZoneTree/Segments/DiskSegmentVariations/FixedSizeKeyDiskSegment.cs
@@ -208,6 +208,60 @@ public sealed class FixedSizeKeyDiskSegment<TKey, TValue> : DiskSegment<TKey, TV
     }
   }
 
+  public unsafe override int ReadEntries(
+      long startIndex,
+      int count,
+      TKey[] keys,
+      TValue[] values,
+      int destinationIndex,
+      BlockPin blockPin)
+  {
+    if (startIndex < 0 || startIndex >= Length || count <= 0)
+      return 0;
+    count = (int)Math.Min(count, Length - startIndex);
+
+    try
+    {
+      Interlocked.Increment(ref ReadCount);
+      if (IsDropping)
+      {
+        throw new DiskSegmentIsDroppingException();
+      }
+
+      var pin1 = blockPin?.ToSingleBlockPin(1);
+      var pin2 = blockPin?.ToSingleBlockPin(2);
+      var headSize = sizeof(ValueHead) + KeySize;
+      var headerBytes = DataHeaderDevice.GetBytes(
+          startIndex * headSize,
+          count * headSize,
+          pin1);
+
+      for (var i = 0; i < count; ++i)
+      {
+        var headerOffset = i * headSize;
+        var targetIndex = destinationIndex + i;
+        keys[targetIndex] = KeySerializer.Deserialize(
+            headerBytes.Slice(headerOffset, KeySize));
+        var head = BinarySerializerHelper.FromByteArray<ValueHead>(
+            headerBytes,
+            headerOffset + KeySize);
+        values[targetIndex] = ValueSerializer.Deserialize(
+            DataDevice.GetBytes(
+                head.ValueOffset,
+                head.ValueLength,
+                pin2));
+      }
+
+      blockPin?.SetDevice1(pin1.Device);
+      blockPin?.SetDevice2(pin2.Device);
+      return count;
+    }
+    finally
+    {
+      Interlocked.Decrement(ref ReadCount);
+    }
+  }
+
   protected override void DeleteDevices()
   {
     DataHeaderDevice?.Delete();

--- a/src/ZoneTree/Segments/DiskSegmentVariations/FixedSizeValueDiskSegment.cs
+++ b/src/ZoneTree/Segments/DiskSegmentVariations/FixedSizeValueDiskSegment.cs
@@ -207,6 +207,60 @@ public sealed class FixedSizeValueDiskSegment<TKey, TValue> : DiskSegment<TKey, 
     }
   }
 
+  public unsafe override int ReadEntries(
+      long startIndex,
+      int count,
+      TKey[] keys,
+      TValue[] values,
+      int destinationIndex,
+      BlockPin blockPin)
+  {
+    if (startIndex < 0 || startIndex >= Length || count <= 0)
+      return 0;
+    count = (int)Math.Min(count, Length - startIndex);
+
+    try
+    {
+      Interlocked.Increment(ref ReadCount);
+      if (IsDropping)
+      {
+        throw new DiskSegmentIsDroppingException();
+      }
+
+      var pin1 = blockPin?.ToSingleBlockPin(1);
+      var pin2 = blockPin?.ToSingleBlockPin(2);
+      var headSize = sizeof(KeyHead) + ValueSize;
+      var headerBytes = DataHeaderDevice.GetBytes(
+          startIndex * headSize,
+          count * headSize,
+          pin1);
+
+      for (var i = 0; i < count; ++i)
+      {
+        var headerOffset = i * headSize;
+        var head = BinarySerializerHelper.FromByteArray<KeyHead>(
+            headerBytes,
+            headerOffset);
+        var targetIndex = destinationIndex + i;
+        values[targetIndex] = ValueSerializer.Deserialize(
+            headerBytes.Slice(headerOffset + sizeof(KeyHead), ValueSize));
+        keys[targetIndex] = KeySerializer.Deserialize(
+            DataDevice.GetBytes(
+                head.KeyOffset,
+                head.KeyLength,
+                pin2));
+      }
+
+      blockPin?.SetDevice1(pin1.Device);
+      blockPin?.SetDevice2(pin2.Device);
+      return count;
+    }
+    finally
+    {
+      Interlocked.Decrement(ref ReadCount);
+    }
+  }
+
   protected override void DeleteDevices()
   {
     DataHeaderDevice?.Delete();

--- a/src/ZoneTree/Segments/DiskSegmentVariations/VariableSizeDiskSegment.cs
+++ b/src/ZoneTree/Segments/DiskSegmentVariations/VariableSizeDiskSegment.cs
@@ -217,6 +217,75 @@ public sealed partial class VariableSizeDiskSegment<TKey, TValue> : DiskSegment<
     }
   }
 
+  public unsafe override int ReadEntries(
+      long startIndex,
+      int count,
+      TKey[] keys,
+      TValue[] values,
+      int destinationIndex,
+      BlockPin blockPin)
+  {
+    if (startIndex < 0 || startIndex >= Length || count <= 0)
+      return 0;
+    count = (int)Math.Min(count, Length - startIndex);
+
+    try
+    {
+      Interlocked.Increment(ref ReadCount);
+      if (IsDropping)
+      {
+        throw new DiskSegmentIsDroppingException();
+      }
+
+      var pin1 = blockPin?.ToSingleBlockPin(1);
+      var pin2 = blockPin?.ToSingleBlockPin(2);
+      var headSize = sizeof(EntryHead);
+      var headerBytes = DataHeaderDevice.GetBytes(
+          startIndex * headSize,
+          count * headSize,
+          pin1);
+
+      for (var i = 0; i < count; ++i)
+      {
+        var targetIndex = destinationIndex + i;
+        var head = BinarySerializerHelper.FromByteArray<EntryHead>(
+            headerBytes,
+            i * headSize);
+        if (head.ValueOffset == head.KeyOffset + head.KeyLength)
+        {
+          var entryBytes = DataDevice.GetBytes(
+              head.KeyOffset,
+              head.KeyLength + head.ValueLength,
+              pin2);
+          keys[targetIndex] = KeySerializer.Deserialize(
+              entryBytes.Slice(0, head.KeyLength));
+          values[targetIndex] = ValueSerializer.Deserialize(
+              entryBytes.Slice(head.KeyLength, head.ValueLength));
+          continue;
+        }
+
+        keys[targetIndex] = KeySerializer.Deserialize(
+            DataDevice.GetBytes(
+                head.KeyOffset,
+                head.KeyLength,
+                pin2));
+        values[targetIndex] = ValueSerializer.Deserialize(
+            DataDevice.GetBytes(
+                head.ValueOffset,
+                head.ValueLength,
+                pin2));
+      }
+
+      blockPin?.SetDevice1(pin1.Device);
+      blockPin?.SetDevice2(pin2.Device);
+      return count;
+    }
+    finally
+    {
+      Interlocked.Decrement(ref ReadCount);
+    }
+  }
+
   protected override void DeleteDevices()
   {
     DataHeaderDevice?.Delete();

--- a/src/ZoneTree/Segments/IDiskSegment.cs
+++ b/src/ZoneTree/Segments/IDiskSegment.cs
@@ -116,4 +116,11 @@ public interface IDiskSegment<TKey, TValue> : IReadOnlySegment<TKey, TValue>, II
   /// </summary>
   /// <param name="defaultSparseArray"></param>
   void SetDefaultSparseArray(IReadOnlyList<SparseArrayEntry<TKey, TValue>> defaultSparseArray);
+
+  /// <summary>
+  /// Returns a seekable iterator over the segment.
+  /// </summary>
+  ISeekableIterator<TKey, TValue> GetSeekableIterator(
+      bool contributeToTheBlockCache,
+      int prefetchSize);
 }

--- a/src/ZoneTree/Segments/MultiPart/MultiPartDiskSegment.cs
+++ b/src/ZoneTree/Segments/MultiPart/MultiPartDiskSegment.cs
@@ -453,7 +453,23 @@ public sealed class MultiPartDiskSegment<TKey, TValue> : IDiskSegment<TKey, TVal
 
   public ISeekableIterator<TKey, TValue> GetSeekableIterator(bool contributeToTheBlockCache)
   {
-    return new SeekableIterator<TKey, TValue>(this, contributeToTheBlockCache);
+    return GetSeekableIterator(
+        contributeToTheBlockCache,
+        IteratorDefaultValues.DiskSegmentPrefetchSize);
+  }
+
+  public ISeekableIterator<TKey, TValue> GetSeekableIterator(
+      bool contributeToTheBlockCache,
+      int prefetchSize)
+  {
+    if (prefetchSize < 2)
+      return new SeekableIterator<TKey, TValue>(this, contributeToTheBlockCache);
+
+    return new PrefetchingSeekableIterator<TKey, TValue>(
+          this,
+          ReadEntries,
+          prefetchSize,
+          contributeToTheBlockCache);
   }
 
   public void InitSparseArray(int size)
@@ -689,5 +705,74 @@ public sealed class MultiPartDiskSegment<TKey, TValue> : IDiskSegment<TKey, TVal
       return PartValues[partIndex * 2 + 1];
 
     return Parts[partIndex].GetValue(localIndex, blockPin);
+  }
+
+  public int ReadEntries(
+     long startIndex,
+     int count,
+     TKey[] keys,
+     TValue[] values,
+     int destinationIndex,
+     BlockPin blockPin)
+  {
+    if (startIndex < 0 || startIndex >= Length || count <= 0)
+      return 0;
+    count = (int)Math.Min(count, Length - startIndex);
+
+    var partIndex = 0;
+    long partStartIndex = 0;
+    var partLength = Parts[partIndex].Length;
+    while (partStartIndex + partLength <= startIndex)
+    {
+      partStartIndex += partLength;
+      ++partIndex;
+      partLength = Parts[partIndex].Length;
+    }
+
+    var read = 0;
+    while (read < count)
+    {
+      var part = Parts[partIndex];
+      var localIndex = startIndex + read - partStartIndex;
+      var partReadCount = (int)Math.Min(count - read, part.Length - localIndex);
+      var targetIndex = destinationIndex + read;
+      if (part is DiskSegment<TKey, TValue> diskSegment)
+      {
+        read += diskSegment.ReadEntries(
+            localIndex,
+            partReadCount,
+            keys,
+            values,
+            targetIndex,
+            blockPin);
+      }
+      else if (part is MultiPartDiskSegment<TKey, TValue> multiPartDiskSegment)
+      {
+        read += multiPartDiskSegment.ReadEntries(
+            localIndex,
+            partReadCount,
+            keys,
+            values,
+            targetIndex,
+            blockPin);
+      }
+      else
+      {
+        for (var i = 0; i < partReadCount; ++i)
+        {
+          keys[targetIndex + i] = part.GetKey(localIndex + i, blockPin);
+          values[targetIndex + i] = part.GetValue(localIndex + i, blockPin);
+        }
+        read += partReadCount;
+      }
+
+      if (read == count)
+        break;
+
+      partStartIndex += part.Length;
+      ++partIndex;
+    }
+
+    return read;
   }
 }

--- a/src/ZoneTree/Segments/NullDisk/NullDiskSegment.cs
+++ b/src/ZoneTree/Segments/NullDisk/NullDiskSegment.cs
@@ -110,6 +110,13 @@ public sealed class NullDiskSegment<TKey, TValue> : IDiskSegment<TKey, TValue>
     return new NullDiskSegmentSeekableIterator<TKey, TValue>();
   }
 
+  public ISeekableIterator<TKey, TValue> GetSeekableIterator(
+      bool contributeToTheBlockCache,
+      int prefetchSize)
+  {
+    return new NullDiskSegmentSeekableIterator<TKey, TValue>();
+  }
+
   public void ReleaseResources()
   {
     // Nothing to release.


### PR DESCRIPTION
**Description**
This PR adds opt-in prefetching for disk-backed iterators.

**What Changed**
- Added `IteratorOptions` for runtime iterator configuration.
- Added `DiskSegmentPrefetchSize`, defaulting to `0` so existing iterator behavior remains unchanged.
- Added `PrefetchingSeekableIterator` for sequential disk-segment scans when prefetching is explicitly enabled.
- Added `ReadEntries` APIs for disk segment variants and multipart disk segments.
- Routed iterator creation through the new options/overloads for forward and reverse iterators.
- Added focused tests for prefetched scans across:
  - fixed-size key/value segments
  - fixed-size key segments
  - fixed-size value segments
  - variable-size segments
  - single disk segment mode
  - multipart disk segment mode
- Bumped package version to `1.9.4.0`.

**Why**
Sequential scans over disk segments can avoid repeated per-record read paths when callers opt into prefetching. The default stays conservative: no prefetch unless requested.