### PR TITLE
Performance Feature: Add bounded materialized entry cache.

### DIFF
--- a/src/ZoneTree.UnitTests/MaterializedEntryCacheTests.cs
+++ b/src/ZoneTree.UnitTests/MaterializedEntryCacheTests.cs
@@ -1,0 +1,365 @@
+using ZoneTree.Options;
+using ZoneTree.Segments.Block;
+
+namespace ZoneTree.UnitTests;
+
+public sealed class MaterializedEntryCacheTests
+{
+  const ulong HashMultiplier = 0x9E3779B97F4A7C15UL;
+
+  [TestCase(0, 2)]
+  [TestCase(7, 8)]
+  [TestCase(14, 2)]
+  [TestCase(15, 2)]
+  [TestCase(16, 15)]
+  [TestCase(15, 17)]
+  [TestCase(31, 32)]
+  public void RangesUseSourceAndDestinationOffsets(
+      long startIndex,
+      int count)
+  {
+    const int sourceIndex = 3;
+    const int destinationIndex = 5;
+    var cache = MaterializedEntryCache<long, string>.GetOrCreate(
+        CreateBlock(),
+        128);
+    var sourceKeys = new long[sourceIndex + count + 2];
+    var sourceValues = new string[sourceIndex + count + 2];
+    for (var i = 0; i < count; ++i)
+    {
+      sourceKeys[sourceIndex + i] = startIndex + i;
+      sourceValues[sourceIndex + i] = $"value-{startIndex + i}";
+    }
+    cache.Add(
+        startIndex,
+        count,
+        sourceKeys,
+        sourceValues,
+        sourceIndex);
+
+    var destinationKeys = Enumerable.Repeat(-1L, destinationIndex + count + 2).ToArray();
+    var destinationValues = Enumerable.Repeat("untouched", destinationIndex + count + 2).ToArray();
+    var copied = cache.TryCopy(
+        startIndex,
+        count,
+        destinationKeys,
+        destinationValues,
+        destinationIndex);
+
+    Assert.That(copied, Is.True);
+    Assert.That(
+        destinationKeys.Skip(destinationIndex).Take(count),
+        Is.EqualTo(Enumerable.Range(0, count).Select(i => startIndex + i)));
+    Assert.That(
+        destinationValues.Skip(destinationIndex).Take(count),
+        Is.EqualTo(Enumerable.Range(0, count).Select(i => $"value-{startIndex + i}")));
+    Assert.That(destinationKeys.Take(destinationIndex), Is.All.EqualTo(-1L));
+    Assert.That(destinationValues.Take(destinationIndex), Is.All.EqualTo("untouched"));
+  }
+
+  [Test]
+  public void DefaultSizeIs4096Chunks()
+  {
+    Assert.That(DiskSegmentDefaultValues.MaterializedEntryCacheSize, Is.EqualTo(4096));
+    Assert.That(new DiskSegmentOptions().MaterializedEntryCacheSize, Is.EqualTo(4096));
+  }
+
+  [Test]
+  public void ZeroSizeDisablesCacheCreation()
+  {
+    var block = CreateBlock();
+
+    var cache = MaterializedEntryCache<int, int>.GetOrCreate(block, 0);
+
+    Assert.That(cache, Is.Null);
+    Assert.That(block.MaterializedEntries, Is.Null);
+  }
+
+  [Test]
+  public void NullBlockAndNegativeSizeDisableCacheCreation()
+  {
+    Assert.That(
+        MaterializedEntryCache<int, int>.GetOrCreate(null, 16),
+        Is.Null);
+
+    var block = CreateBlock();
+    Assert.That(
+        MaterializedEntryCache<int, int>.GetOrCreate(block, -1),
+        Is.Null);
+    Assert.That(block.MaterializedEntries, Is.Null);
+  }
+
+  [Test]
+  public void RepeatedCreationReturnsSameTypedCache()
+  {
+    var block = CreateBlock();
+
+    var first = MaterializedEntryCache<int, int>.GetOrCreate(block, 16);
+    var second = MaterializedEntryCache<int, int>.GetOrCreate(block, 32);
+
+    Assert.That(second, Is.SameAs(first));
+  }
+
+  [Test]
+  public void BlockAcceptsOnlyOneMaterializedEntryType()
+  {
+    var block = CreateBlock();
+
+    var first = MaterializedEntryCache<int, int>.GetOrCreate(block, 16);
+    var conflicting = MaterializedEntryCache<string, long>.GetOrCreate(block, 16);
+
+    Assert.That(first, Is.Not.Null);
+    Assert.That(conflicting, Is.Null);
+  }
+
+  [Test]
+  public void ConcurrentCreationPublishesOneInstance()
+  {
+    var block = CreateBlock();
+    var caches = new MaterializedEntryCache<int, int>[256];
+
+    Parallel.For(0, caches.Length, i =>
+        caches[i] = MaterializedEntryCache<int, int>.GetOrCreate(block, 16));
+
+    Assert.That(caches, Is.All.SameAs(caches[0]));
+  }
+
+  [Test]
+  public void SingleRecordAndNonPositiveCountsAreNotCached()
+  {
+    var cache = MaterializedEntryCache<int, int>.GetOrCreate(CreateBlock(), 16);
+    cache.Add(10, 1, new[] { 10 }, new[] { 110 }, 0);
+    cache.Add(10, 0, Array.Empty<int>(), Array.Empty<int>(), 0);
+    cache.Add(10, -1, Array.Empty<int>(), Array.Empty<int>(), 0);
+
+    Assert.That(cache.TryCopy(10, 1, new int[1], new int[1], 0), Is.False);
+    Assert.That(cache.TryCopy(10, 0, Array.Empty<int>(), Array.Empty<int>(), 0), Is.False);
+    Assert.That(cache.TryCopy(10, -1, Array.Empty<int>(), Array.Empty<int>(), 0), Is.False);
+  }
+
+  [Test]
+  public void UnalignedOverlappingRangesReuseCanonicalChunks()
+  {
+    var cache = MaterializedEntryCache<int, int>.GetOrCreate(CreateBlock(), 16);
+    var firstKeys = Enumerable.Range(5, 16).ToArray();
+    var firstValues = firstKeys.Select(x => x + 100).ToArray();
+    cache.Add(5, 16, firstKeys, firstValues, 0);
+
+    var secondKeys = Enumerable.Range(0, 16).ToArray();
+    var secondValues = secondKeys.Select(x => x + 100).ToArray();
+    cache.Add(0, 16, secondKeys, secondValues, 0);
+
+    var keys = new int[16];
+    var values = new int[16];
+    Assert.That(cache.TryCopy(5, 16, keys, values, 0), Is.True);
+    Assert.That(keys, Is.EqualTo(firstKeys));
+    Assert.That(values, Is.EqualTo(firstValues));
+  }
+
+  [Test]
+  public void LargerPrefetchCanServeSmallerUnalignedRead()
+  {
+    var cache = MaterializedEntryCache<int, int>.GetOrCreate(CreateBlock(), 16);
+    var prefetchedKeys = Enumerable.Range(0, 64).ToArray();
+    var prefetchedValues = prefetchedKeys.Select(x => x + 100).ToArray();
+    cache.Add(0, 64, prefetchedKeys, prefetchedValues, 0);
+
+    var keys = new int[16];
+    var values = new int[16];
+    Assert.That(cache.TryCopy(7, 16, keys, values, 0), Is.True);
+    Assert.That(keys, Is.EqualTo(Enumerable.Range(7, 16)));
+    Assert.That(values, Is.EqualTo(Enumerable.Range(107, 16)));
+  }
+
+  [TestCase(false)]
+  [TestCase(true)]
+  public void PartialWritesCompleteCanonicalChunk(bool reverseOrder)
+  {
+    var cache = MaterializedEntryCache<int, int>.GetOrCreate(CreateBlock(), 16);
+    var firstStartIndex = reverseOrder ? 8 : 0;
+    var secondStartIndex = reverseOrder ? 0 : 8;
+    cache.Add(
+        firstStartIndex,
+        8,
+        Enumerable.Range(firstStartIndex, 8).ToArray(),
+        Enumerable.Range(firstStartIndex + 100, 8).ToArray(),
+        0);
+
+    Assert.That(TryCopyFullChunk(cache, 0), Is.False);
+
+    cache.Add(
+        secondStartIndex,
+        8,
+        Enumerable.Range(secondStartIndex, 8).ToArray(),
+        Enumerable.Range(secondStartIndex + 100, 8).ToArray(),
+        0);
+
+    Assert.That(TryCopyFullChunk(cache, 0), Is.True);
+  }
+
+  [Test]
+  public void MissingMiddleChunkMakesMultiChunkReadMiss()
+  {
+    var cache = MaterializedEntryCache<int, int>.GetOrCreate(CreateBlock(), 64);
+    AddFullChunk(cache, 0);
+    AddFullChunk(cache, 2);
+
+    Assert.That(TryCopyFullChunk(cache, 0), Is.True);
+    Assert.That(TryCopyFullChunk(cache, 2), Is.True);
+    Assert.That(cache.TryCopy(0, 48, new int[48], new int[48], 0), Is.False);
+  }
+
+  [Test]
+  public void CacheOwnsReferenceTypeSourceArrays()
+  {
+    var cache = MaterializedEntryCache<string, string>.GetOrCreate(CreateBlock(), 16);
+    var keys = Enumerable.Range(0, 16).Select(i => $"key-{i}").ToArray();
+    var values = Enumerable.Range(0, 16).Select(i => $"value-{i}").ToArray();
+    cache.Add(0, 16, keys, values, 0);
+
+    Array.Fill(keys, "changed-key");
+    Array.Fill(values, "changed-value");
+
+    var cachedKeys = new string[16];
+    var cachedValues = new string[16];
+    Assert.That(cache.TryCopy(0, 16, cachedKeys, cachedValues, 0), Is.True);
+    Assert.That(cachedKeys, Is.EqualTo(Enumerable.Range(0, 16).Select(i => $"key-{i}")));
+    Assert.That(cachedValues, Is.EqualTo(Enumerable.Range(0, 16).Select(i => $"value-{i}")));
+  }
+
+  [Test]
+  public void IndexesAboveIntMaxValueRemainDistinct()
+  {
+    var startIndex = (long)int.MaxValue + 37;
+    var cache = MaterializedEntryCache<long, string>.GetOrCreate(CreateBlock(), 64);
+    var keys = Enumerable.Range(0, 32).Select(i => startIndex + i).ToArray();
+    var values = keys.Select(x => $"value-{x}").ToArray();
+    cache.Add(startIndex, 32, keys, values, 0);
+
+    var cachedKeys = new long[32];
+    var cachedValues = new string[32];
+    Assert.That(cache.TryCopy(startIndex, 32, cachedKeys, cachedValues, 0), Is.True);
+    Assert.That(cachedKeys, Is.EqualTo(keys));
+    Assert.That(cachedValues, Is.EqualTo(values));
+  }
+
+  [Test]
+  public void OneSlotRetainsOnlyOneChunk()
+  {
+    var cache = MaterializedEntryCache<int, int>.GetOrCreate(CreateBlock(), 1);
+    AddFullChunk(cache, 0);
+    AddFullChunk(cache, 1);
+
+    Assert.That(TryCopyFullChunk(cache, 0), Is.False);
+    Assert.That(TryCopyFullChunk(cache, 1), Is.True);
+  }
+
+  [Test]
+  public void ArbitrarySizeDistributesChunksAcrossAllSlots()
+  {
+    const int cacheSize = 3;
+    var block = CreateBlock();
+    var cache = MaterializedEntryCache<int, int>.GetOrCreate(block, cacheSize);
+    var chunkIndexes = FindChunkIndexForEachSlot(cacheSize);
+
+    foreach (var chunkIndex in chunkIndexes)
+      AddFullChunk(cache, chunkIndex);
+
+    foreach (var chunkIndex in chunkIndexes)
+      Assert.That(TryCopyFullChunk(cache, chunkIndex), Is.True);
+  }
+
+  [Test]
+  public void LargePrefetchCannotRetainMoreChunksThanSlots()
+  {
+    const int cacheSize = 4;
+    const int startIndex = 3;
+    const int count = 64 * 16 + 7;
+    var cache = MaterializedEntryCache<int, int>.GetOrCreate(CreateBlock(), cacheSize);
+    var keys = Enumerable.Range(startIndex, count).ToArray();
+    var values = keys.Select(x => x + 100).ToArray();
+    cache.Add(startIndex, keys.Length, keys, values, 0);
+
+    var retainedChunks = Enumerable.Range(0, 65)
+        .Count(chunkIndex => TryCopyFullChunk(cache, chunkIndex));
+
+    Assert.That(retainedChunks, Is.LessThanOrEqualTo(cacheSize));
+    Assert.That(retainedChunks, Is.GreaterThan(0));
+  }
+
+  [Test]
+  public void ConcurrentReadsNeverReturnIncorrectPublishedValues()
+  {
+    const int chunkCount = 64;
+    var cache = MaterializedEntryCache<int, int>.GetOrCreate(CreateBlock(), 32);
+    var incorrectCopies = 0;
+
+    Parallel.For(0, 20_000, iteration =>
+    {
+      var chunkIndex = iteration % chunkCount;
+      var startIndex = chunkIndex * 16;
+      var keys = Enumerable.Range(startIndex, 16).ToArray();
+      var values = keys.Select(x => x + 100).ToArray();
+      cache.Add(startIndex, 16, keys, values, 0);
+
+      var cachedKeys = new int[16];
+      var cachedValues = new int[16];
+      if (cache.TryCopy(startIndex, 16, cachedKeys, cachedValues, 0) &&
+          (!cachedKeys.SequenceEqual(keys) || !cachedValues.SequenceEqual(values)))
+      {
+        Interlocked.Increment(ref incorrectCopies);
+      }
+    });
+
+    Assert.That(incorrectCopies, Is.Zero);
+  }
+
+  static DecompressedBlock CreateBlock()
+  {
+    return new DecompressedBlock(
+        0,
+        Memory<byte>.Empty,
+        CompressionMethod.None,
+        0);
+  }
+
+  static void AddFullChunk(
+      MaterializedEntryCache<int, int> cache,
+      long chunkIndex)
+  {
+    var startIndex = checked((int)(chunkIndex * 16));
+    var keys = Enumerable.Range(startIndex, 16).ToArray();
+    var values = keys.Select(x => x + 100).ToArray();
+    cache.Add(startIndex, 16, keys, values, 0);
+  }
+
+  static bool TryCopyFullChunk(
+      MaterializedEntryCache<int, int> cache,
+      long chunkIndex)
+  {
+    var startIndex = checked((int)(chunkIndex * 16));
+    var keys = new int[16];
+    var values = new int[16];
+    return cache.TryCopy(startIndex, 16, keys, values, 0) &&
+           keys.SequenceEqual(Enumerable.Range(startIndex, 16)) &&
+           values.SequenceEqual(Enumerable.Range(startIndex + 100, 16));
+  }
+
+  static long[] FindChunkIndexForEachSlot(int cacheSize)
+  {
+    var result = new long[cacheSize];
+    var found = new bool[cacheSize];
+    var remaining = cacheSize;
+    for (long chunkIndex = 0; remaining != 0; ++chunkIndex)
+    {
+      var hash = unchecked((ulong)chunkIndex * HashMultiplier);
+      var slot = (int)Math.BigMul(hash, (ulong)(uint)cacheSize, out _);
+      if (found[slot])
+        continue;
+      result[slot] = chunkIndex;
+      found[slot] = true;
+      --remaining;
+    }
+    return result;
+  }
+}

