### PR TITLE
Performance: Scale disk reads and iterator lifecycle under concurrent workloads

### DIFF
--- a/src/ZoneTree.UnitTests/DiskSegmentLeaseTests.cs
+++ b/src/ZoneTree.UnitTests/DiskSegmentLeaseTests.cs
@@ -1,0 +1,251 @@
+using ZoneTree.Collections;
+using ZoneTree.Comparers;
+using ZoneTree.Options;
+using ZoneTree.Segments;
+using ZoneTree.Segments.Block;
+using ZoneTree.Segments.Disk;
+using ZoneTree.Serializers;
+
+namespace ZoneTree.UnitTests;
+
+public sealed class DiskSegmentLeaseTests
+{
+  [Test]
+  public void AllowsRepeatedAttachAndDetachWhileActive()
+  {
+    var segment = CreateSegment();
+
+    segment.AttachIterator();
+    segment.DetachIterator();
+    segment.AttachIterator();
+    segment.DetachIterator();
+
+    Assert.That(segment.DeleteCount, Is.Zero);
+  }
+
+  [Test]
+  public void DefersDropUntilTheLastIteratorDetaches()
+  {
+    var segment = CreateSegment();
+    segment.AttachIterator();
+    segment.AttachIterator();
+
+    segment.Drop();
+
+    Assert.Multiple(() =>
+    {
+      Assert.That(segment.DeleteCount, Is.Zero);
+      Assert.Throws<InvalidOperationException>(segment.AttachIterator);
+    });
+
+    segment.DetachIterator();
+    Assert.That(segment.DeleteCount, Is.Zero);
+
+    segment.DetachIterator();
+    Assert.That(segment.DeleteCount, Is.EqualTo(1));
+  }
+
+  [Test]
+  public void ConcurrentDetachesCompleteDropExactlyOnce()
+  {
+    const int iteratorCount = 64;
+    var segment = CreateSegment();
+    for (var i = 0; i < iteratorCount; ++i)
+      segment.AttachIterator();
+    segment.Drop();
+
+    Parallel.For(0, iteratorCount, _ => segment.DetachIterator());
+
+    Assert.That(segment.DeleteCount, Is.EqualTo(1));
+  }
+
+  [Test]
+  public void ImmediateDropIsIdempotent()
+  {
+    var segment = CreateSegment();
+
+    segment.Drop();
+    segment.Drop();
+
+    Assert.That(segment.DeleteCount, Is.EqualTo(1));
+  }
+
+  [Test]
+  public void ActiveReadDelaysDeviceDeletion()
+  {
+    var segment = CreateSegment();
+    var readStripe = segment.BeginTestRead();
+    Task drop = null;
+
+    try
+    {
+      Assert.That(segment.ActiveReads, Is.EqualTo(1));
+      drop = Task.Run(segment.Drop);
+
+      Assert.That(
+          SpinWait.SpinUntil(
+              () => segment.IsDropInProgress,
+              TimeSpan.FromSeconds(5)),
+          Is.True);
+      Assert.That(segment.DeleteStarted.IsSet, Is.False);
+    }
+    finally
+    {
+      segment.EndTestRead(readStripe);
+      drop?.Wait(TimeSpan.FromSeconds(5));
+    }
+
+    Assert.Multiple(() =>
+    {
+      Assert.That(segment.ActiveReads, Is.Zero);
+      Assert.That(segment.DeleteCount, Is.EqualTo(1));
+    });
+  }
+
+  [Test]
+  public void ConcurrentDropWaitsForInProgressDeletion()
+  {
+    var segment = CreateSegment();
+    segment.BlockDelete = true;
+
+    var firstDrop = Task.Run(segment.Drop);
+    Task secondDrop = null;
+    try
+    {
+      Assert.That(segment.DeleteStarted.Wait(TimeSpan.FromSeconds(5)), Is.True);
+
+      using var secondDropStarted = new ManualResetEventSlim();
+      secondDrop = Task.Run(() =>
+      {
+        secondDropStarted.Set();
+        segment.Drop();
+      });
+      Assert.That(secondDropStarted.Wait(TimeSpan.FromSeconds(5)), Is.True);
+      Assert.That(secondDrop.Wait(TimeSpan.FromMilliseconds(100)), Is.False);
+    }
+    finally
+    {
+      segment.AllowDelete.Set();
+      firstDrop.Wait(TimeSpan.FromSeconds(5));
+      secondDrop?.Wait(TimeSpan.FromSeconds(5));
+    }
+
+    Assert.That(segment.DeleteCount, Is.EqualTo(1));
+  }
+
+  [Test]
+  public void FailedImmediateDropCanBeRetried()
+  {
+    var segment = CreateSegment();
+    segment.ThrowOnDelete = true;
+
+    Assert.Throws<InvalidOperationException>(segment.Drop);
+    Assert.That(segment.DeleteCount, Is.EqualTo(1));
+
+    segment.ThrowOnDelete = false;
+    segment.Drop();
+
+    Assert.That(segment.DeleteCount, Is.EqualTo(2));
+  }
+
+  [Test]
+  public void FailedDeferredDropIsReportedAndCanBeRetried()
+  {
+    var segment = CreateSegment();
+    Exception reportedException = null;
+    segment.DropFailureReporter = (_, exception) => reportedException = exception;
+    segment.ThrowOnDelete = true;
+    segment.AttachIterator();
+    segment.Drop();
+
+    Assert.DoesNotThrow(segment.DetachIterator);
+    Assert.Multiple(() =>
+    {
+      Assert.That(segment.DeleteCount, Is.EqualTo(1));
+      Assert.That(reportedException, Is.TypeOf<InvalidOperationException>());
+    });
+
+    segment.ThrowOnDelete = false;
+    segment.Drop();
+
+    Assert.That(segment.DeleteCount, Is.EqualTo(2));
+  }
+
+  [Test]
+  public void RejectsUnbalancedDetach()
+  {
+    var segment = CreateSegment();
+
+    Assert.Throws<InvalidOperationException>(segment.DetachIterator);
+  }
+
+  static TestDiskSegment CreateSegment()
+  {
+    var options = new ZoneTreeOptions<int, int>
+    {
+      Comparer = new Int32ComparerAscending(),
+      KeySerializer = new Int32Serializer(),
+      ValueSerializer = new Int32Serializer()
+    };
+    return new TestDiskSegment(options);
+  }
+
+  sealed class TestDiskSegment(
+      ZoneTreeOptions<int, int> options) : DiskSegment<int, int>(1, options)
+  {
+    int deleteCount;
+
+    public int DeleteCount => Volatile.Read(ref deleteCount);
+
+    public int ActiveReads => ActiveReadCount;
+
+    public bool IsDropInProgress => IsDropping;
+
+    public bool ThrowOnDelete;
+
+    public bool BlockDelete;
+
+    public readonly ManualResetEventSlim DeleteStarted = new();
+
+    public readonly ManualResetEventSlim AllowDelete = new();
+
+    public override int ReadBufferCount => 0;
+
+    public int BeginTestRead() => BeginRead();
+
+    public void EndTestRead(int stripeIndex) => EndRead(stripeIndex);
+
+    protected override int ReadKey(long index, BlockPin blockPin) => (int)index;
+
+    protected override int ReadValue(long index, BlockPin blockPin) => (int)index;
+
+    public override int ReadEntries(
+        long startIndex,
+        int count,
+        int[] keys,
+        int[] values,
+        int destinationIndex,
+        BlockPin blockPin)
+    {
+      return 0;
+    }
+
+    protected override void DeleteDevices()
+    {
+      Interlocked.Increment(ref deleteCount);
+      DeleteStarted.Set();
+      if (BlockDelete)
+        AllowDelete.Wait();
+      if (ThrowOnDelete)
+        throw new InvalidOperationException("Test drop failure.");
+    }
+
+    public override int ReleaseReadBuffers(long ticks) => 0;
+
+    public override void SetDefaultSparseArray(
+        IReadOnlyList<SparseArrayEntry<int, int>> defaultSparseArray)
+    {
+      SparseArray = defaultSparseArray;
+    }
+  }
+}

