### PR TITLE
Fix the flaky test provider in LiveBackupTests.

### DIFF
--- a/src/ZoneTree.UnitTests/LiveBackupTests.cs
+++ b/src/ZoneTree.UnitTests/LiveBackupTests.cs
@@ -1185,6 +1185,8 @@ public sealed class LiveBackupTests
   sealed class CatalogTrackingLiveBackupProvider
       : InMemoryLiveBackupProvider
   {
+    readonly Lock SyncRoot = new();
+
     readonly HashSet<string> Files = new(StringComparer.Ordinal);
 
     int FileUploads;
@@ -1202,8 +1204,10 @@ public sealed class LiveBackupTests
         CancellationToken cancellationToken)
     {
       cancellationToken.ThrowIfCancellationRequested();
+      ArgumentNullException.ThrowIfNull(file);
       Interlocked.Increment(ref FileUploads);
-      Files.Add(file.SegmentId.ToString());
+      lock (SyncRoot)
+        Files.Add(file.FileName);
       return Task.CompletedTask;
     }
 
@@ -1213,8 +1217,10 @@ public sealed class LiveBackupTests
         CancellationToken cancellationToken)
     {
       cancellationToken.ThrowIfCancellationRequested();
+      ArgumentNullException.ThrowIfNull(file);
       Interlocked.Increment(ref UseSegmentCalls);
-      return Task.FromResult(!Files.Contains(file.SegmentId.ToString()));
+      lock (SyncRoot)
+        return Task.FromResult(!Files.Contains(file.FileName));
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes a flaky live backup unit test by making the test backup provider match the `ILiveBackupStore` concurrency contract.

## What Changed

- Made `CatalogTrackingLiveBackupProvider` thread-safe by locking access to its uploaded-file catalog.
- Changed uploaded-file tracking from `SegmentId` to `FileName`, so the fake provider tracks physical segment files the same way the real local backup provider does.
- Kept the existing assertion semantics: the second generation should ask the provider about existing files but should not upload them again.

## Why

`LiveBackup` may call `UseSegmentAsync` and `UploadSegmentFileAsync` concurrently because segment files are copied with `Parallel.ForEachAsync`. The test provider used a plain `HashSet` without synchronization, which could race in CI and incorrectly report that previously uploaded files were missing.
