### PR TITLE
Performance Feature: Add search hint prefetch option to improve sequential lookup speed.

### DIFF
--- a/src/ZoneTree.UnitTests/CircularCacheTests.cs
+++ b/src/ZoneTree.UnitTests/CircularCacheTests.cs
@@ -1,0 +1,22 @@
+using ZoneTree.Segments.Disk;
+
+namespace ZoneTree.UnitTests;
+
+public sealed class CircularCacheTests
+{
+  [Test]
+  public void DistributesIndexesWithIdenticalLowBits()
+  {
+    var cache = new CircularCache<int>(8, 10_000);
+    var first = 1;
+    var second = 2;
+
+    cache.TryAdd(0, ref first);
+    cache.TryAdd(8, ref second);
+
+    Assert.That(cache.TryGet(0, out var firstResult), Is.True);
+    Assert.That(firstResult, Is.EqualTo(first));
+    Assert.That(cache.TryGet(8, out var secondResult), Is.True);
+    Assert.That(secondResult, Is.EqualTo(second));
+  }
+}

--- a/src/ZoneTree.UnitTests/DiskSegmentFactoryTests.cs
+++ b/src/ZoneTree.UnitTests/DiskSegmentFactoryTests.cs
@@ -130,6 +130,27 @@ public sealed class DiskSegmentFactoryTests
         Assert.That(diskSegment.TryGet(keys[i], out var value), Is.True);
         Assert.That(value, Is.EqualTo(values[i]));
       }
+
+      for (var i = recordCount - 1; i >= 0; --i)
+      {
+        Assert.That(diskSegment.TryGet(keys[i], out var value), Is.True);
+        Assert.That(value, Is.EqualTo(values[i]));
+      }
+
+      int[] mixedIndexes =
+      [
+        0,
+        1,
+        2,
+        recordCount - 1,
+        recordCount - 2,
+        recordCount - 3
+      ];
+      foreach (var index in mixedIndexes)
+      {
+        Assert.That(diskSegment.TryGet(keys[index], out var value), Is.True);
+        Assert.That(value, Is.EqualTo(values[index]));
+      }
     }
 
     DeleteDirectory(dataPath);