--- a/src/ZoneTree.UnitTests/DiskSegmentReadCountTests.cs
+++ b/src/ZoneTree.UnitTests/DiskSegmentReadCountTests.cs
@@ -1,0 +1,141 @@
+using System.Reflection;
+using ZoneTree.Options;
+using ZoneTree.Segments;
+using ZoneTree.Segments.DiskSegmentVariations;
+using ZoneTree.Serializers;
+
+namespace ZoneTree.UnitTests;
+
+public sealed class DiskSegmentReadCountTests
+{
+  [Test]
+  public void FixedSizeKeyAndValueCacheHitsKeepReadCountBalanced()
+  {
+    AssertCacheHitsKeepReadCountBalanced(
+        "FixedSizeKeyAndValueCacheHitsKeepReadCountBalanced",
+        1,
+        2,
+        typeof(FixedSizeKeyAndValueDiskSegment<int, int>),
+        factory => factory.DisableDeletion());
+  }
+
+  [Test]
+  public void FixedSizeKeyCacheHitsKeepReadCountBalanced()
+  {
+    AssertCacheHitsKeepReadCountBalanced(
+        "FixedSizeKeyCacheHitsKeepReadCountBalanced",
+        1,
+        "value-1",
+        typeof(FixedSizeKeyDiskSegment<int, string>),
+        factory => factory
+            .DisableDeletion()
+            .SetValueSerializer(new UnicodeStringSerializer()));
+  }
+
+  [Test]
+  public void FixedSizeValueCacheHitsKeepReadCountBalanced()
+  {
+    AssertCacheHitsKeepReadCountBalanced(
+        "FixedSizeValueCacheHitsKeepReadCountBalanced",
+        "key-1",
+        2,
+        typeof(FixedSizeValueDiskSegment<string, int>),
+        factory => factory
+            .DisableDeletion()
+            .SetKeySerializer(new UnicodeStringSerializer()));
+  }
+
+  [Test]
+  public void VariableSizeCacheHitsKeepReadCountBalanced()
+  {
+    AssertCacheHitsKeepReadCountBalanced(
+        "VariableSizeCacheHitsKeepReadCountBalanced",
+        "key-1",
+        "value-1",
+        typeof(VariableSizeDiskSegment<string, string>),
+        factory => factory
+            .DisableDeletion()
+            .SetKeySerializer(new UnicodeStringSerializer())
+            .SetValueSerializer(new UnicodeStringSerializer()));
+  }
+
+  static void AssertCacheHitsKeepReadCountBalanced<TKey, TValue>(
+      string testName,
+      TKey key,
+      TValue value,
+      Type expectedSegmentType,
+      Func<ZoneTreeFactory<TKey, TValue>, ZoneTreeFactory<TKey, TValue>> configureFactory)
+  {
+    var dataPath = "data/" + testName;
+    DeleteDirectory(dataPath);
+
+    try
+    {
+      using var zoneTree = configureFactory(new ZoneTreeFactory<TKey, TValue>())
+          .SetDataDirectory(dataPath)
+          .SetWriteAheadLogDirectory(dataPath)
+          .ConfigureWriteAheadLogOptions(options =>
+              options.WriteAheadLogMode = WriteAheadLogMode.None)
+          .ConfigureDiskSegmentOptions(options =>
+          {
+            options.DiskSegmentMode = DiskSegmentMode.SingleDiskSegment;
+            options.KeyCacheSize = 8;
+            options.ValueCacheSize = 8;
+          })
+          .OpenOrCreate();
+
+      zoneTree.Upsert(key, value);
+      zoneTree.Maintenance.MoveMutableSegmentForward();
+      zoneTree.Maintenance.StartMergeOperation().Join();
+
+      var diskSegment = zoneTree.Maintenance.DiskSegment;
+      Assert.That(diskSegment.GetType(), Is.EqualTo(expectedSegmentType));
+
+      Assert.That(diskSegment.GetKey(0), Is.EqualTo(key));
+      AssertReadCountIsZero(diskSegment, "key cache warm-up");
+      Assert.That(diskSegment.GetKey(0), Is.EqualTo(key));
+      AssertReadCountIsZero(diskSegment, "key cache hit");
+
+      Assert.That(diskSegment.GetValue(0), Is.EqualTo(value));
+      AssertReadCountIsZero(diskSegment, "value cache warm-up");
+      Assert.That(diskSegment.GetValue(0), Is.EqualTo(value));
+      AssertReadCountIsZero(diskSegment, "value cache hit");
+    }
+    finally
+    {
+      DeleteDirectory(dataPath);
+    }
+  }
+
+  static void AssertReadCountIsZero<TKey, TValue>(
+      IDiskSegment<TKey, TValue> diskSegment,
+      string operation)
+  {
+    Assert.That(
+        GetReadCount(diskSegment),
+        Is.Zero,
+        $"ReadCount must remain balanced after {operation}.");
+  }
+
+  static int GetReadCount<TKey, TValue>(IDiskSegment<TKey, TValue> diskSegment)
+  {
+    for (var type = diskSegment.GetType(); type != null; type = type.BaseType)
+    {
+      var property = type.GetProperty(
+          "ActiveReadCount",
+          BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
+      if (property != null)
+        return (int)property.GetValue(diskSegment);
+    }
+
+    throw new MissingMemberException(
+        diskSegment.GetType().FullName,
+        "ActiveReadCount");
+  }
+
+  static void DeleteDirectory(string path)
+  {
+    if (Directory.Exists(path))
+      Directory.Delete(path, true);
+  }
+}

--- a/src/ZoneTree.UnitTests/LiveBackupTests.cs
+++ b/src/ZoneTree.UnitTests/LiveBackupTests.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using System.Text.Json;
 using ZoneTree.Backup;
 using ZoneTree.Logger;
@@ -410,7 +409,15 @@ public sealed class LiveBackupTests
     Assert.That(exception, Is.Not.Null);
     Assert.That(exception.InnerException, Is.TypeOf<InvalidOperationException>());
 
-    Assert.That(GetIteratorReaderCount(diskSegment), Is.EqualTo(0));
+    var diskSegmentFiles = diskSegment.GetFiles();
+    Assert.That(diskSegmentFiles, Is.Not.Empty);
+
+    diskSegment.Drop();
+
+    Assert.That(
+        diskSegmentFiles.All(file => !File.Exists(file.Path)),
+        Is.True,
+        "The failed backup left an iterator lease attached to the disk segment.");
 
     backup.Stop();
     zoneTree.Maintenance.Drop();
@@ -905,23 +912,6 @@ public sealed class LiveBackupTests
             backupPath,
             file.BackupPath.Replace('/', Path.DirectorySeparatorChar))),
         Is.True);