--- a/src/ZoneTree.UnitTests/ZoneTreeMetaOptionsTests.cs
+++ b/src/ZoneTree.UnitTests/ZoneTreeMetaOptionsTests.cs
@@ -18,6 +18,9 @@ public sealed class ZoneTreeMetaOptionsTests
       using var zoneTree = OpenConfiguredZoneTree(dataPath, expected);
       zoneTree.Maintenance.SaveMetaData();
 
+      Assert.That(
+          zoneTree.Maintenance.CloneOptions().DiskSegmentOptions.MaterializedEntryCacheSize,
+          Is.EqualTo(expected.DiskSegmentMaterializedEntryCacheSize));
       AssertMetadataOptions(dataPath, expected);
     }
     finally
@@ -87,6 +90,7 @@ public sealed class ZoneTreeMetaOptionsTests
           options.MinimumRecordCount = expected.DiskSegmentMinimumRecordCount;
           options.KeyCacheSize = expected.DiskSegmentKeyCacheSize;
           options.ValueCacheSize = expected.DiskSegmentValueCacheSize;
+          options.MaterializedEntryCacheSize = expected.DiskSegmentMaterializedEntryCacheSize;
           options.KeyCacheRecordLifeTimeInMillisecond =
               expected.DiskSegmentKeyCacheRecordLifeTimeInMillisecond;
           options.ValueCacheRecordLifeTimeInMillisecond =