--- a/src/ZoneTree.UnitTests/DiskSegmentSearchHintTests.cs
+++ b/src/ZoneTree.UnitTests/DiskSegmentSearchHintTests.cs
@@ -1,0 +1,215 @@
+using ZoneTree.Collections;
+using ZoneTree.Comparers;
+using ZoneTree.Options;
+using ZoneTree.Segments.Block;
+using ZoneTree.Segments.Disk;
+using ZoneTree.Serializers;
+
+namespace ZoneTree.UnitTests;
+
+public sealed class DiskSegmentSearchHintTests
+{
+  [Test]
+  public void DefaultPrefetchSizeIs16()
+  {
+    Assert.That(DiskSegmentDefaultValues.SearchHintPrefetchSize, Is.EqualTo(16));
+    Assert.That(new DiskSegmentOptions().SearchHintPrefetchSize, Is.EqualTo(16));
+  }
+
+  [Test]
+  public void ZeroDisablesSearchHintPrefetch()
+  {
+    using var segment = CreateSegment(0);
+
+    AssertGet(segment, 0);
+    AssertGet(segment, 1);
+    AssertGet(segment, 2);
+
+    Assert.That(segment.ReadEntriesCounts, Is.Empty);
+  }
+
+  [TestCase(1)]
+  [TestCase(7)]
+  [TestCase(16)]
+  public void ConfiguredSizeControlsForwardPrefetch(int prefetchSize)
+  {
+    using var segment = CreateSegment(prefetchSize, 64);
+
+    AssertGet(segment, 0);
+    AssertGet(segment, 1);
+    AssertGet(segment, 2);
+
+    Assert.That(segment.ReadEntriesCounts, Is.EqualTo(new[] { prefetchSize }));
+    AssertGet(segment, 3);
+    if (prefetchSize > 1)
+      Assert.That(segment.ReadEntriesCounts, Has.Count.EqualTo(1));
+  }
+
+  [Test]
+  public void PrefetchIsClippedAtSegmentBoundary()
+  {
+    using var segment = CreateSegment(64, 5);
+
+    AssertGet(segment, 2);
+    AssertGet(segment, 3);
+    AssertGet(segment, 4);
+
+    Assert.That(segment.ReadEntriesCounts, Is.EqualTo(new[] { 1 }));
+  }
+
+  [Test]
+  public void ReverseSearchPrefetchesConfiguredWindow()
+  {
+    using var segment = CreateSegment(4, 16);
+
+    AssertGet(segment, 9);
+    AssertGet(segment, 8);
+    AssertGet(segment, 7);
+    AssertGet(segment, 6);
+
+    Assert.That(segment.ReadEntriesCounts, Is.EqualTo(new[] { 4 }));
+  }
+
+  [Test]
+  public void NonSequentialSearchesDoNotPrefetch()
+  {
+    using var segment = CreateSegment(16, 64);
+
+    AssertGet(segment, 0);
+    AssertGet(segment, 2);
+    AssertGet(segment, 4);
+    AssertGet(segment, 6);
+
+    Assert.That(segment.ReadEntriesCounts, Is.Empty);
+  }
+
+  [Test]
+  public void PrefetchReleasesPinnedBlocks()
+  {
+    using var segment = CreateSegment(16, 64);
+
+    AssertGet(segment, 0);
+    AssertGet(segment, 1);
+    AssertGet(segment, 2);
+
+    Assert.That(segment.LastBlockPin, Is.Not.Null);
+    Assert.That(segment.LastBlockPin.Device1, Is.Null);
+    Assert.That(segment.LastBlockPin.Device2, Is.Null);
+  }
+
+  [Test]
+  public void FailedPrefetchReleasesPinnedBlocks()
+  {
+    using var segment = CreateSegment(16, 64);
+    segment.ThrowFromReadEntries = true;
+
+    AssertGet(segment, 0);
+    AssertGet(segment, 1);
+    Assert.Throws<InvalidOperationException>(() => segment.TryGet(2, out _));
+
+    Assert.That(segment.LastBlockPin, Is.Not.Null);
+    Assert.That(segment.LastBlockPin.Device1, Is.Null);
+    Assert.That(segment.LastBlockPin.Device2, Is.Null);
+  }
+
+  static void AssertGet(TestDiskSegment segment, int key)
+  {
+    Assert.That(segment.TryGet(key, out var value), Is.True);
+    Assert.That(value, Is.EqualTo(key + 100));
+  }
+
+  static TestDiskSegment CreateSegment(
+      int searchHintPrefetchSize,
+      int length = 32)
+  {
+    var options = new ZoneTreeOptions<int, int>
+    {
+      Comparer = new Int32ComparerAscending(),
+      KeySerializer = new Int32Serializer(),
+      ValueSerializer = new Int32Serializer(),
+      DiskSegmentOptions = new DiskSegmentOptions
+      {
+        SearchHintPrefetchSize = searchHintPrefetchSize
+      }
+    };
+    return new TestDiskSegment(options, length);
+  }
+
+  sealed class TestDiskSegment : DiskSegment<int, int>
+  {
+    public readonly List<int> ReadEntriesCounts = [];
+
+    public BlockPin LastBlockPin;
+
+    public bool ThrowFromReadEntries;
+
+    public override int ReadBufferCount => 0;
+
+    public TestDiskSegment(
+        ZoneTreeOptions<int, int> options,
+        int length) : base(1, options)
+    {
+      Length = length;
+    }
+
+    protected override int ReadKey(long index, BlockPin blockPin)
+    {
+      return checked((int)index);
+    }
+
+    protected override int ReadValue(long index, BlockPin blockPin)
+    {
+      return checked((int)index + 100);
+    }
+
+    public override int ReadEntries(
+        long startIndex,
+        int count,
+        int[] keys,
+        int[] values,
+        int destinationIndex,
+        BlockPin blockPin)
+    {
+      if (startIndex < 0 || startIndex >= Length || count <= 0)
+        return 0;
+
+      count = (int)Math.Min(count, Length - startIndex);
+      ReadEntriesCounts.Add(count);
+      LastBlockPin = blockPin;
+      blockPin?.SetDevice1(new DecompressedBlock(
+          0,
+          Memory<byte>.Empty,
+          CompressionMethod.None,
+          0));
+      blockPin?.SetDevice2(new DecompressedBlock(
+          1,
+          Memory<byte>.Empty,
+          CompressionMethod.None,
+          0));
+      if (ThrowFromReadEntries)
+        throw new InvalidOperationException("Test read failure.");
+      for (var i = 0; i < count; ++i)
+      {
+        var key = checked((int)startIndex + i);
+        keys[destinationIndex + i] = key;
+        values[destinationIndex + i] = key + 100;
+      }
+      return count;
+    }
+
+    protected override void DeleteDevices()
+    {
+    }
+
+    public override int ReleaseReadBuffers(long ticks)
+    {
+      return 0;
+    }
+
+    public override void SetDefaultSparseArray(
+        IReadOnlyList<SparseArrayEntry<int, int>> defaultSparseArray)
+    {
+      SparseArray = defaultSparseArray;
+    }
+  }
+}