-  }
-
-  static int GetIteratorReaderCount(IDiskSegment<int, int> diskSegment)
-  {
-    var type = diskSegment.GetType();
-    while (type != null)
-    {
-      var field = type.GetField(
-          "IteratorReaderCount",
-          BindingFlags.Instance | BindingFlags.NonPublic);
-      if (field != null)
-        return (int)field.GetValue(diskSegment);
-      type = type.BaseType;
-    }
-    throw new MissingFieldException(
-        diskSegment.GetType().FullName,
-        "IteratorReaderCount");
   }
 
   public sealed class TestLiveBackupGenerationCatalog

--- a/src/ZoneTree.UnitTests/MultiPartDiskSegmentLeaseTests.cs
+++ b/src/ZoneTree.UnitTests/MultiPartDiskSegmentLeaseTests.cs
@@ -1,0 +1,141 @@
+using ZoneTree.AbstractFileStream;
+using ZoneTree.Collections;
+using ZoneTree.Comparers;
+using ZoneTree.Core;
+using ZoneTree.Logger;
+using ZoneTree.Options;
+using ZoneTree.Segments;
+using ZoneTree.Segments.Disk;
+using ZoneTree.Segments.MultiPart;
+using ZoneTree.Segments.RandomAccess;
+using ZoneTree.Serializers;
+using ZoneTree.WAL;
+
+namespace ZoneTree.UnitTests;
+
+public sealed class MultiPartDiskSegmentLeaseTests
+{
+  [Test]
+  public void DeferredDropPreservesTheFirstExclusionPlan()
+  {
+    var options = CreateOptions();
+    var deviceManager = options.RandomAccessDeviceManager;
+    var idProvider = new IncrementalIdProvider();
+    IDiskSegment<int, int> preservedPart = null;
+    IDiskSegment<int, int> droppedPart = null;
+    IDiskSegment<int, int> multiPart = null;
+    var iteratorAttached = false;
+
+    try
+    {
+      preservedPart = CreatePart(options, idProvider, 1, 2);
+      droppedPart = CreatePart(options, idProvider, 3, 4);
+      using (var creator = new MultiPartDiskSegmentCreator<int, int>(
+          options,
+          idProvider))
+      {
+        creator.Append(preservedPart, 1, 2, 1, 2);
+        creator.Append(droppedPart, 3, 4, 3, 4);
+        multiPart = creator.CreateReadOnlyDiskSegment();
+      }
+
+      var excludedPartIds = new HashSet<long> { preservedPart.SegmentId };
+      multiPart.AttachIterator();
+      iteratorAttached = true;
+
+      multiPart.Drop(excludedPartIds);
+      excludedPartIds.Clear();
+      multiPart.Drop();
+
+      Assert.Multiple(() =>
+      {
+        Assert.That(DeviceExists(deviceManager, preservedPart), Is.True);
+        Assert.That(DeviceExists(deviceManager, droppedPart), Is.True);
+        Assert.That(MultiPartMetadataExists(deviceManager, multiPart), Is.True);
+      });
+
+      multiPart.DetachIterator();
+      iteratorAttached = false;
+
+      Assert.Multiple(() =>
+      {
+        Assert.That(DeviceExists(deviceManager, preservedPart), Is.True);
+        Assert.That(DeviceExists(deviceManager, droppedPart), Is.False);
+        Assert.That(MultiPartMetadataExists(deviceManager, multiPart), Is.False);
+        Assert.That(preservedPart.TryGet(1, out var value), Is.True);
+        Assert.That(value, Is.EqualTo(1));
+      });
+    }
+    finally
+    {
+      if (iteratorAttached)
+        multiPart.DetachIterator();
+      multiPart?.Drop();
+      preservedPart?.Drop();
+      droppedPart?.Drop();
+      deviceManager.DropStore();
+    }
+  }
+
+  static ZoneTreeOptions<int, int> CreateOptions()
+  {
+    var logger = new ConsoleLogger(LogLevel.Error);
+    var options = new ZoneTreeOptions<int, int>
+    {
+      Comparer = new Int32ComparerAscending(),
+      KeySerializer = new Int32Serializer(),
+      ValueSerializer = new Int32Serializer(),
+      Logger = logger,
+      WriteAheadLogProvider = new NullWriteAheadLogProvider(),
+      RandomAccessDeviceManager = new RandomAccessDeviceManager(
+          logger,
+          new InMemoryFileStreamProvider(),
+          "data/DeferredDropPreservesTheFirstExclusionPlan"),
+      DiskSegmentOptions = new DiskSegmentOptions
+      {
+        DiskSegmentMode = DiskSegmentMode.MultiPartDiskSegment,
+        CompressionMethod = CompressionMethod.None,
+        CompressionLevel = 0,
+        CompressionBlockSize = 1024,
+        MinimumRecordCount = 1,
+        MaximumRecordCount = 100,
+        DefaultSparseArrayStepSize = 0,
+      },
+      AllowUnsafeOptionValues = true,
+    };
+    options.DisableDeletion();
+    options.Validate();
+    return options;
+  }
+
+  static IDiskSegment<int, int> CreatePart(
+      ZoneTreeOptions<int, int> options,
+      IIncrementalIdProvider idProvider,
+      params int[] keys)
+  {
+    using var creator = new DiskSegmentCreator<int, int>(options, idProvider);
+    foreach (var key in keys)
+      creator.Append(key, key, IteratorPosition.None);
+    return creator.CreateReadOnlyDiskSegment();
+  }
+
+  static bool DeviceExists(
+      IRandomAccessDeviceManager deviceManager,
+      IDiskSegment<int, int> segment)
+  {
+    return deviceManager.DeviceExists(
+        segment.SegmentId,
+        DiskSegmentConstants.DataCategory,
+        isCompressed: true);
+  }
+
+  static bool MultiPartMetadataExists(
+      IRandomAccessDeviceManager deviceManager,
+      IDiskSegment<int, int> segment)
+  {
+    return deviceManager.DeviceExists(
+        segment.SegmentId,
+        DiskSegmentConstants.MultiPartDiskSegmentCategory,
+        isCompressed: false);
+  }
+}