@@ -122,6 +126,7 @@ public sealed class ZoneTreeMetaOptionsTests
           DiskSegmentMinimumRecordCount: 51,
           DiskSegmentKeyCacheSize: 11,
           DiskSegmentValueCacheSize: 13,
+          DiskSegmentMaterializedEntryCacheSize: 17,
           DiskSegmentKeyCacheRecordLifeTimeInMillisecond: 23,
           DiskSegmentValueCacheRecordLifeTimeInMillisecond: 29,
           DefaultSparseArrayStepSize: 31),
@@ -146,6 +151,7 @@ public sealed class ZoneTreeMetaOptionsTests
           DiskSegmentMinimumRecordCount: 53,
           DiskSegmentKeyCacheSize: 17,
           DiskSegmentValueCacheSize: 19,
+          DiskSegmentMaterializedEntryCacheSize: 23,
           DiskSegmentKeyCacheRecordLifeTimeInMillisecond: 31,
           DiskSegmentValueCacheRecordLifeTimeInMillisecond: 37,
           DefaultSparseArrayStepSize: 41),
@@ -170,6 +176,7 @@ public sealed class ZoneTreeMetaOptionsTests
           DiskSegmentMinimumRecordCount: 59,
           DiskSegmentKeyCacheSize: 23,
           DiskSegmentValueCacheSize: 29,