--- a/src/ZoneTree.UnitTests/ZoneTreeMetaOptionsTests.cs
+++ b/src/ZoneTree.UnitTests/ZoneTreeMetaOptionsTests.cs
@@ -21,6 +21,9 @@ public sealed class ZoneTreeMetaOptionsTests
       Assert.That(
           zoneTree.Maintenance.CloneOptions().DiskSegmentOptions.MaterializedEntryCacheSize,
           Is.EqualTo(expected.DiskSegmentMaterializedEntryCacheSize));
+      Assert.That(
+          zoneTree.Maintenance.CloneOptions().DiskSegmentOptions.SearchHintPrefetchSize,
+          Is.EqualTo(expected.DiskSegmentSearchHintPrefetchSize));
       AssertMetadataOptions(dataPath, expected);
     }
     finally
@@ -91,6 +94,7 @@ public sealed class ZoneTreeMetaOptionsTests
           options.KeyCacheSize = expected.DiskSegmentKeyCacheSize;
           options.ValueCacheSize = expected.DiskSegmentValueCacheSize;
           options.MaterializedEntryCacheSize = expected.DiskSegmentMaterializedEntryCacheSize;
+          options.SearchHintPrefetchSize = expected.DiskSegmentSearchHintPrefetchSize;
           options.KeyCacheRecordLifeTimeInMillisecond =
               expected.DiskSegmentKeyCacheRecordLifeTimeInMillisecond;
           options.ValueCacheRecordLifeTimeInMillisecond =
@@ -127,6 +131,7 @@ public sealed class ZoneTreeMetaOptionsTests
           DiskSegmentKeyCacheSize: 11,
           DiskSegmentValueCacheSize: 13,
           DiskSegmentMaterializedEntryCacheSize: 17,
+          DiskSegmentSearchHintPrefetchSize: 19,
           DiskSegmentKeyCacheRecordLifeTimeInMillisecond: 23,
           DiskSegmentValueCacheRecordLifeTimeInMillisecond: 29,
           DefaultSparseArrayStepSize: 31),
@@ -152,6 +157,7 @@ public sealed class ZoneTreeMetaOptionsTests
           DiskSegmentKeyCacheSize: 17,
           DiskSegmentValueCacheSize: 19,
           DiskSegmentMaterializedEntryCacheSize: 23,
+          DiskSegmentSearchHintPrefetchSize: 29,
           DiskSegmentKeyCacheRecordLifeTimeInMillisecond: 31,
           DiskSegmentValueCacheRecordLifeTimeInMillisecond: 37,
           DefaultSparseArrayStepSize: 41),
@@ -177,6 +183,7 @@ public sealed class ZoneTreeMetaOptionsTests
           DiskSegmentKeyCacheSize: 23,
           DiskSegmentValueCacheSize: 29,
           DiskSegmentMaterializedEntryCacheSize: 31,
+          DiskSegmentSearchHintPrefetchSize: 37,
           DiskSegmentKeyCacheRecordLifeTimeInMillisecond: 41,
           DiskSegmentValueCacheRecordLifeTimeInMillisecond: 43,
           DefaultSparseArrayStepSize: 47),
@@ -223,6 +230,8 @@ public sealed class ZoneTreeMetaOptionsTests
     Assert.That(diskOptions.ValueCacheSize, Is.EqualTo(expected.DiskSegmentValueCacheSize));
     Assert.That(diskOptions.MaterializedEntryCacheSize,
         Is.EqualTo(expected.DiskSegmentMaterializedEntryCacheSize));
+    Assert.That(diskOptions.SearchHintPrefetchSize,
+        Is.EqualTo(expected.DiskSegmentSearchHintPrefetchSize));
     Assert.That(diskOptions.KeyCacheRecordLifeTimeInMillisecond,
         Is.EqualTo(expected.DiskSegmentKeyCacheRecordLifeTimeInMillisecond));
     Assert.That(diskOptions.ValueCacheRecordLifeTimeInMillisecond,
@@ -272,6 +281,7 @@ public sealed class ZoneTreeMetaOptionsTests
       int DiskSegmentKeyCacheSize,
       int DiskSegmentValueCacheSize,
       int DiskSegmentMaterializedEntryCacheSize,
+      int DiskSegmentSearchHintPrefetchSize,
       int DiskSegmentKeyCacheRecordLifeTimeInMillisecond,
       int DiskSegmentValueCacheRecordLifeTimeInMillisecond,
       int DefaultSparseArrayStepSize);