--- a/src/ZoneTree.UnitTests/ZoneTreeDisposalTests.cs
+++ b/src/ZoneTree.UnitTests/ZoneTreeDisposalTests.cs
@@ -1,0 +1,49 @@
+using ZoneTree.Core;
+using ZoneTree.Options;
+
+namespace ZoneTree.UnitTests;
+
+public sealed class ZoneTreeDisposalTests
+{
+  [Test]
+  public void DisposeSynchronouslyReleasesLiveIteratorResources()
+  {
+    var dataPath = "data/DisposeSynchronouslyReleasesLiveIteratorResources";
+    DeleteDirectory(dataPath);
+    var zoneTree = CreateZoneTree(dataPath);
+    zoneTree.Upsert(1, 10);
+    zoneTree.Maintenance.MoveMutableSegmentForward();
+    zoneTree.Maintenance.StartMergeOperation().Join();
+    var iterator = (ZoneTreeIterator<int, int>)zoneTree.CreateIterator(
+        IteratorType.NoRefresh);
+
+    Assert.That(iterator.Next(), Is.True);
+    Assert.That(iterator.DiskSegment, Is.Not.Null);
+
+    zoneTree.Dispose();
+
+    Assert.Multiple(() =>
+    {
+      Assert.That(iterator.DiskSegment, Is.Null);
+      Assert.That(iterator.BottomSegments, Is.Null);
+    });
+
+    iterator.Dispose();
+    DeleteDirectory(dataPath);
+  }
+
+  static IZoneTree<int, int> CreateZoneTree(string dataPath)
+  {
+    return new ZoneTreeFactory<int, int>()
+        .Configure(options => options.AllowUnsafeOptionValues = true)
+        .SetDataDirectory(dataPath)
+        .SetWriteAheadLogDirectory(dataPath)
+        .OpenOrCreate();
+  }
+
+  static void DeleteDirectory(string dataPath)
+  {
+    if (Directory.Exists(dataPath))
+      Directory.Delete(dataPath, recursive: true);
+  }
+}

--- a/src/ZoneTree/Segments/Disk/DiskSegment.cs
+++ b/src/ZoneTree/Segments/Disk/DiskSegment.cs
@@ -1,4 +1,6 @@
+using System.Numerics;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using ZoneTree.Collections;
 using ZoneTree.Comparers;
 using ZoneTree.Exceptions;
@@ -6,11 +8,24 @@ using ZoneTree.Options;
 using ZoneTree.Segments.Block;
 using ZoneTree.Segments.RandomAccess;
 using ZoneTree.Serializers;
+using ZoneTree.Synchronization;
 
 namespace ZoneTree.Segments.Disk;
 