+          DiskSegmentMaterializedEntryCacheSize: 31,
           DiskSegmentKeyCacheRecordLifeTimeInMillisecond: 41,
           DiskSegmentValueCacheRecordLifeTimeInMillisecond: 43,
           DefaultSparseArrayStepSize: 47),
@@ -214,6 +221,8 @@ public sealed class ZoneTreeMetaOptionsTests
     Assert.That(diskOptions.MinimumRecordCount, Is.EqualTo(expected.DiskSegmentMinimumRecordCount));
     Assert.That(diskOptions.KeyCacheSize, Is.EqualTo(expected.DiskSegmentKeyCacheSize));
     Assert.That(diskOptions.ValueCacheSize, Is.EqualTo(expected.DiskSegmentValueCacheSize));
+    Assert.That(diskOptions.MaterializedEntryCacheSize,
+        Is.EqualTo(expected.DiskSegmentMaterializedEntryCacheSize));
     Assert.That(diskOptions.KeyCacheRecordLifeTimeInMillisecond,
         Is.EqualTo(expected.DiskSegmentKeyCacheRecordLifeTimeInMillisecond));
     Assert.That(diskOptions.ValueCacheRecordLifeTimeInMillisecond,
@@ -262,6 +271,7 @@ public sealed class ZoneTreeMetaOptionsTests
       int DiskSegmentMinimumRecordCount,
       int DiskSegmentKeyCacheSize,
       int DiskSegmentValueCacheSize,
+      int DiskSegmentMaterializedEntryCacheSize,
       int DiskSegmentKeyCacheRecordLifeTimeInMillisecond,
       int DiskSegmentValueCacheRecordLifeTimeInMillisecond,
       int DefaultSparseArrayStepSize);

--- a/src/ZoneTree.UnitTests/ZoneTreeOptionsValidationTests.cs
+++ b/src/ZoneTree.UnitTests/ZoneTreeOptionsValidationTests.cs
@@ -232,6 +232,10 @@ public sealed class ZoneTreeOptionsValidationTests
         "DiskSegmentOptions.ValueCacheSize");
 
     yield return Invalid(
+        options => options.DiskSegmentOptions.MaterializedEntryCacheSize = -1,
+        "DiskSegmentOptions.MaterializedEntryCacheSize");
+
+    yield return Invalid(
         options => options.DiskSegmentOptions.KeyCacheRecordLifeTimeInMillisecond = -1,
         "DiskSegmentOptions.KeyCacheRecordLifeTimeInMillisecond");
 

--- a/src/ZoneTree/Core/ZoneTree.cs
+++ b/src/ZoneTree/Core/ZoneTree.cs
@@ -383,6 +383,7 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
       DiskSegmentMode = dsk.DiskSegmentMode,
       KeyCacheRecordLifeTimeInMillisecond = dsk.KeyCacheRecordLifeTimeInMillisecond,
       KeyCacheSize = dsk.KeyCacheSize,
+      MaterializedEntryCacheSize = dsk.MaterializedEntryCacheSize,
       MaximumRecordCount = dsk.MaximumRecordCount,
       MinimumRecordCount = dsk.MinimumRecordCount,
       ValueCacheRecordLifeTimeInMillisecond = dsk.ValueCacheRecordLifeTimeInMillisecond,

--- a/src/ZoneTree/Options/DiskSegmentDefaultValues.cs
+++ b/src/ZoneTree/Options/DiskSegmentDefaultValues.cs
@@ -18,6 +18,8 @@ public static class DiskSegmentDefaultValues
 
   public static readonly int ValueCacheSize = 1024;
 
+  public static readonly int MaterializedEntryCacheSize = 4096;
+
   public static readonly int KeyCacheRecordLifeTimeInMillisecond = 10_000;
 
   public static readonly int ValueCacheRecordLifeTimeInMillisecond = 10_000;