--- a/src/ZoneTree.UnitTests/ZoneTreeOptionsValidationTests.cs
+++ b/src/ZoneTree.UnitTests/ZoneTreeOptionsValidationTests.cs
@@ -236,6 +236,10 @@ public sealed class ZoneTreeOptionsValidationTests
         "DiskSegmentOptions.MaterializedEntryCacheSize");
 
     yield return Invalid(
+        options => options.DiskSegmentOptions.SearchHintPrefetchSize = -1,
+        "DiskSegmentOptions.SearchHintPrefetchSize");
+
+    yield return Invalid(
         options => options.DiskSegmentOptions.KeyCacheRecordLifeTimeInMillisecond = -1,
         "DiskSegmentOptions.KeyCacheRecordLifeTimeInMillisecond");
 

--- a/src/ZoneTree/Core/ZoneTree.cs
+++ b/src/ZoneTree/Core/ZoneTree.cs
@@ -384,6 +384,7 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
       KeyCacheRecordLifeTimeInMillisecond = dsk.KeyCacheRecordLifeTimeInMillisecond,
       KeyCacheSize = dsk.KeyCacheSize,
       MaterializedEntryCacheSize = dsk.MaterializedEntryCacheSize,
+      SearchHintPrefetchSize = dsk.SearchHintPrefetchSize,
       MaximumRecordCount = dsk.MaximumRecordCount,
       MinimumRecordCount = dsk.MinimumRecordCount,
       ValueCacheRecordLifeTimeInMillisecond = dsk.ValueCacheRecordLifeTimeInMillisecond,

--- a/src/ZoneTree/Options/DiskSegmentDefaultValues.cs
+++ b/src/ZoneTree/Options/DiskSegmentDefaultValues.cs
@@ -20,6 +20,8 @@ public static class DiskSegmentDefaultValues
 
   public static readonly int MaterializedEntryCacheSize = 4096;
 
+  public static readonly int SearchHintPrefetchSize = 16;
+
   public static readonly int KeyCacheRecordLifeTimeInMillisecond = 10_000;
 
   public static readonly int ValueCacheRecordLifeTimeInMillisecond = 10_000;

--- a/src/ZoneTree/Options/DiskSegmentOptions.cs
+++ b/src/ZoneTree/Options/DiskSegmentOptions.cs
@@ -90,6 +90,17 @@ public sealed class DiskSegmentOptions
       = DiskSegmentDefaultValues.MaterializedEntryCacheSize;
 
   /// <summary>
+  /// Gets or sets the number of adjacent entries prefetched after sequential
+  /// <c>TryGet</c> calls are detected. Larger values can improve sustained
+  /// sequential lookup throughput, but may read and retain more keys and
+  /// values when the access pattern changes. Buffers are allocated lazily per
+  /// disk segment and calling thread. Setting this value to zero disables
+  /// search hints. The default value is 16 entries.
+  /// </summary>
+  public int SearchHintPrefetchSize { get; set; }
+      = DiskSegmentDefaultValues.SearchHintPrefetchSize;
+
+  /// <summary>
   /// Gets or sets the maximum lifetime of a record in the key cache, in milliseconds.
   /// Longer lifetimes can keep cached keys in memory for longer.
   /// Default value is 10,000 milliseconds (10 seconds).

--- a/src/ZoneTree/Options/ZoneTreeOptionValidationRules.cs
+++ b/src/ZoneTree/Options/ZoneTreeOptionValidationRules.cs
@@ -41,6 +41,9 @@ internal static class ZoneTreeOptionValidationRules
   public static readonly Rule DiskSegmentMaterializedEntryCacheSize =
       Rule.Min(0);
 
+  public static readonly Rule DiskSegmentSearchHintPrefetchSize =
+      Rule.Min(0);
+
   public static readonly Rule DiskSegmentKeyCacheRecordLifeTimeInMillisecond =
       Rule.MinSeconds(0);
 

--- a/src/ZoneTree/Options/ZoneTreeOptionsValidator.cs
+++ b/src/ZoneTree/Options/ZoneTreeOptionsValidator.cs
@@ -213,6 +213,12 @@ internal static class ZoneTreeOptionsValidator
     if (exception != null)
       return exception;
 
+    exception = ZoneTreeOptionValidationRules.DiskSegmentSearchHintPrefetchSize.Validate(
+        Option(owner, nameof(options.SearchHintPrefetchSize)),
+        options.SearchHintPrefetchSize);
+    if (exception != null)
+      return exception;
+
     exception = ZoneTreeOptionValidationRules.DiskSegmentKeyCacheRecordLifeTimeInMillisecond.Validate(
         Option(owner, nameof(options.KeyCacheRecordLifeTimeInMillisecond)),
         options.KeyCacheRecordLifeTimeInMillisecond);