+[StructLayout(LayoutKind.Explicit, Size = 64)]
+struct ReadCounterStripe
+{
+  [FieldOffset(0)]
+  public int Value;
+}
+
 public abstract class DiskSegment<TKey, TValue> : IDiskSegment<TKey, TValue>
 {
+  static readonly int ReadCounterStripeCount = (int)BitOperations.RoundUpToPowerOf2(
+      (uint)Math.Min(Environment.ProcessorCount, 64));
+
+  static readonly int ReadCounterStripeMask = ReadCounterStripeCount - 1;
+
   sealed class SearchHint
   {
     public readonly BlockPin BlockPin = new()
@@ -59,15 +74,17 @@ public abstract class DiskSegment<TKey, TValue> : IDiskSegment<TKey, TValue>
 
   protected IReadOnlyList<SparseArrayEntry<TKey, TValue>> SparseArray = Array.Empty<SparseArrayEntry<TKey, TValue>>();
 
-  int IteratorReaderCount;
+  LifecycleLeaseState IteratorLeaseState;
 
-  protected volatile int ReadCount;
+  /// <summary>
+  /// Gets the number of active iterator leases.
+  /// </summary>
+  public long IteratorReaderCount => IteratorLeaseState.LeaseCount;
 
-  volatile bool IsDropRequested;
+  readonly ReadCounterStripe[] ReadCounterStripes =
+      new ReadCounterStripe[ReadCounterStripeCount];
 
   protected volatile bool IsDropping;
-
-  bool IsDropped;
 
   readonly Lock DropLock = new();
 
@@ -90,6 +107,18 @@ public abstract class DiskSegment<TKey, TValue> : IDiskSegment<TKey, TValue>
   public CircularCache<TKey> CircularKeyCache { get; }
 
   public CircularCache<TValue> CircularValueCache { get; }
+
+  protected int ActiveReadCount
+  {
+    get
+    {
+      var result = 0;
+      var stripes = ReadCounterStripes;
+      for (var i = 0; i < stripes.Length; ++i)
+        result += Volatile.Read(ref stripes[i].Value);
+      return result;
+    }
+  }
 
   protected ZoneTreeOptions<TKey, TValue> Options;
 
@@ -395,6 +424,24 @@ public abstract class DiskSegment<TKey, TValue> : IDiskSegment<TKey, TValue>
 
   protected TValue ReadValue(long index) => ReadValue(index, null);
 
+  [MethodImpl(MethodImplOptions.AggressiveInlining)]
+  protected int BeginRead()
+  {
+    var stripeIndex = Thread.GetCurrentProcessorId() & ReadCounterStripeMask;
+    Interlocked.Increment(ref ReadCounterStripes[stripeIndex].Value);
+    if (!IsDropping)
+      return stripeIndex;
+
+    Interlocked.Decrement(ref ReadCounterStripes[stripeIndex].Value);
+    throw new DiskSegmentIsDroppingException();
+  }
+
+  [MethodImpl(MethodImplOptions.AggressiveInlining)]
+  protected void EndRead(int stripeIndex)
+  {
+    Interlocked.Decrement(ref ReadCounterStripes[stripeIndex].Value);
+  }
+
   protected abstract TKey ReadKey(long index, BlockPin blockPin);
 
   protected abstract TValue ReadValue(long index, BlockPin blockPin);
@@ -499,36 +546,11 @@ public abstract class DiskSegment<TKey, TValue> : IDiskSegment<TKey, TValue>
   {
     lock (DropLock)
     {
-      if (IsDropped)
-        return;
-      if (IteratorReaderCount > 0)
-      {
-        // iterators are long-lived objects.
-        // Cancel the drop, and let the iterators
-        // call drop when they are disposed.
-        IsDropRequested = true;
-        return;
-      }
-
-      // reads will increase ReadCount when they begin,
-      // and decrease ReadCount when they end.
-      IsDropping = true;
-      // After the flag change,
-      // reads will start throwing DiskSegmentIsDroppingException
-
-      // Delay the drop operation until all reads finalized
-      // either with success or exception.
-      if (ReadCount > 0)
-      {
-        // Synchronize reads with drop operation.
-        SpinWait.SpinUntil(() => ReadCount == 0);
-      }
-
-      // No active reads remaining.
-      // Safe to drop.
-
-      DeleteDevices();
-      IsDropped = true;
+      // Request retirement and prevent new iterators from attaching.
+      // Complete the drop immediately when no iterators are active;
+      // otherwise, the final iterator completes it when detached.
+      if (IteratorLeaseState.RequestRetirement())
+        CompleteDrop(reportFailure: false);
     }
   }
 
@@ -541,28 +563,53 @@ public abstract class DiskSegment<TKey, TValue> : IDiskSegment<TKey, TValue>
 
   public void AttachIterator()
   {
-    lock (DropLock)
-    {
-      ++IteratorReaderCount;
-    }
+    if (!IteratorLeaseState.TryAcquire())
+      throw new InvalidOperationException(
+          "Cannot attach an iterator after disk segment retirement has started.");
   }
 
   public void DetachIterator()
   {
-    lock (DropLock)
+    if (IteratorLeaseState.Release())
     {
-      --IteratorReaderCount;
-      if (IsDropRequested && IteratorReaderCount == 0)
+      lock (DropLock)
       {
-        try
-        {
-          Drop();
-        }
-        catch (Exception e)
-        {
-          DropFailureReporter?.Invoke(this, e);
-        }
+        if (IteratorLeaseState.TryBeginRetirementCompletion())
+          CompleteDrop(reportFailure: true);
       }
+    }
+  }
+
+  void CompleteDrop(bool reportFailure)
+  {
+    try
+    {
+      // reads will increase ReadCount when they begin,
+      // and decrease ReadCount when they end.
+      IsDropping = true;
+      // After the flag change,
+      // reads will start throwing DiskSegmentIsDroppingException
+
+      // Delay the drop operation until all reads finalized
+      // either with success or exception.
+      if (ActiveReadCount != 0)
+      {
+        // Synchronize reads with drop operation.
+        SpinWait.SpinUntil(() => ActiveReadCount == 0);
+      }
+
+      // No active reads remaining.
+      // Safe to drop.
+
+      DeleteDevices();
+      IteratorLeaseState.CompleteRetirement();
+    }
+    catch (Exception e)
+    {
+      IteratorLeaseState.CancelRetirementCompletion();
+      if (!reportFailure)
+        throw;
+      DropFailureReporter?.Invoke(this, e);
     }
   }
 

--- a/src/ZoneTree/Segments/DiskSegmentVariations/FixedSizeKeyAndValueDiskSegment.cs
+++ b/src/ZoneTree/Segments/DiskSegmentVariations/FixedSizeKeyAndValueDiskSegment.cs
@@ -128,14 +128,10 @@ public sealed class FixedSizeKeyAndValueDiskSegment<TKey, TValue> : DiskSegment<
 
   protected override TKey ReadKey(long index, BlockPin blockPin)
   {
+    if (CircularKeyCache.TryGet(index, out var key)) return key;
+    var readStripe = BeginRead();
     try
     {
-      if (CircularKeyCache.TryGet(index, out var key)) return key;
-      Interlocked.Increment(ref ReadCount);
-      if (IsDropping)
-      {
-        throw new DiskSegmentIsDroppingException();
-      }
       var itemSize = KeySize + ValueSize;
       var pin1 = blockPin?.ToSingleBlockPin(1);
       var keyBytes = DataDevice.GetBytes(
@@ -149,20 +145,16 @@ public sealed class FixedSizeKeyAndValueDiskSegment<TKey, TValue> : DiskSegment<
     }
     finally
     {
-      Interlocked.Decrement(ref ReadCount);
+      EndRead(readStripe);
     }
   }
 
   protected override TValue ReadValue(long index, BlockPin blockPin)
   {
+    if (CircularValueCache.TryGet(index, out var value)) return value;
+    var readStripe = BeginRead();
     try
     {
-      if (CircularValueCache.TryGet(index, out var value)) return value;
-      Interlocked.Increment(ref ReadCount);
-      if (IsDropping)
-      {
-        throw new DiskSegmentIsDroppingException();
-      }
       var itemSize = KeySize + ValueSize;
       var pin1 = blockPin?.ToSingleBlockPin(1);
       var valueBytes = DataDevice.GetBytes(
@@ -176,7 +168,7 @@ public sealed class FixedSizeKeyAndValueDiskSegment<TKey, TValue> : DiskSegment<
     }
     finally
     {
-      Interlocked.Decrement(ref ReadCount);
+      EndRead(readStripe);
     }
   }
 
@@ -192,14 +184,9 @@ public sealed class FixedSizeKeyAndValueDiskSegment<TKey, TValue> : DiskSegment<
       return 0;
     count = (int)Math.Min(count, Length - startIndex);
 
+    var readStripe = BeginRead();
     try
     {
-      Interlocked.Increment(ref ReadCount);
-      if (IsDropping)
-      {
-        throw new DiskSegmentIsDroppingException();
-      }
-
       var itemSize = KeySize + ValueSize;
       var pin1 = blockPin?.ToSingleBlockPin(1);
       var bytes = DataDevice.GetBytes(
@@ -241,7 +228,7 @@ public sealed class FixedSizeKeyAndValueDiskSegment<TKey, TValue> : DiskSegment<
     }
     finally
     {
-      Interlocked.Decrement(ref ReadCount);
+      EndRead(readStripe);
     }
   }
 

--- a/src/ZoneTree/Segments/DiskSegmentVariations/FixedSizeKeyDiskSegment.cs
+++ b/src/ZoneTree/Segments/DiskSegmentVariations/FixedSizeKeyDiskSegment.cs
@@ -148,14 +148,10 @@ public sealed class FixedSizeKeyDiskSegment<TKey, TValue> : DiskSegment<TKey, TV
 
   protected unsafe override TKey ReadKey(long index, BlockPin blockPin)
   {
+    if (CircularKeyCache.TryGet(index, out var key)) return key;
+    var readStripe = BeginRead();
     try
     {
-      if (CircularKeyCache.TryGet(index, out var key)) return key;
-      Interlocked.Increment(ref ReadCount);
-      if (IsDropping)
-      {
-        throw new DiskSegmentIsDroppingException();
-      }
       var pin1 = blockPin?.ToSingleBlockPin(1);
       var headSize = sizeof(ValueHead) + KeySize;
       var keyBytes = DataHeaderDevice.GetBytes(
@@ -169,21 +165,16 @@ public sealed class FixedSizeKeyDiskSegment<TKey, TValue> : DiskSegment<TKey, TV
     }
     finally
     {
-      Interlocked.Decrement(ref ReadCount);
+      EndRead(readStripe);
     }
   }
 
   protected unsafe override TValue ReadValue(long index, BlockPin blockPin)
   {
+    if (CircularValueCache.TryGet(index, out var value)) return value;
+    var readStripe = BeginRead();
     try
     {
-      if (CircularValueCache.TryGet(index, out var value)) return value;
-      Interlocked.Increment(ref ReadCount);
-      if (IsDropping)
-      {
-        throw new DiskSegmentIsDroppingException();
-      }
-
       var pin1 = blockPin?.ToSingleBlockPin(1);
       var pin2 = blockPin?.ToSingleBlockPin(2);
       var headSize = sizeof(ValueHead) + KeySize;
@@ -204,7 +195,7 @@ public sealed class FixedSizeKeyDiskSegment<TKey, TValue> : DiskSegment<TKey, TV
     }
     finally
     {
-      Interlocked.Decrement(ref ReadCount);
+      EndRead(readStripe);
     }
   }
 
@@ -220,14 +211,9 @@ public sealed class FixedSizeKeyDiskSegment<TKey, TValue> : DiskSegment<TKey, TV
       return 0;
     count = (int)Math.Min(count, Length - startIndex);
 
+    var readStripe = BeginRead();
     try
     {
-      Interlocked.Increment(ref ReadCount);
-      if (IsDropping)
-      {
-        throw new DiskSegmentIsDroppingException();
-      }
-
       var pin1 = blockPin?.ToSingleBlockPin(1);
       var pin2 = blockPin?.ToSingleBlockPin(2);
       var headSize = sizeof(ValueHead) + KeySize;
@@ -277,7 +263,7 @@ public sealed class FixedSizeKeyDiskSegment<TKey, TValue> : DiskSegment<TKey, TV
     }
     finally
     {
-      Interlocked.Decrement(ref ReadCount);
+      EndRead(readStripe);
     }
   }
 

--- a/src/ZoneTree/Segments/DiskSegmentVariations/FixedSizeValueDiskSegment.cs
+++ b/src/ZoneTree/Segments/DiskSegmentVariations/FixedSizeValueDiskSegment.cs
@@ -147,14 +147,10 @@ public sealed class FixedSizeValueDiskSegment<TKey, TValue> : DiskSegment<TKey, 
 
   protected unsafe override TKey ReadKey(long index, BlockPin blockPin)
   {
+    if (CircularKeyCache.TryGet(index, out var key)) return key;
+    var readStripe = BeginRead();
     try
     {
-      if (CircularKeyCache.TryGet(index, out var key)) return key;
-      Interlocked.Increment(ref ReadCount);
-      if (IsDropping)
-      {
-        throw new DiskSegmentIsDroppingException();
-      }
       var pin1 = blockPin?.ToSingleBlockPin(1);
       var pin2 = blockPin?.ToSingleBlockPin(2);
       var headSize = sizeof(KeyHead) + ValueSize;
@@ -175,21 +171,16 @@ public sealed class FixedSizeValueDiskSegment<TKey, TValue> : DiskSegment<TKey, 
     }
     finally
     {
-      Interlocked.Decrement(ref ReadCount);
+      EndRead(readStripe);
     }
   }
 
   protected unsafe override TValue ReadValue(long index, BlockPin blockPin)
   {
+    if (CircularValueCache.TryGet(index, out var value)) return value;
+    var readStripe = BeginRead();
     try
     {
-      if (CircularValueCache.TryGet(index, out var value)) return value;
-      Interlocked.Increment(ref ReadCount);
-      if (IsDropping)
-      {
-        throw new DiskSegmentIsDroppingException();
-      }
-
       var pin1 = blockPin?.ToSingleBlockPin(1);
       var headSize = sizeof(KeyHead) + ValueSize;
       var valueBytes = DataHeaderDevice.GetBytes(
@@ -203,7 +194,7 @@ public sealed class FixedSizeValueDiskSegment<TKey, TValue> : DiskSegment<TKey, 
     }
     finally
     {
-      Interlocked.Decrement(ref ReadCount);
+      EndRead(readStripe);
     }
   }
 
@@ -219,14 +210,9 @@ public sealed class FixedSizeValueDiskSegment<TKey, TValue> : DiskSegment<TKey, 
       return 0;
     count = (int)Math.Min(count, Length - startIndex);
 
+    var readStripe = BeginRead();
     try
     {
-      Interlocked.Increment(ref ReadCount);
-      if (IsDropping)
-      {
-        throw new DiskSegmentIsDroppingException();
-      }
-
       var pin1 = blockPin?.ToSingleBlockPin(1);
       var pin2 = blockPin?.ToSingleBlockPin(2);
       var headSize = sizeof(KeyHead) + ValueSize;
@@ -276,7 +262,7 @@ public sealed class FixedSizeValueDiskSegment<TKey, TValue> : DiskSegment<TKey, 
     }
     finally
     {
-      Interlocked.Decrement(ref ReadCount);
+      EndRead(readStripe);
     }
   }
 

--- a/src/ZoneTree/Segments/DiskSegmentVariations/VariableSizeDiskSegment.cs
+++ b/src/ZoneTree/Segments/DiskSegmentVariations/VariableSizeDiskSegment.cs
@@ -153,14 +153,10 @@ public sealed partial class VariableSizeDiskSegment<TKey, TValue> : DiskSegment<
 
   protected unsafe override TKey ReadKey(long index, BlockPin blockPin)
   {
+    if (CircularKeyCache.TryGet(index, out var key)) return key;
+    var readStripe = BeginRead();
     try
     {
-      if (CircularKeyCache.TryGet(index, out var key)) return key;
-      Interlocked.Increment(ref ReadCount);
-      if (IsDropping)
-      {
-        throw new DiskSegmentIsDroppingException();
-      }
       var pin1 = blockPin?.ToSingleBlockPin(1);
       var pin2 = blockPin?.ToSingleBlockPin(2);
       var headBytes = DataHeaderDevice.GetBytes(
@@ -180,20 +176,16 @@ public sealed partial class VariableSizeDiskSegment<TKey, TValue> : DiskSegment<
     }
     finally
     {
-      Interlocked.Decrement(ref ReadCount);
+      EndRead(readStripe);
     }
   }
 
   protected unsafe override TValue ReadValue(long index, BlockPin blockPin)
   {
+    if (CircularValueCache.TryGet(index, out var value)) return value;
+    var readStripe = BeginRead();
     try
     {
-      if (CircularValueCache.TryGet(index, out var value)) return value;
-      Interlocked.Increment(ref ReadCount);
-      if (IsDropping)
-      {
-        throw new DiskSegmentIsDroppingException();
-      }
       var pin1 = blockPin?.ToSingleBlockPin(1);
       var pin2 = blockPin?.ToSingleBlockPin(2);
       var headBytes = DataHeaderDevice.GetBytes(
@@ -213,7 +205,7 @@ public sealed partial class VariableSizeDiskSegment<TKey, TValue> : DiskSegment<
     }
     finally
     {
-      Interlocked.Decrement(ref ReadCount);
+      EndRead(readStripe);
     }
   }
 
@@ -229,14 +221,9 @@ public sealed partial class VariableSizeDiskSegment<TKey, TValue> : DiskSegment<
       return 0;
     count = (int)Math.Min(count, Length - startIndex);
 
+    var readStripe = BeginRead();
     try
     {
-      Interlocked.Increment(ref ReadCount);
-      if (IsDropping)
-      {
-        throw new DiskSegmentIsDroppingException();
-      }
-
       var pin1 = blockPin?.ToSingleBlockPin(1);
       var pin2 = blockPin?.ToSingleBlockPin(2);
       var headSize = sizeof(EntryHead);
@@ -301,7 +288,7 @@ public sealed partial class VariableSizeDiskSegment<TKey, TValue> : DiskSegment<
     }
     finally
     {
-      Interlocked.Decrement(ref ReadCount);
+      EndRead(readStripe);
     }
   }
 

--- a/src/ZoneTree/Segments/IDiskSegment.cs
+++ b/src/ZoneTree/Segments/IDiskSegment.cs
@@ -28,17 +28,14 @@ public interface IDiskSegment<TKey, TValue> : IReadOnlySegment<TKey, TValue>, II
   void LoadIntoMemory();
 
   /// <summary>
-  /// Increments the iterator reader counter
-  /// to ensure that disk segment stays alive
+  /// Acquires an iterator lease
+  /// to ensure that the disk segment stays alive
   /// until all iterators call DetachIterator.
   /// </summary>
   void AttachIterator();
 
   /// <summary>
-  /// Decrements the iterator reader counter.
-  /// When there is no attached iterator remaining and
-  /// the drop is already requested,
-  /// calls Drop().
+  /// Releases an iterator lease. The final lease completes a pending drop.
   /// </summary>
   void DetachIterator();
 

--- a/src/ZoneTree/Segments/MultiPart/MultiPartDiskSegment.cs
+++ b/src/ZoneTree/Segments/MultiPart/MultiPartDiskSegment.cs
@@ -9,6 +9,7 @@ using ZoneTree.Segments.Block;
 using ZoneTree.Segments.Disk;
 using ZoneTree.Segments.RandomAccess;
 using ZoneTree.Serializers;
+using ZoneTree.Synchronization;
 
 namespace ZoneTree.Segments.MultiPart;
 
@@ -28,13 +29,13 @@ public sealed class MultiPartDiskSegment<TKey, TValue> : IDiskSegment<TKey, TVal
 
   readonly ISerializer<TValue> ValueSerializer;
 
-  int IteratorReaderCount;
-
-  bool IsDropRequested;
-
-  bool IsDropped;
+  LifecycleLeaseState IteratorLeaseState;
 
   readonly Lock DropLock = new();
+
+  bool HasPendingDropPlan;
+
+  HashSet<long> PendingDropExcludedPartIds;
 
   readonly IReadOnlyList<IDiskSegment<TKey, TValue>> Parts;
 
@@ -235,10 +236,9 @@ public sealed class MultiPartDiskSegment<TKey, TValue> : IDiskSegment<TKey, TVal
 
   public void AttachIterator()
   {
-    lock (DropLock)
-    {
-      ++IteratorReaderCount;
-    }
+    if (!IteratorLeaseState.TryAcquire())
+      throw new InvalidOperationException(
+          "Cannot attach an iterator after disk segment retirement has started.");
   }
 
   public bool ContainsKey(in TKey key)
@@ -261,57 +261,56 @@ public sealed class MultiPartDiskSegment<TKey, TValue> : IDiskSegment<TKey, TVal
 
   public void Drop()
   {
-    lock (DropLock)
-    {
-      if (IsDropped)
-        return;
-      if (IteratorReaderCount > 0)
-      {
-        // iterators are long-lived objects.
-        // Cancel the drop, and let the iterators
-        // call drop when they are disposed.
-        IsDropRequested = true;
-        return;
-      }
-
-      var len = Parts.Count;
-      for (var i = 0; i < len; ++i)
-        Parts[i].Drop();
-
-      DropMeta();
-
-      IsDropped = true;
-    }
+    RequestDrop(excludedPartIds: null);
   }
 
   public void Drop(HashSet<long> excludedPartIds)
   {
+    RequestDrop(excludedPartIds);
+  }
+
+  void RequestDrop(HashSet<long> excludedPartIds)
+  {
     lock (DropLock)
     {
-      if (IsDropped)
-        return;
-      if (IteratorReaderCount > 0)
+      if (!HasPendingDropPlan)
       {
-        // iterators are long-lived objects.
-        // Cancel the drop, and let the iterators
-        // call drop when they are disposed.
-        IsDropRequested = true;
-        return;
+        HasPendingDropPlan = true;
+        PendingDropExcludedPartIds = excludedPartIds is null
+            ? null
+            : [.. excludedPartIds];
       }
 
+      if (IteratorLeaseState.RequestRetirement())
+        CompleteDrop(PendingDropExcludedPartIds, reportFailure: false);
+    }
+  }
+
+  void CompleteDrop(
+      HashSet<long> excludedPartIds,
+      bool reportFailure)
+  {
+    try
+    {
       var len = Parts.Count;
       for (var i = 0; i < len; ++i)
       {
         var part = Parts[i];
-
-        if (excludedPartIds.Contains(part.SegmentId))
+        if (excludedPartIds?.Contains(part.SegmentId) == true)
           continue;
         part.Drop();
       }
 
       DropMeta();
-
-      IsDropped = true;
+      IteratorLeaseState.CompleteRetirement();
+      PendingDropExcludedPartIds = null;
+    }
+    catch (Exception e)
+    {
+      IteratorLeaseState.CancelRetirementCompletion();
+      if (!reportFailure)
+        throw;
+      DropFailureReporter?.Invoke(this, e);
     }
   }
 
@@ -503,19 +502,12 @@ public sealed class MultiPartDiskSegment<TKey, TValue> : IDiskSegment<TKey, TVal
 
   public void DetachIterator()
   {
-    lock (DropLock)
+    if (IteratorLeaseState.Release())
     {
-      --IteratorReaderCount;
-      if (IsDropRequested && IteratorReaderCount == 0)
+      lock (DropLock)
       {
-        try
-        {
-          Drop();
-        }
-        catch (Exception e)
-        {
-          DropFailureReporter?.Invoke(this, e);
-        }
+        if (IteratorLeaseState.TryBeginRetirementCompletion())
+          CompleteDrop(PendingDropExcludedPartIds, reportFailure: true);
       }
     }
   }

--- a/src/ZoneTree/Synchronization/LifecycleLeaseState.cs
+++ b/src/ZoneTree/Synchronization/LifecycleLeaseState.cs
@@ -1,0 +1,113 @@
+namespace ZoneTree.Synchronization;
+
+/// <summary>
+/// Coordinates leases with deferred, exactly-once resource retirement.
+/// </summary>
+struct LifecycleLeaseState
+{
+  const int StateShift = 61;
+
+  const long LeaseCountMask = (1L << StateShift) - 1;
+
+  const long LifecycleMask = ~LeaseCountMask;
+
+  const long Active = 0;
+
+  // The retirement-request bit is monotonic. Every subsequent lifecycle state
+  // retains it, allowing RequestRetirement to use one atomic OR.
+  const long RetirementRequested = 1L << StateShift;
+
+  const long Retiring = RetirementRequested | (1L << (StateShift + 1));
+
+  const long Retired = Retiring | long.MinValue;
+
+  long State;
+
+  public long LeaseCount => Volatile.Read(ref State) & LeaseCountMask;
+
+  /// <summary>
+  /// Tries to acquire a lease while the resource is active.
+  /// </summary>
+  public bool TryAcquire()
+  {
+    while (true)
+    {
+      var state = Volatile.Read(ref State);
+      if ((state & LifecycleMask) != Active)
+        return false;
+      if ((state & LeaseCountMask) == LeaseCountMask)
+        throw new InvalidOperationException("The lifecycle lease count reached its maximum value.");
+      if (Interlocked.CompareExchange(ref State, state + 1, state) == state)
+        return true;
+    }
+  }
+
+  /// <summary>
+  /// Releases a lease and returns true when the final lease makes a previously
+  /// requested retirement eligible for completion.
+  /// </summary>
+  public bool Release()
+  {
+    while (true)
+    {
+      var state = Volatile.Read(ref State);
+      var leaseCount = state & LeaseCountMask;
+      if (leaseCount == 0)
+        throw new InvalidOperationException("The lifecycle does not have an active lease to release.");
+
+      var lifecycle = state & LifecycleMask;
+      if (lifecycle is not Active and not RetirementRequested)
+        throw new InvalidOperationException("The lifecycle cannot release a lease in its current state.");
+
+      var completeRetirement = lifecycle == RetirementRequested && leaseCount == 1;
+      var nextState = state - 1;
+      if (Interlocked.CompareExchange(ref State, nextState, state) == state)
+        return completeRetirement;
+    }
+  }
+
+  /// <summary>
+  /// Requests retirement without waiting for active leases. Returns true only
+  /// when this caller owns retirement completion because no leases remain.
+  /// </summary>
+  public bool RequestRetirement()
+  {
+    var previousState = Interlocked.Or(ref State, RetirementRequested);
+    var lifecycle = previousState & LifecycleMask;
+    if (lifecycle is Retiring or Retired ||
+        (previousState & LeaseCountMask) != 0)
+      return false;
+
+    return Interlocked.CompareExchange(
+        ref State,
+        Retiring,
+        RetirementRequested) == RetirementRequested;
+  }
+
+  /// <summary>
+  /// Tries to own retirement completion after the final lease has been
+  /// released.
+  /// </summary>
+  public bool TryBeginRetirementCompletion()
+  {
+    return Interlocked.CompareExchange(
+        ref State,
+        Retiring,
+        RetirementRequested) == RetirementRequested;
+  }
+
+  public void CompleteRetirement()
+  {
+    if (Interlocked.CompareExchange(ref State, Retired, Retiring) != Retiring)
+      throw new InvalidOperationException("The lifecycle is not completing retirement.");
+  }
+
+  public void CancelRetirementCompletion()
+  {
+    if (Interlocked.CompareExchange(
+        ref State,
+        RetirementRequested,
+        Retiring) != Retiring)
+      throw new InvalidOperationException("The lifecycle is not completing retirement.");
+  }
+}


### PR DESCRIPTION
## Summary

This PR removes shared synchronization bottlenecks from disk-segment reads and iterator lifetime management while preserving ZoneTree's single-thread performance and drop semantics.

The result is strong parallel scaling across reads, lookups, scans, and indexed queries.

In the current 1M-profile benchmark, ZoneTree completes the measured workload phases in:

- **58.6 seconds at p1**
- **10.4 seconds at p16**
- **5.65x overall scale-up**

At p16, ZoneTree reaches **6.4M direct reads/s**, **3.9M email lookups/s**, and up to **390K indexed queries/s**.

## Performance

Current Windows benchmark results with 1M profiles on a 20-logical-processor Intel Core Ultra 7 265KF using .NET 10:

| Workload | p1 | p16 | Scale-up |
|---|---:|---:|---:|
| Completed phase time | 58.6s | 10.4s | **5.65x** |
| Read by user ID | 867K/s | 6.41M/s | **7.39x** |
| Lookup by email | 396K/s | 3.92M/s | **9.89x** |
| Country/status query | 30.9K/s | 181.9K/s | **5.89x** |
| Created-at range query | 39.3K/s | 384.7K/s | **9.79x** |
| Top-reputation query | 43.3K/s | 371.4K/s | **8.58x** |
| Profile updates | 141K/s | 627K/s | **4.43x** |

In the same p16 run:

- ZoneTree completed measured phases in **10.4s**, versus **53.9s** for RocksDB.
- ZoneTree delivered **6.41M reads/s**, versus **136K/s** for RocksDB.
- ZoneTree delivered **385K created-at queries/s**, versus **50.6K/s** for RocksDB.
- Cross-engine checksum validation passed.

These numbers describe the current validated p1 and p16 runs. They are not presented as a historical before/after comparison.

## Implementation

### Scalable read accounting

The single shared `ReadCount` is replaced with cache-line-padded counters distributed across available processors.

- Reduces cache-line contention during concurrent disk reads.
- Uses a power-of-two stripe count capped at 64.
- Preserves the existing rule that active reads must finish before device deletion.
- Centralizes balanced accounting in `BeginRead()` and `EndRead()`.
- Keeps cache hits outside read accounting because they do not access disposable devices.

### Atomic iterator lifecycle

A reusable `LifecycleLeaseState` replaces lock-protected iterator counters.

The atomic state coordinates:

- Lease acquisition while the segment is active.
- Rejection of new iterators after retirement begins.
- Non-blocking drop requests while iterators remain active.
- Exactly-once deletion by either the drop caller or final iterator.
- Retry after failed deletion.
- Detection of unbalanced lease release.

This removes `DropLock` from normal iterator attach and detach operations. The lock remains only around rare deletion completion.

### Correct deferred multipart deletion

Multipart drop requests now preserve an immutable snapshot of their exclusion set while active iterators defer deletion.

This ensures that part files transferred to a new multipart segment are not deleted when the final iterator completes retirement.

The first drop request remains authoritative, repeated requests are idempotent, and failed deletion retries use the same plan.

### Lifecycle robustness

- Tree disposal continues to synchronously release live iterator resources.
- Failed live backups release their segment leases.
- Deferred deletion failures are reported and remain retryable.
- `IteratorReaderCount` is exposed directly on physical disk segments without reflection-based test hooks.

## Tests

Added focused coverage for:

- Repeated iterator lease acquisition and release.
- Deferred deletion until the final iterator detaches.
- Concurrent detach with exactly-once deletion.
- Immediate and repeated drop.
- Active reads delaying device deletion.
- Concurrent drop calls.
- Immediate and deferred deletion failure recovery.
- Unbalanced iterator detach.
- Read-counter balance across all four disk-segment layouts.
- Multipart exclusion preservation during deferred deletion.
- Caller mutation and repeated drop requests.
- Synchronous tree disposal with live iterators.
- Failed live-backup lease cleanup.

Current focused lifecycle tests pass, and p1/p16 benchmark checksum validation succeeds.