--- a/src/ZoneTree/Options/DiskSegmentOptions.cs
+++ b/src/ZoneTree/Options/DiskSegmentOptions.cs
@@ -78,6 +78,18 @@ public sealed class DiskSegmentOptions
   public int ValueCacheSize { get; set; } = DiskSegmentDefaultValues.ValueCacheSize;
 
   /// <summary>
+  /// Gets or sets the maximum number of materialized 16-entry chunks cached
+  /// per decompressed disk block. Chunks are aligned by absolute disk index,
+  /// allowing iterators with different
+  /// <see cref="IteratorOptions.DiskSegmentPrefetchSize"/> values to reuse the
+  /// same entries without retaining overlapping batches. The default value of
+  /// 4096 chunks retains at most 65,536 materialized entries per decompressed
+  /// block. Setting this value to zero disables the cache.
+  /// </summary>
+  public int MaterializedEntryCacheSize { get; set; }
+      = DiskSegmentDefaultValues.MaterializedEntryCacheSize;
+
+  /// <summary>
   /// Gets or sets the maximum lifetime of a record in the key cache, in milliseconds.
   /// Longer lifetimes can keep cached keys in memory for longer.
   /// Default value is 10,000 milliseconds (10 seconds).

--- a/src/ZoneTree/Options/ZoneTreeOptionValidationRules.cs
+++ b/src/ZoneTree/Options/ZoneTreeOptionValidationRules.cs
@@ -38,6 +38,9 @@ internal static class ZoneTreeOptionValidationRules
   public static readonly Rule DiskSegmentValueCacheSize =
       Rule.Min(0);
 
+  public static readonly Rule DiskSegmentMaterializedEntryCacheSize =
+      Rule.Min(0);
+
   public static readonly Rule DiskSegmentKeyCacheRecordLifeTimeInMillisecond =
       Rule.MinSeconds(0);
 

--- a/src/ZoneTree/Options/ZoneTreeOptionsValidator.cs
+++ b/src/ZoneTree/Options/ZoneTreeOptionsValidator.cs
@@ -207,6 +207,12 @@ internal static class ZoneTreeOptionsValidator
     if (exception != null)
       return exception;
 
+    exception = ZoneTreeOptionValidationRules.DiskSegmentMaterializedEntryCacheSize.Validate(
+        Option(owner, nameof(options.MaterializedEntryCacheSize)),
+        options.MaterializedEntryCacheSize);
+    if (exception != null)
+      return exception;
+
     exception = ZoneTreeOptionValidationRules.DiskSegmentKeyCacheRecordLifeTimeInMillisecond.Validate(
         Option(owner, nameof(options.KeyCacheRecordLifeTimeInMillisecond)),
         options.KeyCacheRecordLifeTimeInMillisecond);

--- a/src/ZoneTree/Segments/Block/DecompressedBlock.cs
+++ b/src/ZoneTree/Segments/Block/DecompressedBlock.cs
@@ -34,6 +34,8 @@ public sealed class DecompressedBlock
     set => Volatile.Write(ref _lastAccessTicks, value);
   }
 