--- a/src/ZoneTree/Segments/Block/BlockPin.cs
+++ b/src/ZoneTree/Segments/Block/BlockPin.cs
@@ -1,28 +1,17 @@
 namespace ZoneTree.Segments.Block;
 
-public sealed class BlockPin
+public sealed class BlockPin(DecompressedBlock device1 = null, DecompressedBlock device2 = null)
 {
-  public DecompressedBlock Device1;
+  public DecompressedBlock Device1 = device1;
 
-  public DecompressedBlock Device2;
+  public DecompressedBlock Device2 = device2;
 
   public bool ContributeToTheBlockCache;
 
-  public BlockPin(DecompressedBlock device1 = null, DecompressedBlock device2 = null)
-  {
-    Device1 = device1;
-    Device2 = device2;
-  }
   public SingleBlockPin ToSingleBlockPin(int num)
   {
-    if (num == 1) return new SingleBlockPin(Device1)
-    {
-      ContributeToTheBlockCache = ContributeToTheBlockCache
-    };
-    if (num == 2) return new SingleBlockPin(Device2)
-    {
-      ContributeToTheBlockCache = ContributeToTheBlockCache
-    };
+    if (num == 1) return new SingleBlockPin(Device1, ContributeToTheBlockCache);
+    if (num == 2) return new SingleBlockPin(Device2, ContributeToTheBlockCache);
     throw new ArgumentException("Supported device numbers are 1 and 2 but given " + num);
   }
 
@@ -35,6 +24,11 @@ public sealed class BlockPin
   {
     Device2 = device;
   }
-}
 
+  public void Clear()
+  {
+    SetDevice1(null);
+    SetDevice2(null);
+  }
+}
 

--- a/src/ZoneTree/Segments/Block/SingleBlockPin.cs
+++ b/src/ZoneTree/Segments/Block/SingleBlockPin.cs
@@ -1,15 +1,10 @@
 namespace ZoneTree.Segments.Block;
 
-public sealed class SingleBlockPin
+public sealed class SingleBlockPin(DecompressedBlock device, bool contributeToTheBlockCache)
 {
-  public DecompressedBlock Device;
+  public DecompressedBlock Device = device;
 
-  public bool ContributeToTheBlockCache;
-
-  public SingleBlockPin(DecompressedBlock device)
-  {
-    Device = device;
-  }
+  public bool ContributeToTheBlockCache = contributeToTheBlockCache;
 
   public void SetDevice(DecompressedBlock device) { Device = device; }
 }

--- a/src/ZoneTree/Segments/Disk/CircularCache.cs
+++ b/src/ZoneTree/Segments/Disk/CircularCache.cs
@@ -1,13 +1,18 @@
 using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
 
 namespace ZoneTree.Segments.Disk;
 
 public sealed class CircularCache<TDataType>
 {
+  const ulong HashMultiplier = 0x9E3779B97F4A7C15UL;
+
   public sealed class CacheAndCacheSize
   {
     public int CacheSize;
     public CachedRecord[] circularBuffer;
+    internal int HashShift;
   }
 
   public sealed class CachedRecord
@@ -22,52 +27,15 @@ public sealed class CircularCache<TDataType>
 
   public int RecordLifeTimeInMillisecond { get; set; } = 10000;
 
-  int statsCacheHit;
-
-  int statsCacheMiss;
-
-  public (int cacheHit, int cacheMiss) CacheStats => (statsCacheHit, statsCacheMiss);
-
-  public void ResetCacheStats()
-  {
-    statsCacheHit = 0;
-    statsCacheMiss = 0;
-  }
-
   public CircularCache(int cacheSize, int recordLifeTimeInMillisecond)
   {
     RecordLifeTimeInMillisecond = recordLifeTimeInMillisecond;
     Cache = new CacheAndCacheSize()
     {
       CacheSize = cacheSize,
-      circularBuffer = new CachedRecord[cacheSize]
+      circularBuffer = new CachedRecord[cacheSize],
+      HashShift = GetHashShift(cacheSize)
     };
-  }
-
-  public void SetCacheSize(int cacheSize)
-  {
-    if (cacheSize < 0)
-      cacheSize = 0;
-    var newBuffer = new CachedRecord[cacheSize];
-    var newCache = new CacheAndCacheSize
-    {
-      CacheSize = cacheSize,
-      circularBuffer = newBuffer
-    };
-    if (cacheSize > 0)
-    {
-      var ticks = Environment.TickCount64 - RecordLifeTimeInMillisecond;
-      var oldBuffer = Cache.circularBuffer;
-      var len = oldBuffer.Length;
-      for (int i = 0; i < len; i++)
-      {
-        var record = oldBuffer[i];
-        var circularIndex = i % cacheSize;
-        if (record.IsExpired(ticks)) continue;
-        newBuffer[circularIndex] = record;
-      }
-    }
-    Cache = newCache;
   }
 
   public bool TryGet(long index, out TDataType key)
@@ -80,17 +48,14 @@ public sealed class CircularCache<TDataType>
       return false;
     }
     var circularBuffer = cache.circularBuffer;