+  public object MaterializedEntries;
+
   public DecompressedBlock(
       int blockIndex,
       int blockSize,

--- a/src/ZoneTree/Segments/Block/MaterializedEntryCache.cs
+++ b/src/ZoneTree/Segments/Block/MaterializedEntryCache.cs
@@ -1,0 +1,215 @@
+using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace ZoneTree.Segments.Block;
+
+public sealed class MaterializedEntryCache<TKey, TValue>
+{
+  const int ChunkSize = 16;
+
+  const ulong HashMultiplier = 11400714819323198485UL;
+
+  readonly MaterializedEntryChunk<TKey, TValue>[] Slots;
+
+  readonly int HashShift;
+
+  MaterializedEntryCache(int cacheSize)
+  {
+    Slots = new MaterializedEntryChunk<TKey, TValue>[cacheSize];
+    HashShift = cacheSize > 1 && BitOperations.IsPow2((uint)cacheSize)
+        ? 64 - BitOperations.Log2((uint)cacheSize)
+        : 0;
+  }
+
+  public static MaterializedEntryCache<TKey, TValue> GetOrCreate(
+      DecompressedBlock block,
+      int cacheSize)
+  {
+    if (block == null || cacheSize <= 0)
+      return null;
+
+    var entries = Volatile.Read(ref block.MaterializedEntries);
+    if (entries is MaterializedEntryCache<TKey, TValue> cache)
+      return cache;
+    if (entries != null)
+      return null;
+
+    cache = new MaterializedEntryCache<TKey, TValue>(cacheSize);
+    entries = Interlocked.CompareExchange(
+        ref block.MaterializedEntries,
+        cache,
+        null);
+    return entries == null
+        ? cache
+        : entries as MaterializedEntryCache<TKey, TValue>;
+  }
+
+  public bool TryCopy(
+      long startIndex,
+      int count,
+      TKey[] keys,
+      TValue[] values,
+      int destinationIndex)
+  {
+    if (count <= 0)
+      return false;
+
+    var currentIndex = startIndex;
+    var remaining = count;
+    while (remaining != 0)
+    {
+      var chunkStartIndex = GetChunkStartIndex(currentIndex);
+      var chunkOffset = (int)(currentIndex - chunkStartIndex);
+      var copyCount = Math.Min(ChunkSize - chunkOffset, remaining);
+      var chunkIndex = chunkStartIndex / ChunkSize;
+      var chunk = Volatile.Read(ref Slots[GetSlot(chunkIndex)]);
+      if (chunk == null ||
+          chunk.StartIndex != chunkStartIndex ||
+          !chunk.TryCopy(
+              currentIndex,
+              copyCount,
+              keys,
+              values,
+              destinationIndex))
+      {
+        return false;
+      }
+
+      currentIndex += copyCount;
+      destinationIndex += copyCount;
+      remaining -= copyCount;
+    }
+    return true;
+  }
+
+  public void Add(
+      long startIndex,
+      int count,
+      TKey[] keys,
+      TValue[] values,
+      int sourceIndex)
+  {
+    // Single-record reads are used while creating sparse arrays. Caching them
+    // would populate many mostly empty chunks with little chance of reuse.
+    if (count <= 1)
+      return;
+
+    var currentIndex = startIndex;
+    var remaining = count;
+    while (remaining != 0)
+    {
+      var chunkStartIndex = GetChunkStartIndex(currentIndex);
+      var chunkOffset = (int)(currentIndex - chunkStartIndex);
+      var copyCount = Math.Min(ChunkSize - chunkOffset, remaining);
+      var chunkIndex = chunkStartIndex / ChunkSize;
+      var slot = GetSlot(chunkIndex);
+      var chunk = Volatile.Read(ref Slots[slot]);
+      if (chunk == null ||
+          chunk.StartIndex != chunkStartIndex ||
+          !chunk.Contains(currentIndex, copyCount))
+      {
+        var copiedKeys = new TKey[ChunkSize];
+        var copiedValues = new TValue[ChunkSize];
+        ushort validEntries = 0;
+        if (chunk != null && chunk.StartIndex == chunkStartIndex)
+        {
+          Array.Copy(chunk.Keys, copiedKeys, ChunkSize);
+          Array.Copy(chunk.Values, copiedValues, ChunkSize);
+          validEntries = chunk.ValidEntries;
+        }
+
+        Array.Copy(keys, sourceIndex, copiedKeys, chunkOffset, copyCount);
+        Array.Copy(values, sourceIndex, copiedValues, chunkOffset, copyCount);
+        validEntries |= MaterializedEntryChunk<TKey, TValue>
+            .GetEntryMask(chunkOffset, copyCount);
+
+        var newChunk = new MaterializedEntryChunk<TKey, TValue>(
+            chunkStartIndex,
+            validEntries,
+            copiedKeys,
+            copiedValues);
+        Volatile.Write(ref Slots[slot], newChunk);
+      }
+
+      currentIndex += copyCount;
+      sourceIndex += copyCount;
+      remaining -= copyCount;
+    }
+  }
+
+  [MethodImpl(MethodImplOptions.AggressiveInlining)]
+  static long GetChunkStartIndex(long index)
+  {
+    return index / ChunkSize * ChunkSize;
+  }
+
+  [MethodImpl(MethodImplOptions.AggressiveInlining)]
+  int GetSlot(long chunkIndex)
+  {
+    unchecked
+    {
+      var hash = (ulong)chunkIndex * HashMultiplier;
+      if (HashShift != 0)
+        return (int)(hash >> HashShift);
+      if (Slots.Length == 1)
+        return 0;
+      return (int)Math.BigMul(
+          hash,
+          (ulong)(uint)Slots.Length,
+          out _);
+    }
+  }
+}
+
+public sealed class MaterializedEntryChunk<TKey, TValue>(
+    long startIndex,
+    ushort validEntries,
+    TKey[] keys,
+    TValue[] values)
+{
+  public readonly long StartIndex = startIndex;
+
+  public readonly ushort ValidEntries = validEntries;
+
+  public readonly TKey[] Keys = keys;
+
+  public readonly TValue[] Values = values;
+
+  public bool Contains(long startIndex, int count)
+  {
+    var offset = startIndex - StartIndex;
+    if (offset < 0 || offset > 15 || count > 16 - offset)
+      return false;
+    var entryMask = GetEntryMask((int)offset, count);
+    return (ValidEntries & entryMask) == entryMask;
+  }
+
+  public bool TryCopy(
+      long startIndex,
+      int count,
+      TKey[] keys,
+      TValue[] values,
+      int destinationIndex)
+  {
+    var offset = startIndex - StartIndex;
+    if (offset < 0 || offset > 15 || count > 16 - offset)
+      return false;
+
+    var sourceIndex = (int)offset;
+    var entryMask = GetEntryMask(sourceIndex, count);
+    if ((ValidEntries & entryMask) != entryMask)
+      return false;
+
+    Array.Copy(Keys, sourceIndex, keys, destinationIndex, count);
+    Array.Copy(Values, sourceIndex, values, destinationIndex, count);
+    return true;
+  }
+
+  [MethodImpl(MethodImplOptions.AggressiveInlining)]
+  public static ushort GetEntryMask(int offset, int count)
+  {
+    return (ushort)(((1U << count) - 1U) << offset);
+  }
+}

--- a/src/ZoneTree/Segments/Disk/DiskSegment.cs
+++ b/src/ZoneTree/Segments/Disk/DiskSegment.cs
@@ -19,6 +19,8 @@ public abstract class DiskSegment<TKey, TValue> : IDiskSegment<TKey, TValue>
 
   protected readonly ISerializer<TValue> ValueSerializer;
 
+  protected readonly int MaterializedEntryCacheSize;
+
   protected IRandomAccessDevice DataDevice;
 
   protected int KeySize;
@@ -67,6 +69,7 @@ public abstract class DiskSegment<TKey, TValue> : IDiskSegment<TKey, TValue>
     KeySerializer = options.KeySerializer;
     ValueSerializer = options.ValueSerializer;
     var diskOptions = options.DiskSegmentOptions;
+    MaterializedEntryCacheSize = diskOptions.MaterializedEntryCacheSize;
     CircularKeyCache = new CircularCache<TKey>(
         diskOptions.KeyCacheSize,
         diskOptions.KeyCacheRecordLifeTimeInMillisecond);
@@ -87,6 +90,7 @@ public abstract class DiskSegment<TKey, TValue> : IDiskSegment<TKey, TValue>
     KeySerializer = options.KeySerializer;
     ValueSerializer = options.ValueSerializer;
     var diskOptions = options.DiskSegmentOptions;
+    MaterializedEntryCacheSize = diskOptions.MaterializedEntryCacheSize;
     CircularKeyCache = new CircularCache<TKey>(
         diskOptions.KeyCacheSize,
         diskOptions.KeyCacheRecordLifeTimeInMillisecond);

--- a/src/ZoneTree/Segments/Disk/DiskSegment.cs
+++ b/src/ZoneTree/Segments/Disk/DiskSegment.cs
@@ -174,14 +174,16 @@ public abstract class DiskSegment<TKey, TValue> : IDiskSegment<TKey, TValue>
     if (step < 1)
       return;
     var sparseArray = new List<SparseArrayEntry<TKey, TValue>>();
+    var keys = new TKey[1];
+    var values = new TValue[1];
     for (int i = 0; i < len; i += step)
     {
-      var sparseArrayEntry = CreateSparseArrayEntry(i);
+      var sparseArrayEntry = CreateSparseArrayEntry(i, keys, values);
       sparseArray.Add(sparseArrayEntry);
     }
     if (sparseArray[^1].Index != len - 1)
     {
-      var sparseArrayEntry = CreateSparseArrayEntry(len - 1);
+      var sparseArrayEntry = CreateSparseArrayEntry(len - 1, keys, values);
       sparseArray.Add(sparseArrayEntry);
     }
     SparseArray = sparseArray;
@@ -192,13 +194,15 @@ public abstract class DiskSegment<TKey, TValue> : IDiskSegment<TKey, TValue>
     InitSparseArray((int)Math.Min(Length, int.MaxValue));
   }
 
-  SparseArrayEntry<TKey, TValue> CreateSparseArrayEntry(long index)
+  SparseArrayEntry<TKey, TValue> CreateSparseArrayEntry(
+      long index,
+      TKey[] keys,
+      TValue[] values)
   {
-    // Optimisation possibility? read key and value together to reduce IO calls.
-    var key = ReadKey(index);
-    var value = ReadValue(index);
-    var sparseArrayEntry = new SparseArrayEntry<TKey, TValue>(key, value, index);
-    return sparseArrayEntry;
+    if (ReadEntries(index, 1, keys, values, 0, null) != 1)
+      throw new InvalidOperationException(
+          $"Could not read sparse-array entry at index {index}.");
+    return new SparseArrayEntry<TKey, TValue>(keys[0], values[0], index);
   }
 
   protected TKey ReadKey(long index) => ReadKey(index, null);

--- a/src/ZoneTree/Segments/DiskSegmentVariations/FixedSizeKeyAndValueDiskSegment.cs
+++ b/src/ZoneTree/Segments/DiskSegmentVariations/FixedSizeKeyAndValueDiskSegment.cs
@@ -206,6 +206,24 @@ public sealed class FixedSizeKeyAndValueDiskSegment<TKey, TValue> : DiskSegment<
           itemSize * startIndex,
           itemSize * count,
           pin1);
+      MaterializedEntryCache<TKey, TValue> cache = null;
+
+      if (count > 1)
+      {
+        cache = MaterializedEntryCache<TKey, TValue>.GetOrCreate(
+            pin1?.Device,
+            MaterializedEntryCacheSize);
+        if (cache != null && cache.TryCopy(
+            startIndex,
+            count,
+            keys,
+            values,
+            destinationIndex))
+        {
+          blockPin?.SetDevice1(pin1.Device);
+          return count;
+        }
+      }
 
       for (var i = 0; i < count; ++i)
       {
@@ -217,6 +235,7 @@ public sealed class FixedSizeKeyAndValueDiskSegment<TKey, TValue> : DiskSegment<
             bytes.Slice(sourceOffset + KeySize, ValueSize));
       }
 
+      cache?.Add(startIndex, count, keys, values, destinationIndex);
       blockPin?.SetDevice1(pin1.Device);
       return count;
     }
@@ -236,7 +255,7 @@ public sealed class FixedSizeKeyAndValueDiskSegment<TKey, TValue> : DiskSegment<
 
   public override void ReleaseResources()
   {
-    DataDevice?.Dispose();
+    base.ReleaseResources();
   }
 
   public override int ReleaseReadBuffers(long ticks)

--- a/src/ZoneTree/Segments/DiskSegmentVariations/FixedSizeKeyDiskSegment.cs
+++ b/src/ZoneTree/Segments/DiskSegmentVariations/FixedSizeKeyDiskSegment.cs
@@ -235,6 +235,24 @@ public sealed class FixedSizeKeyDiskSegment<TKey, TValue> : DiskSegment<TKey, TV
           startIndex * headSize,
           count * headSize,
           pin1);
+      MaterializedEntryCache<TKey, TValue> cache = null;
+
+      if (count > 1)
+      {
+        cache = MaterializedEntryCache<TKey, TValue>.GetOrCreate(
+            pin1?.Device,
+            MaterializedEntryCacheSize);
+        if (cache != null && cache.TryCopy(
+            startIndex,
+            count,
+            keys,
+            values,
+            destinationIndex))
+        {
+          blockPin?.SetDevice1(pin1.Device);
+          return count;
+        }
+      }
 
       for (var i = 0; i < count; ++i)
       {
@@ -252,6 +270,7 @@ public sealed class FixedSizeKeyDiskSegment<TKey, TValue> : DiskSegment<TKey, TV
                 pin2));
       }
 