-    var len = circularBuffer.Length;
-    var circularIndex = index % cacheSize;
+    var circularIndex = GetSlotIndex(index, cache);
     var cacheRecord = circularBuffer[circularIndex];
     if (cacheRecord != null && cacheRecord.Index == index)
     {
       key = cacheRecord.Record;
       cacheRecord.LastAccess = Environment.TickCount64;
-      ++statsCacheHit;
       return true;
     }
-    ++statsCacheMiss;
     key = default;
     return false;
   }
@@ -101,7 +66,7 @@ public sealed class CircularCache<TDataType>
     var cacheSize = cache.CacheSize;
     if (cacheSize < 1) return false;
     var circularBuffer = cache.circularBuffer;
-    var circularIndex = index % cacheSize;
+    var circularIndex = GetSlotIndex(index, cache);
     var cachedRecord = new CachedRecord
     {
       Index = index,
@@ -136,5 +101,27 @@ public sealed class CircularCache<TDataType>
     {
       circularBuffer[i] = null;
     }
+  }
+
+  [MethodImpl(MethodImplOptions.AggressiveInlining)]
+  static int GetSlotIndex(long index, CacheAndCacheSize cache)
+  {
+    var hash = unchecked((ulong)index * HashMultiplier);
+    var hashShift = cache.HashShift;
+    if (hashShift != 0)
+      return (int)(hash >> hashShift);
+    if (cache.CacheSize == 1)
+      return 0;
+    return (int)Math.BigMul(
+        hash,
+        (ulong)(uint)cache.CacheSize,
+        out _);
+  }
+
+  static int GetHashShift(int cacheSize)
+  {
+    return cacheSize > 1 && BitOperations.IsPow2((uint)cacheSize)
+        ? 64 - BitOperations.Log2((uint)cacheSize)
+        : 0;
   }
 }