+      cache?.Add(startIndex, count, keys, values, destinationIndex);
       blockPin?.SetDevice1(pin1.Device);
       blockPin?.SetDevice2(pin2.Device);
       return count;
@@ -274,7 +293,7 @@ public sealed class FixedSizeKeyDiskSegment<TKey, TValue> : DiskSegment<TKey, TV
   public override void ReleaseResources()
   {
     DataHeaderDevice?.Dispose();
-    DataDevice?.Dispose();
+    base.ReleaseResources();
   }
 
   public override int ReleaseReadBuffers(long ticks)

--- a/src/ZoneTree/Segments/DiskSegmentVariations/FixedSizeValueDiskSegment.cs
+++ b/src/ZoneTree/Segments/DiskSegmentVariations/FixedSizeValueDiskSegment.cs
@@ -234,6 +234,24 @@ public sealed class FixedSizeValueDiskSegment<TKey, TValue> : DiskSegment<TKey, 
           startIndex * headSize,
           count * headSize,
           pin1);
+      MaterializedEntryCache<TKey, TValue> cache = null;
+
+      if (count > 1)
+      {
+        cache = MaterializedEntryCache<TKey, TValue>.GetOrCreate(
+            pin1?.Device,
+            MaterializedEntryCacheSize);
+        if (cache != null && cache.TryCopy(
+            startIndex,
+            count,
+            keys,
+            values,
+            destinationIndex))
+        {
+          blockPin?.SetDevice1(pin1.Device);
+          return count;
+        }
+      }
 
       for (var i = 0; i < count; ++i)
       {
@@ -251,6 +269,7 @@ public sealed class FixedSizeValueDiskSegment<TKey, TValue> : DiskSegment<TKey, 
                 pin2));
       }
 
+      cache?.Add(startIndex, count, keys, values, destinationIndex);
       blockPin?.SetDevice1(pin1.Device);
       blockPin?.SetDevice2(pin2.Device);
       return count;
@@ -273,7 +292,7 @@ public sealed class FixedSizeValueDiskSegment<TKey, TValue> : DiskSegment<TKey, 
   public override void ReleaseResources()
   {
     DataHeaderDevice?.Dispose();
-    DataDevice?.Dispose();
+    base.ReleaseResources();
   }
 
   public override int ReleaseReadBuffers(long ticks)

--- a/src/ZoneTree/Segments/DiskSegmentVariations/VariableSizeDiskSegment.cs
+++ b/src/ZoneTree/Segments/DiskSegmentVariations/VariableSizeDiskSegment.cs
@@ -244,6 +244,24 @@ public sealed partial class VariableSizeDiskSegment<TKey, TValue> : DiskSegment<
           startIndex * headSize,
           count * headSize,
           pin1);
+      MaterializedEntryCache<TKey, TValue> cache = null;
+
+      if (count > 1)
+      {
+        cache = MaterializedEntryCache<TKey, TValue>.GetOrCreate(
+            pin1?.Device,
+            MaterializedEntryCacheSize);
+        if (cache != null && cache.TryCopy(
+            startIndex,
+            count,
+            keys,
+            values,
+            destinationIndex))
+        {
+          blockPin?.SetDevice1(pin1.Device);
+          return count;
+        }
+      }
 
       for (var i = 0; i < count; ++i)
       {
@@ -276,6 +294,7 @@ public sealed partial class VariableSizeDiskSegment<TKey, TValue> : DiskSegment<
                 pin2));
       }
 
+      cache?.Add(startIndex, count, keys, values, destinationIndex);
       blockPin?.SetDevice1(pin1.Device);
       blockPin?.SetDevice2(pin2.Device);
       return count;
@@ -298,7 +317,7 @@ public sealed partial class VariableSizeDiskSegment<TKey, TValue> : DiskSegment<
   public override void ReleaseResources()
   {
     DataHeaderDevice?.Dispose();
-    DataDevice?.Dispose();
+    base.ReleaseResources();
   }
 
   public override int ReleaseReadBuffers(long ticks)


### PR DESCRIPTION
## Summary

Adds a bounded per-block cache for materialized disk-segment entries, avoiding repeated key/value deserialization during scans and iterator reads.

## What Changed

- Cache entries in canonical, index-aligned chunks of 16 records.
- Reuse cached chunks across iterators with different prefetch sizes.
- Support partial and unaligned reads spanning multiple chunks.
- Avoid caching single-record reads used while building sparse arrays.
- Use bounded slot replacement with uniform hashing for arbitrary cache sizes.
- Publish cache instances and completed chunks safely for concurrent readers.
- Integrate caching into all four disk-segment layouts.
- Add `DiskSegmentOptions.MaterializedEntryCacheSize`.
  - Default: `4096` chunks per decompressed block.
  - Maximum retained entries: `65,536` per block.
  - Set to `0` to disable.
- Include the option in validation, cloning, and metadata handling.
- Release disk-segment resources through the shared base implementation.

## Testing

Added coverage for:

- Aligned, unaligned, partial, and multi-chunk reads
- Different iterator prefetch sizes
- Source and destination offsets
- Disabled and arbitrary cache sizes
- Slot replacement and capacity limits
- Large disk indexes
- Concurrent creation, publication, reads, and writes
- Option defaults, validation, cloning, and metadata persistence