--- a/src/ZoneTree/Segments/Disk/DiskSegment.cs
+++ b/src/ZoneTree/Segments/Disk/DiskSegment.cs
@@ -11,6 +11,34 @@ namespace ZoneTree.Segments.Disk;
 
 public abstract class DiskSegment<TKey, TValue> : IDiskSegment<TKey, TValue>
 {
+  sealed class SearchHint
+  {
+    public readonly BlockPin BlockPin = new()
+    {
+      ContributeToTheBlockCache = true
+    };
+
+    public long LastIndex = -1;
+
+    public int Direction;
+
+    public TKey[] PrefetchedKeys;
+
+    public TValue[] PrefetchedValues;
+
+    public long PrefetchStartIndex;
+
+    public int PrefetchCount;
+
+    public int PrefetchPosition;
+
+    public void EnsurePrefetchBuffers(int prefetchSize)
+    {
+      PrefetchedKeys ??= new TKey[prefetchSize];
+      PrefetchedValues ??= new TValue[prefetchSize];
+    }
+  }
+
   public long SegmentId { get; }
 
   readonly IRefComparer<TKey> Comparer;
@@ -20,6 +48,8 @@ public abstract class DiskSegment<TKey, TValue> : IDiskSegment<TKey, TValue>
   protected readonly ISerializer<TValue> ValueSerializer;
 
   protected readonly int MaterializedEntryCacheSize;
+
+  readonly int SearchHintPrefetchSize;
 
   protected IRandomAccessDevice DataDevice;
 
@@ -40,6 +70,10 @@ public abstract class DiskSegment<TKey, TValue> : IDiskSegment<TKey, TValue>
   bool IsDropped;
 
   readonly Lock DropLock = new();
+
+  readonly ThreadLocal<SearchHint> SearchHints;
+
+  int AreSearchHintsDisposed;
 
   public long Length { get; protected set; }
 
@@ -70,6 +104,9 @@ public abstract class DiskSegment<TKey, TValue> : IDiskSegment<TKey, TValue>
     ValueSerializer = options.ValueSerializer;
     var diskOptions = options.DiskSegmentOptions;
     MaterializedEntryCacheSize = diskOptions.MaterializedEntryCacheSize;
+    SearchHintPrefetchSize = diskOptions.SearchHintPrefetchSize;
+    if (SearchHintPrefetchSize > 0)
+      SearchHints = new(() => new());
     CircularKeyCache = new CircularCache<TKey>(
         diskOptions.KeyCacheSize,
         diskOptions.KeyCacheRecordLifeTimeInMillisecond);
@@ -91,6 +128,9 @@ public abstract class DiskSegment<TKey, TValue> : IDiskSegment<TKey, TValue>
     ValueSerializer = options.ValueSerializer;
     var diskOptions = options.DiskSegmentOptions;
     MaterializedEntryCacheSize = diskOptions.MaterializedEntryCacheSize;
+    SearchHintPrefetchSize = diskOptions.SearchHintPrefetchSize;
+    if (SearchHintPrefetchSize > 0)
+      SearchHints = new(() => new());
     CircularKeyCache = new CircularCache<TKey>(
         diskOptions.KeyCacheSize,
         diskOptions.KeyCacheRecordLifeTimeInMillisecond);
@@ -131,6 +171,17 @@ public abstract class DiskSegment<TKey, TValue> : IDiskSegment<TKey, TValue>
 
   public bool TryGet(in TKey key, out TValue value)
   {
+    var searchHint = SearchHints?.Value;
+    var direction = searchHint?.Direction ?? 0;
+    if (direction != 0 && TryGetFromSearchHint(
+        searchHint,
+        direction,
+        in key,
+        out value))
+    {
+      return true;
+    }
+
     var sparseArrayLength = SparseArray.Count;
     long lower = 0;
     long upper = Length - 1;
@@ -140,11 +191,15 @@ public abstract class DiskSegment<TKey, TValue> : IDiskSegment<TKey, TValue>
       (var index, var found) = SearchLastSmallerOrEqualPositionInSparseArray(in key);
       if (found)
       {
+        if (searchHint != null)
+          UpdateSearchHint(searchHint, SparseArray[index].Index);
         value = SparseArray[index].Value;
         return true;
       }
       if (index == -1 || index == sparseArrayLength - 1)
       {
+        if (searchHint != null)
+          ResetSearchHint(searchHint);
         value = default;
         return false;
       }
@@ -154,11 +209,142 @@ public abstract class DiskSegment<TKey, TValue> : IDiskSegment<TKey, TValue>
     var result = BinarySearchAlgorithms.BinarySearch(ReadKey, lower, upper, Comparer, in key);
     if (result < 0)
     {
+      if (searchHint != null)
+        ResetSearchHint(searchHint);
       value = default;
       return false;
     }
+    if (searchHint != null)
+      UpdateSearchHint(searchHint, result);
     value = GetValue(result);
     return true;
+  }
+
+  bool TryGetFromSearchHint(
+      SearchHint searchHint,
+      int direction,
+      in TKey key,
+      out TValue value)
+  {
+    var hintedIndex = searchHint.LastIndex + direction;
+    if ((ulong)hintedIndex >= (ulong)Length)
+    {
+      InvalidateSearchHintPrefetch(searchHint);
+      value = default;
+      return false;
+    }
+
+    var position = searchHint.PrefetchPosition;
+    if ((uint)position >= (uint)searchHint.PrefetchCount ||
+        searchHint.PrefetchStartIndex + position != hintedIndex)
+    {
+      if (!PrefetchSearchHint(searchHint, hintedIndex, direction))
+      {
+        InvalidateSearchHintPrefetch(searchHint);
+        value = default;
+        return false;
+      }
+      position = searchHint.PrefetchPosition;
+    }
+
+    var hintedKey = searchHint.PrefetchedKeys[position];
+    if (Comparer.Compare(in hintedKey, in key) != 0)
+    {
+      InvalidateSearchHintPrefetch(searchHint);
+      value = default;
+      return false;
+    }
+
+    value = searchHint.PrefetchedValues[position];
+    searchHint.LastIndex = hintedIndex;
+    searchHint.PrefetchPosition = position + direction;
+    return true;
+  }
+
+  bool PrefetchSearchHint(
+      SearchHint searchHint,
+      long hintedIndex,
+      int direction)
+  {
+    var prefetchSize = (int)Math.Min(SearchHintPrefetchSize, Length);
+    long startIndex;
+    int count;
+    int position;
+    if (direction > 0)
+    {
+      startIndex = hintedIndex;
+      count = (int)Math.Min(prefetchSize, Length - startIndex);
+      position = 0;
+    }
+    else
+    {
+      startIndex = Math.Max(0, hintedIndex - prefetchSize + 1);
+      count = (int)(hintedIndex - startIndex + 1);
+      position = count - 1;
+    }
+
+    searchHint.EnsurePrefetchBuffers(prefetchSize);
+    int readCount;
+    try
+    {
+      readCount = ReadEntries(
+          startIndex,
+          count,
+          searchHint.PrefetchedKeys,
+          searchHint.PrefetchedValues,
+          0,
+          searchHint.BlockPin);
+    }
+    finally
+    {
+      searchHint.BlockPin.Clear();
+    }
+    if (readCount != count)
+      return false;
+
+    searchHint.PrefetchStartIndex = startIndex;
+    searchHint.PrefetchCount = readCount;
+    searchHint.PrefetchPosition = position;
+    return true;
+  }
+
+  [MethodImpl(MethodImplOptions.AggressiveInlining)]
+  static void UpdateSearchHint(SearchHint searchHint, long index)
+  {
+    var lastIndex = searchHint.LastIndex;
+    searchHint.Direction = lastIndex < 0
+        ? 0
+        : (index - lastIndex) switch
+        {
+          1 => 1,
+          -1 => -1,
+          _ => 0
+        };
+    searchHint.LastIndex = index;
+    ClearSearchHintPrefetch(searchHint);
+  }
+
+  [MethodImpl(MethodImplOptions.AggressiveInlining)]
+  static void ResetSearchHint(SearchHint searchHint)
+  {
+    searchHint.LastIndex = -1;
+    searchHint.Direction = 0;
+    ClearSearchHintPrefetch(searchHint);
+  }
+
+  [MethodImpl(MethodImplOptions.AggressiveInlining)]
+  static void InvalidateSearchHintPrefetch(SearchHint searchHint)
+  {
+    searchHint.Direction = 0;
+    ClearSearchHintPrefetch(searchHint);
+  }
+
+  [MethodImpl(MethodImplOptions.AggressiveInlining)]
+  static void ClearSearchHintPrefetch(SearchHint searchHint)
+  {
+    searchHint.PrefetchCount = 0;
+    searchHint.PrefetchPosition = 0;
+    searchHint.BlockPin.Clear();
   }
 
   public void InitSparseArray(int size)
@@ -305,6 +491,7 @@ public abstract class DiskSegment<TKey, TValue> : IDiskSegment<TKey, TValue>
   {
     if (!disposing)
       return;
+    DisposeSearchHints();
     ReleaseResources();
   }
 
@@ -444,7 +631,16 @@ public abstract class DiskSegment<TKey, TValue> : IDiskSegment<TKey, TValue>
 
   public virtual void ReleaseResources()
   {
+    DisposeSearchHints();
     DataDevice?.Dispose();
+  }
+
+  void DisposeSearchHints()
+  {
+    var searchHints = SearchHints;
+    if (searchHints != null &&
+        Interlocked.Exchange(ref AreSearchHintsDisposed, 1) == 0)
+      searchHints.Dispose();
   }
 
   public abstract int ReleaseReadBuffers(long ticks);


### PR DESCRIPTION
## Summary

This PR improves sequential `TryGet` performance for disk segments by detecting adjacent lookups and prefetching a configurable window of entries.

It also improves circular-cache key distribution and removes unused cache APIs and statistics from the hot read path.

## Changes

- Detect forward and reverse sequential `TryGet` access patterns.
- Prefetch adjacent keys and values after a sequential pattern is established.
- Keep search-hint state isolated per disk segment and thread.
- Allocate prefetch buffers lazily.
- Reuse a `BlockPin` within each prefetch operation and clear it deterministically, including exceptional paths.
- Fall back to the normal sparse-array and binary-search path when a hint does not match.
- Dispose thread-local search-hint state with the owning disk segment.
- Distribute circular-cache indexes using multiplicative hashing instead of relying on low index bits.
- Support both power-of-two and arbitrary circular-cache capacities.
- Remove unused circular-cache statistics and `SetCacheSize`.
- Simplify `BlockPin` and `SingleBlockPin` construction.

## Configuration

Adds `DiskSegmentOptions.SearchHintPrefetchSize`:

- Default: `16`
- `0`: disables search hints
- Positive values: control the number of adjacent entries prefetched
- Larger values may improve sustained sequential lookups at the cost of larger per-thread, per-segment buffers

The option is validated, cloned, and persisted through ZoneTree metadata.

## Correctness

Search hints are strictly an optimization. A missing, stale, mismatched, or out-of-range hint returns execution to the existing lookup path.

Coverage includes:

- Forward and reverse sequential lookups
- Random and mixed lookup patterns
- Segment boundaries and clipped prefetch windows
- Multiple prefetch sizes
- Disabled search hints
- Normal and exceptional block-pin cleanup
- All supported disk-segment layouts
- Circular-cache distribution for indexes sharing identical low bits
- Option validation and metadata persistence