### PR TITLE
Performance Feature: Unlock concurrent read scaling with mutable-segment Bloom filtering

### DIFF
--- a/src/ZoneTree.UnitTests/BottomSegmentMergeTests.cs
+++ b/src/ZoneTree.UnitTests/BottomSegmentMergeTests.cs
@@ -5,6 +5,7 @@ using ZoneTree.AbstractFileStream;
 using ZoneTree.Comparers;
 using ZoneTree.Core;
 using ZoneTree.Logger;
+using ZoneTree.Hashers;
 using ZoneTree.Options;
 using ZoneTree.Segments;
 using ZoneTree.Segments.Disk;
@@ -322,6 +323,7 @@ public sealed class BottomSegmentMergeTests
     var options = new ZoneTreeOptions<int, int>
     {
       Comparer = new Int32ComparerAscending(),
+      KeyHasher = new DefaultKeyHasher<int>(),
       KeySerializer = new Int32Serializer(),
       ValueSerializer = new Int32Serializer(),
       Logger = logger,
@@ -362,6 +364,7 @@ public sealed class BottomSegmentMergeTests
     var options = new ZoneTreeOptions<int, int>
     {
       Comparer = new Int32ComparerAscending(),
+      KeyHasher = new DefaultKeyHasher<int>(),
       KeySerializer = new Int32Serializer(),
       ValueSerializer = new Int32Serializer(),
       Logger = logger,

--- a/src/ZoneTree.UnitTests/KeyHasherTests.cs
+++ b/src/ZoneTree.UnitTests/KeyHasherTests.cs
@@ -1,0 +1,64 @@
+using ZoneTree.AbstractFileStream;
+using ZoneTree.Hashers;
+using ZoneTree.PresetTypes;
+
+namespace ZoneTree.UnitTests;
+
+public sealed class KeyHasherTests
+{
+  [Test]
+  public void ProvidesHashersForKnownKeyTypes()
+  {
+    Assert.Multiple(() =>
+    {
+      Assert.That(ComponentsForKnownTypes.GetKeyHasher<int>(), Is.Not.Null);
+      Assert.That(ComponentsForKnownTypes.GetKeyHasher<long>(), Is.Not.Null);
+      Assert.That(ComponentsForKnownTypes.GetKeyHasher<Guid>(), Is.Not.Null);
+      Assert.That(ComponentsForKnownTypes.GetKeyHasher<string>(), Is.Not.Null);
+      Assert.That(
+          ComponentsForKnownTypes.GetKeyHasher<Memory<byte>>(),
+          Is.Not.Null);
+    });
+  }
+
+  [Test]
+  public void ByteArrayHasherUsesSequenceContent()
+  {
+    var hasher = new ByteArrayKeyHasher();
+    Memory<byte> first = new byte[] { 1, 2, 3, 4 };
+    Memory<byte> second = new byte[] { 1, 2, 3, 4 };
+
+    Assert.That(
+        hasher.GetHashCode(in first),
+        Is.EqualTo(hasher.GetHashCode(in second)));
+  }
+
+  [Test]
+  public void FactoryPreservesConfiguredKeyHasher()
+  {
+    var keyHasher = new ConstantKeyHasher();
+    var factory = new ZoneTreeFactory<int, int>(
+        new InMemoryFileStreamProvider())
+        .SetKeyHasher(keyHasher);
+
+    using var zoneTree = factory.OpenOrCreate();
+
+    Assert.That(factory.Options.KeyHasher, Is.SameAs(keyHasher));
+  }
+
+  [Test]
+  public void FactoryFillsKeyHasherForKnownType()
+  {
+    var factory = new ZoneTreeFactory<int, int>(
+        new InMemoryFileStreamProvider());
+
+    using var zoneTree = factory.OpenOrCreate();
+
+    Assert.That(factory.Options.KeyHasher, Is.TypeOf<DefaultKeyHasher<int>>());
+  }
+
+  sealed class ConstantKeyHasher : IKeyHasher<int>
+  {
+    public int GetHashCode(in int key) => 42;
+  }
+}

--- a/src/ZoneTree.UnitTests/MultiPartDiskSegmentLeaseTests.cs
+++ b/src/ZoneTree.UnitTests/MultiPartDiskSegmentLeaseTests.cs
@@ -3,6 +3,7 @@ using ZoneTree.Collections;
 using ZoneTree.Comparers;
 using ZoneTree.Core;
 using ZoneTree.Logger;
+using ZoneTree.Hashers;
 using ZoneTree.Options;
 using ZoneTree.Segments;
 using ZoneTree.Segments.Disk;
@@ -83,6 +84,7 @@ public sealed class MultiPartDiskSegmentLeaseTests
     var options = new ZoneTreeOptions<int, int>
     {
       Comparer = new Int32ComparerAscending(),
+      KeyHasher = new DefaultKeyHasher<int>(),
       KeySerializer = new Int32Serializer(),
       ValueSerializer = new Int32Serializer(),
       Logger = logger,

--- a/src/ZoneTree.UnitTests/MutableSegmentBloomFilterTests.cs
+++ b/src/ZoneTree.UnitTests/MutableSegmentBloomFilterTests.cs
@@ -1,0 +1,166 @@
+using ZoneTree.Comparers;
+using ZoneTree.Hashers;
+using ZoneTree.Options;
+
+namespace ZoneTree.UnitTests;
+
+public sealed class MutableSegmentBloomFilterTests
+{
+  [Test]
+  public void FindsInsertedKeysAndRejectsMissingKeys()
+  {
+    var dataPath = "data/MutableSegmentBloomFilterFindsInsertedKeys";
+    DeleteDirectory(dataPath);
+    using (var zoneTree = new ZoneTreeFactory<long, long>()
+        .Configure(options => options.AllowUnsafeOptionValues = true)
+        .SetMutableSegmentMaxItemCount(10_000)
+        .SetDataDirectory(dataPath)
+        .SetWriteAheadLogDirectory(dataPath)
+        .OpenOrCreate())
+    {
+      for (var i = 1L; i <= 1_000; ++i)
+        zoneTree.Upsert(i, i * 2);
+
+      Assert.Multiple(() =>
+      {
+        for (var i = 1L; i <= 1_000; ++i)
+        {
+          Assert.That(zoneTree.TryGet(i, out var value), Is.True);
+          Assert.That(value, Is.EqualTo(i * 2));
+        }
+
+        for (var i = 1_001L; i <= 2_000; ++i)
+          Assert.That(zoneTree.TryGet(i, out _), Is.False);
+      });
+    }
+
+    DeleteDirectory(dataPath);
+  }
+
+  [Test]
+  public void ConcurrentWritesDoNotCreateFalseNegatives()
+  {
+    const int itemCount = 100_000;
+    var dataPath = "data/MutableSegmentBloomFilterConcurrentWrites";
+    DeleteDirectory(dataPath);
+    using (var zoneTree = new ZoneTreeFactory<int, int>()
+        .Configure(options => options.AllowUnsafeOptionValues = true)
+        .SetMutableSegmentMaxItemCount(itemCount + 1)
+        .SetDataDirectory(dataPath)
+        .SetWriteAheadLogDirectory(dataPath)
+        .OpenOrCreate())
+    {
+      Parallel.For(1, itemCount + 1, i => zoneTree.Upsert(i, i));
+
+      Assert.Multiple(() =>
+      {
+        for (var i = 1; i <= itemCount; ++i)
+        {
+          Assert.That(zoneTree.TryGet(i, out var value), Is.True);
+          Assert.That(value, Is.EqualTo(i));
+        }
+      });
+    }
+
+    DeleteDirectory(dataPath);
+  }
+
+  [Test]
+  public void CanDisableBloomFilter()
+  {
+    var dataPath = "data/MutableSegmentBloomFilterDisabled";
+    DeleteDirectory(dataPath);
+    using (var zoneTree = new ZoneTreeFactory<int, int>()
+        .SetMutableSegmentBloomFilterBitsPerItem(0)
+        .SetDataDirectory(dataPath)
+        .SetWriteAheadLogDirectory(dataPath)
+        .OpenOrCreate())
+    {
+      zoneTree.Upsert(1, 2);
+
+      Assert.Multiple(() =>
+      {
+        Assert.That(zoneTree.TryGet(1, out var value), Is.True);
+        Assert.That(value, Is.EqualTo(2));
+        Assert.That(zoneTree.TryGet(2, out _), Is.False);
+      });
+    }
+
+    DeleteDirectory(dataPath);
+  }
+
+  [Test]
+  public void UsesConfiguredHasherForComparerEquivalentKeys()
+  {
+    var dataPath = "data/MutableSegmentBloomFilterConfiguredHasher";
+    var hasher = new TrackingOrdinalIgnoreCaseKeyHasher();
+    DeleteDirectory(dataPath);
+    using (var zoneTree = new ZoneTreeFactory<string, int>()
+        .SetComparer(new StringOrdinalIgnoreCaseComparerAscending())
+        .SetKeyHasher(hasher)
+        .SetDataDirectory(dataPath)
+        .SetWriteAheadLogDirectory(dataPath)
+        .OpenOrCreate())
+    {
+      hasher.Reset();
+      zoneTree.Upsert("key", 42);
+
+      Assert.Multiple(() =>
+      {
+        Assert.That(zoneTree.TryGet("KEY", out var value), Is.True);
+        Assert.That(value, Is.EqualTo(42));
+        Assert.That(hasher.CallCount, Is.GreaterThanOrEqualTo(2));
+      });
+    }
+
+    DeleteDirectory(dataPath);
+  }
+
+  [Test]
+  public void MemoryKeysUseContentHasher()
+  {
+    var dataPath = "data/MutableSegmentBloomFilterMemoryKeys";
+    DeleteDirectory(dataPath);
+    using (var zoneTree = new ZoneTreeFactory<Memory<byte>, int>()
+        .SetDataDirectory(dataPath)
+        .SetWriteAheadLogDirectory(dataPath)
+        .OpenOrCreate())
+    {
+      Memory<byte> storedKey = new byte[] { 1, 2, 3, 4 };
+      Memory<byte> equivalentKey = new byte[] { 1, 2, 3, 4 };
+      zoneTree.Upsert(storedKey, 42);
+
+      Assert.Multiple(() =>
+      {
+        Assert.That(zoneTree.TryGet(equivalentKey, out var value), Is.True);
+        Assert.That(value, Is.EqualTo(42));
+      });
+    }
+
+    DeleteDirectory(dataPath);
+  }
+
+  static void DeleteDirectory(string dataPath)
+  {
+    if (Directory.Exists(dataPath))
+      Directory.Delete(dataPath, recursive: true);
+  }
+
+  sealed class TrackingOrdinalIgnoreCaseKeyHasher : IKeyHasher<string>
+  {
+    int Calls;
+
+    public int CallCount => Volatile.Read(ref Calls);
+
+    public int GetHashCode(in string key)
+    {
+      Interlocked.Increment(ref Calls);
+      return StringComparer.OrdinalIgnoreCase.GetHashCode(key);
+    }
+
+    public void Reset()
+    {
+      Volatile.Write(ref Calls, 0);
+    }
+  }
+}

--- a/src/ZoneTree.UnitTests/ZoneTreeMetaOptionsTests.cs
+++ b/src/ZoneTree.UnitTests/ZoneTreeMetaOptionsTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using ZoneTree.Core;
+using ZoneTree.Hashers;
 using ZoneTree.Options;
 using ZoneTree.WAL;
 
@@ -7,6 +8,22 @@ namespace ZoneTree.UnitTests;
 
 public sealed class ZoneTreeMetaOptionsTests
 {
+  [Test]
+  public void MetadataWithoutHasherAndBloomOptionsUsesDefaults()
+  {
+    const string json = """
+        {
+          "Version": "1.0.0"
+        }
+        """;
+
+    var meta = JsonSerializer.Deserialize<ZoneTreeMeta>(json);
+
+    Assert.That(meta, Is.Not.Null);
+    Assert.That(meta.KeyHasherType, Is.Null);
+    Assert.That(meta.MutableSegmentBloomFilterBitsPerItem, Is.Zero);
+  }
+
   [Test]
   public void CreatePersistsActiveOptionsInMetadata()
   {
@@ -67,6 +84,8 @@ public sealed class ZoneTreeMetaOptionsTests
         .SetDataDirectory(dataPath)
         .Configure(options => options.AllowUnsafeOptionValues = true)
         .SetMutableSegmentMaxItemCount(expected.MutableSegmentMaxItemCount)
+        .SetMutableSegmentBloomFilterBitsPerItem(
+            expected.MutableSegmentBloomFilterBitsPerItem)
         .SetDiskSegmentMaxItemCount(expected.DiskSegmentMaxItemCount)
         .ConfigureWriteAheadLogOptions(options =>
         {
@@ -112,6 +131,7 @@ public sealed class ZoneTreeMetaOptionsTests
     {
       CompressionMethod.LZ4 => new ExpectedOptions(
           MutableSegmentMaxItemCount: 37,
+          MutableSegmentBloomFilterBitsPerItem: 5,
           DiskSegmentMaxItemCount: 73,
           WriteAheadLogMode: WriteAheadLogMode.Sync,
           WriteAheadLogCustomOptions: customOptions,
@@ -138,6 +158,7 @@ public sealed class ZoneTreeMetaOptionsTests
 
       CompressionMethod.Zstd => new ExpectedOptions(
           MutableSegmentMaxItemCount: 41,
+          MutableSegmentBloomFilterBitsPerItem: 7,
           DiskSegmentMaxItemCount: 83,
           WriteAheadLogMode: WriteAheadLogMode.SyncCompressed,
           WriteAheadLogCustomOptions: customOptions,
@@ -164,6 +185,7 @@ public sealed class ZoneTreeMetaOptionsTests
 
       CompressionMethod.Brotli => new ExpectedOptions(
           MutableSegmentMaxItemCount: 43,
+          MutableSegmentBloomFilterBitsPerItem: 11,
           DiskSegmentMaxItemCount: 89,
           WriteAheadLogMode: WriteAheadLogMode.SyncCompressed,
           WriteAheadLogCustomOptions: customOptions,
@@ -201,7 +223,13 @@ public sealed class ZoneTreeMetaOptionsTests
     var meta = JsonSerializer.Deserialize<ZoneTreeMeta>(json);
 
     Assert.That(meta, Is.Not.Null);
+    Assert.That(
+        meta.KeyHasherType,
+        Is.EqualTo(typeof(DefaultKeyHasher<string>).SimplifiedFullName()));
     Assert.That(meta.MutableSegmentMaxItemCount, Is.EqualTo(expected.MutableSegmentMaxItemCount));
+    Assert.That(
+        meta.MutableSegmentBloomFilterBitsPerItem,
+        Is.EqualTo(expected.MutableSegmentBloomFilterBitsPerItem));
     Assert.That(meta.DiskSegmentMaxItemCount, Is.EqualTo(expected.DiskSegmentMaxItemCount));
 
     var walOptions = meta.WriteAheadLogOptions;
@@ -240,6 +268,14 @@ public sealed class ZoneTreeMetaOptionsTests
         Is.EqualTo(expected.DefaultSparseArrayStepSize));
 
     using var document = JsonDocument.Parse(json);
+    Assert.That(
+        document.RootElement.GetProperty(nameof(ZoneTreeMeta.KeyHasherType)).GetString(),
+        Is.EqualTo(typeof(DefaultKeyHasher<string>).SimplifiedFullName()));
+    Assert.That(
+        document.RootElement
+            .GetProperty(nameof(ZoneTreeMeta.MutableSegmentBloomFilterBitsPerItem))
+            .GetInt32(),
+        Is.EqualTo(expected.MutableSegmentBloomFilterBitsPerItem));
     var persistedCustomOptions = document.RootElement
         .GetProperty(nameof(ZoneTreeMeta.WriteAheadLogOptions))
         .GetProperty(nameof(WriteAheadLogOptions.CustomOptions))
@@ -262,6 +298,7 @@ public sealed class ZoneTreeMetaOptionsTests
 
   sealed record ExpectedOptions(
       int MutableSegmentMaxItemCount,
+      int MutableSegmentBloomFilterBitsPerItem,
       int DiskSegmentMaxItemCount,
       WriteAheadLogMode WriteAheadLogMode,
       string WriteAheadLogCustomOptions,

--- a/src/ZoneTree.UnitTests/ZoneTreeOptionsValidationTests.cs
+++ b/src/ZoneTree.UnitTests/ZoneTreeOptionsValidationTests.cs
@@ -6,6 +6,7 @@ using ZoneTree.Options;
 using ZoneTree.Segments.RandomAccess;
 using ZoneTree.Serializers;
 using ZoneTree.WAL;
+using ZoneTree.Hashers;
 
 namespace ZoneTree.UnitTests;
 
@@ -69,6 +70,16 @@ public sealed class ZoneTreeOptionsValidationTests
   }
 
   [Test]
+  public void MaximumMutableSegmentBloomFilterBitsPerItemPassesValidation()
+  {
+    var options = CreateValidOptions();
+    options.MutableSegmentBloomFilterBitsPerItem = 64;
+
+    Assert.That(options.TryValidate(out var exception), Is.True);
+    Assert.That(exception, Is.Null);
+  }
+
+  [Test]
   public void AllowUnsafeOptionValuesSkipsNumericRanges()
   {
     var options = CreateValidOptions();
@@ -97,6 +108,33 @@ public sealed class ZoneTreeOptionsValidationTests
     Assert.That(exception, Is.TypeOf<InvalidOptionValueException>());
   }
 
+  [Test]
+  public void CaseInsensitiveComparerRejectsIncompatibleKeyHasher()
+  {
+    var options = CreateValidStringOptions();
+    options.Comparer = new StringOrdinalIgnoreCaseComparerAscending();
+    options.KeyHasher = new DefaultKeyHasher<string>();
+
+    var isValid = options.TryValidate(out var exception);
+
+    Assert.That(isValid, Is.False);
+    Assert.That(exception, Is.TypeOf<InvalidOptionValueException>());
+    Assert.That(
+        ((InvalidOptionValueException)exception).Option,
+        Is.EqualTo(nameof(options.KeyHasher)));
+  }
+
+  [Test]
+  public void CaseInsensitiveComparerAcceptsCompatibleKeyHasher()
+  {
+    var options = CreateValidStringOptions();
+    options.Comparer = new StringOrdinalIgnoreCaseComparerAscending();
+    options.KeyHasher = new OrdinalIgnoreCaseKeyHasher();
+
+    Assert.That(options.TryValidate(out var exception), Is.True);
+    Assert.That(exception, Is.Null);
+  }
+
   static IEnumerable<TestCaseData> MissingOptionCases()
   {
     yield return Missing(
@@ -110,6 +148,10 @@ public sealed class ZoneTreeOptionsValidationTests
     yield return Missing(
         options => options.Comparer = null,
         nameof(ZoneTreeOptions<int, int>.Comparer));
+
+    yield return Missing(
+        options => options.KeyHasher = null,
+        nameof(ZoneTreeOptions<int, int>.KeyHasher));
 
     yield return Missing(
         options => options.IsDeleted = null,
@@ -153,6 +195,14 @@ public sealed class ZoneTreeOptionsValidationTests
     yield return Invalid(
         options => options.MutableSegmentMaxItemCount = 0,
         nameof(ZoneTreeOptions<int, int>.MutableSegmentMaxItemCount));
+
+    yield return Invalid(
+        options => options.MutableSegmentBloomFilterBitsPerItem = -1,
+        nameof(ZoneTreeOptions<int, int>.MutableSegmentBloomFilterBitsPerItem));
+
+    yield return Invalid(
+        options => options.MutableSegmentBloomFilterBitsPerItem = 65,
+        nameof(ZoneTreeOptions<int, int>.MutableSegmentBloomFilterBitsPerItem));
 
     yield return Invalid(
         options => options.DiskSegmentMaxItemCount = 0,
@@ -272,6 +322,7 @@ public sealed class ZoneTreeOptionsValidationTests
     var options = new ZoneTreeOptions<int, int>
     {
       Comparer = new Int32ComparerAscending(),
+      KeyHasher = new DefaultKeyHasher<int>(),
       KeySerializer = new Int32Serializer(),
       ValueSerializer = new Int32Serializer(),
       Logger = logger,
@@ -283,5 +334,33 @@ public sealed class ZoneTreeOptionsValidationTests
     };
     options.DisableDeletion();
     return options;
+  }
+
+  static ZoneTreeOptions<string, string> CreateValidStringOptions()
+  {
+    var logger = new ConsoleLogger(LogLevel.Error);
+    var options = new ZoneTreeOptions<string, string>
+    {
+      Comparer = new StringOrdinalComparerAscending(),
+      KeyHasher = new DefaultKeyHasher<string>(),
+      KeySerializer = new Utf8StringSerializer(),
+      ValueSerializer = new Utf8StringSerializer(),
+      Logger = logger,
+      WriteAheadLogProvider = new NullWriteAheadLogProvider(),
+      RandomAccessDeviceManager = new RandomAccessDeviceManager(
+          logger,
+          new InMemoryFileStreamProvider(),
+          "data/ZoneTreeStringOptionsValidationTests")
+    };
+    options.DisableDeletion();
+    return options;
+  }
+
+  sealed class OrdinalIgnoreCaseKeyHasher : IKeyHasher<string>
+  {
+    public int GetHashCode(in string key)
+    {
+      return StringComparer.OrdinalIgnoreCase.GetHashCode(key);
+    }
   }
 }

--- a/src/ZoneTree/Backup/LiveBackupRestore.cs
+++ b/src/ZoneTree/Backup/LiveBackupRestore.cs
@@ -147,11 +147,14 @@ public sealed class LiveBackupRestore<TKey, TValue>
     var meta = new ZoneTreeMeta
     {
       ComparerType = Options.Comparer.GetType().SimplifiedFullName(),
+      KeyHasherType = Options.KeyHasher?.GetType().SimplifiedFullName(),
       KeyType = typeof(TKey).SimplifiedFullName(),
       ValueType = typeof(TValue).SimplifiedFullName(),
       KeySerializerType = Options.KeySerializer.GetType().SimplifiedFullName(),
       ValueSerializerType = Options.ValueSerializer.GetType().SimplifiedFullName(),
       MutableSegmentMaxItemCount = Options.MutableSegmentMaxItemCount,
+      MutableSegmentBloomFilterBitsPerItem =
+          Options.MutableSegmentBloomFilterBitsPerItem,
       DiskSegmentMaxItemCount = Options.DiskSegmentMaxItemCount,
       WriteAheadLogOptions = Options.WriteAheadLogOptions,
       DiskSegmentOptions = Options.DiskSegmentOptions,

--- a/src/ZoneTree/Collections/BTree/BTree.Read.cs
+++ b/src/ZoneTree/Collections/BTree/BTree.Read.cs
@@ -12,10 +12,6 @@ public sealed partial class BTree<TKey, TValue>
 {
   public bool ContainsKey(in TKey key)
   {
-    if (_length == 0)
-    {
-      return false;
-    }
     var topLevelLocker = TopLevelLocker;
     try
     {
@@ -64,11 +60,6 @@ public sealed partial class BTree<TKey, TValue>
 
   public bool TryGetValue(in TKey key, out TValue value)
   {
-    if (_length == 0)
-    {
-      value = default;
-      return false;
-    }
     var topLevelLocker = TopLevelLocker;
     try
     {

--- a/src/ZoneTree/Collections/ConcurrentBloomFilter.cs
+++ b/src/ZoneTree/Collections/ConcurrentBloomFilter.cs
@@ -1,0 +1,78 @@
+using System.Runtime.CompilerServices;
+using ZoneTree.Hashers;
+
+namespace ZoneTree.Collections;
+
+/// <summary>
+/// A fixed-size Bloom filter supporting concurrent readers and writers.
+/// </summary>
+public sealed class ConcurrentBloomFilter<TKey>
+{
+  const long MaximumBitCount = 1L << 30;
+
+  readonly long[] Words;
+
+  readonly ulong WordMask;
+
+  readonly IKeyHasher<TKey> KeyHasher;
+
+  public ConcurrentBloomFilter(
+      int expectedItemCount,
+      int bitsPerItem,
+      IKeyHasher<TKey> keyHasher)
+  {
+    KeyHasher = keyHasher;
+    var requestedBitCount = Math.Max(
+        64L,
+        (long)expectedItemCount * bitsPerItem);
+    long bitCount = 64;
+    while (bitCount < requestedBitCount && bitCount < MaximumBitCount)
+      bitCount <<= 1;
+
+    Words = new long[bitCount >> 6];
+    WordMask = (ulong)(Words.Length - 1);
+  }
+
+  [MethodImpl(MethodImplOptions.AggressiveInlining)]
+  public void Add(in TKey key)
+  {
+    GetWordAndBitMask(in key, out var wordIndex, out var bitMask);
+    Interlocked.Or(ref Words[wordIndex], bitMask);
+  }
+
+  [MethodImpl(MethodImplOptions.AggressiveInlining)]
+  public bool MightContain(in TKey key)
+  {
+    GetWordAndBitMask(in key, out var wordIndex, out var bitMask);
+    return (Volatile.Read(ref Words[wordIndex]) & bitMask) == bitMask;
+  }
+
+  [MethodImpl(MethodImplOptions.AggressiveInlining)]
+  void GetWordAndBitMask(in TKey key, out int wordIndex, out long bitMask)
+  {
+    var hash = Mix(unchecked((uint)KeyHasher.GetHashCode(in key)));
+    var firstBit = (int)(hash & 63);
+    var bitStep = (int)((hash >> 6) & 31) * 2 + 1;
+    var secondBit = (firstBit + bitStep) & 63;
+    var thirdBit = (secondBit + bitStep) & 63;
+
+    // Keep all probes in one word so publishing them requires one atomic write.
+    wordIndex = (int)((hash >> 11) & WordMask);
+    bitMask = unchecked((long)(
+        (1UL << firstBit) |
+        (1UL << secondBit) |
+        (1UL << thirdBit)));
+  }
+
+  [MethodImpl(MethodImplOptions.AggressiveInlining)]
+  static ulong Mix(uint value)
+  {
+    unchecked
+    {
+      var hash = (ulong)value + 0x9E3779B97F4A7C15UL;
+      hash = (hash ^ (hash >> 30)) * 0xBF58476D1CE4E5B9UL;
+      hash = (hash ^ (hash >> 27)) * 0x94D049BB133111EBUL;
+      return hash ^ (hash >> 31);
+    }
+  }
+}

--- a/src/ZoneTree/Core/ZoneTree.cs
+++ b/src/ZoneTree/Core/ZoneTree.cs
@@ -189,6 +189,7 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
     if (MutableSegment != null)
       ZoneTreeMeta.MutableSegment = MutableSegment.SegmentId;
     ZoneTreeMeta.ComparerType = Options.Comparer.GetType().SimplifiedFullName();
+    ZoneTreeMeta.KeyHasherType = Options.KeyHasher?.GetType().SimplifiedFullName();
     ZoneTreeMeta.KeyType = typeof(TKey).SimplifiedFullName();
     ZoneTreeMeta.ValueType = typeof(TValue).SimplifiedFullName();
     ZoneTreeMeta.KeySerializerType = Options.KeySerializer.GetType().SimplifiedFullName();
@@ -197,6 +198,8 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
     ZoneTreeMeta.ReadOnlySegments = ReadOnlySegmentQueue.Select(x => x.SegmentId).ToArray();
     ZoneTreeMeta.BottomSegments = BottomSegmentQueue.Select(x => x.SegmentId).ToArray();
     ZoneTreeMeta.MutableSegmentMaxItemCount = Options.MutableSegmentMaxItemCount;
+    ZoneTreeMeta.MutableSegmentBloomFilterBitsPerItem =
+        Options.MutableSegmentBloomFilterBitsPerItem;
     ZoneTreeMeta.DiskSegmentMaxItemCount = Options.DiskSegmentMaxItemCount;
     ZoneTreeMeta.WriteAheadLogOptions = Options.WriteAheadLogOptions;
     ZoneTreeMeta.DiskSegmentOptions = Options.DiskSegmentOptions;
@@ -402,9 +405,12 @@ public sealed partial class ZoneTree<TKey, TValue> : IZoneTree<TKey, TValue>, IZ
       DiskSegmentOptions = clonesDiskSegmentOptions,
       EnableSingleSegmentGarbageCollection = options.EnableSingleSegmentGarbageCollection,
       IsDeleted = options.IsDeleted,
+      KeyHasher = options.KeyHasher,
       KeySerializer = options.KeySerializer,
       Logger = options.Logger,
       MarkValueDeleted = options.MarkValueDeleted,
+      MutableSegmentBloomFilterBitsPerItem =
+          options.MutableSegmentBloomFilterBitsPerItem,
       MutableSegmentMaxItemCount = options.MutableSegmentMaxItemCount,
       RandomAccessDeviceManager = options.RandomAccessDeviceManager,
       ValueSerializer = options.ValueSerializer,

--- a/src/ZoneTree/Core/ZoneTreeMeta.cs
+++ b/src/ZoneTree/Core/ZoneTreeMeta.cs
@@ -9,6 +9,8 @@ public sealed class ZoneTreeMeta
 
   public string ComparerType { get; set; }
 
+  public string KeyHasherType { get; set; }
+
   public string KeyType { get; set; }
 
   public string ValueType { get; set; }
@@ -18,6 +20,8 @@ public sealed class ZoneTreeMeta
   public string ValueSerializerType { get; set; }
 
   public int MutableSegmentMaxItemCount { get; set; }
+
+  public int MutableSegmentBloomFilterBitsPerItem { get; set; }
 
   public int DiskSegmentMaxItemCount { get; set; } = 20_000_000;
 

--- a/src/ZoneTree/Core/ZoneTreeMetaWAL.cs
+++ b/src/ZoneTree/Core/ZoneTreeMetaWAL.cs
@@ -232,6 +232,7 @@ public sealed class ZoneTreeMetaWAL<TKey, TValue> : IDisposable
       KeyType = zoneTreeMeta.KeyType,
       ValueType = zoneTreeMeta.ValueType,
       ComparerType = zoneTreeMeta.ComparerType,
+      KeyHasherType = Options.KeyHasher?.GetType().SimplifiedFullName(),
       DiskSegment = diskSegment,
       ReadOnlySegments = readOnlySegments,
       MutableSegment = mutableSegment,
@@ -240,6 +241,8 @@ public sealed class ZoneTreeMetaWAL<TKey, TValue> : IDisposable
       WriteAheadLogOptions = Options.WriteAheadLogOptions,
       DiskSegmentOptions = Options.DiskSegmentOptions,
       MutableSegmentMaxItemCount = Options.MutableSegmentMaxItemCount,
+      MutableSegmentBloomFilterBitsPerItem =
+          Options.MutableSegmentBloomFilterBitsPerItem,
       DiskSegmentMaxItemCount = Options.DiskSegmentMaxItemCount,
       BottomSegments = bottomSegments,
       MaximumOpIndex = zoneTreeMeta.MaximumOpIndex,
@@ -276,6 +279,9 @@ public sealed class ZoneTreeMetaWAL<TKey, TValue> : IDisposable
     zoneTreeMeta.WriteAheadLogOptions = Options.WriteAheadLogOptions;
     zoneTreeMeta.DiskSegmentOptions = Options.DiskSegmentOptions;
     zoneTreeMeta.MutableSegmentMaxItemCount = Options.MutableSegmentMaxItemCount;
+    zoneTreeMeta.KeyHasherType = Options.KeyHasher?.GetType().SimplifiedFullName();
+    zoneTreeMeta.MutableSegmentBloomFilterBitsPerItem =
+        Options.MutableSegmentBloomFilterBitsPerItem;
     zoneTreeMeta.DiskSegmentMaxItemCount = Options.DiskSegmentMaxItemCount;
   }
 

--- a/src/ZoneTree/Hashers/ByteArrayKeyHasher.cs
+++ b/src/ZoneTree/Hashers/ByteArrayKeyHasher.cs
@@ -1,0 +1,25 @@
+using System.Runtime.CompilerServices;
+
+namespace ZoneTree.Hashers;
+
+/// <summary>
+/// Computes content-based hash codes for byte sequences.
+/// </summary>
+public sealed class ByteArrayKeyHasher : IKeyHasher<Memory<byte>>
+{
+  /// <inheritdoc/>
+  [MethodImpl(MethodImplOptions.AggressiveInlining)]
+  public int GetHashCode(in Memory<byte> key)
+  {
+    const uint offsetBasis = 2166136261;
+    const uint prime = 16777619;
+
+    var hash = offsetBasis;
+    foreach (var value in key.Span)
+    {
+      hash ^= value;
+      hash *= prime;
+    }
+    return unchecked((int)hash);
+  }
+}

--- a/src/ZoneTree/Hashers/DefaultKeyHasher.cs
+++ b/src/ZoneTree/Hashers/DefaultKeyHasher.cs
@@ -1,0 +1,20 @@
+using System.Runtime.CompilerServices;
+
+namespace ZoneTree.Hashers;
+
+/// <summary>
+/// Computes key hashes using the default equality comparer for the key type.
+/// </summary>
+/// <typeparam name="TKey">Key type</typeparam>
+public sealed class DefaultKeyHasher<TKey> : IKeyHasher<TKey>
+{
+  readonly EqualityComparer<TKey> EqualityComparer =
+      EqualityComparer<TKey>.Default;
+
+  /// <inheritdoc/>
+  [MethodImpl(MethodImplOptions.AggressiveInlining)]
+  public int GetHashCode(in TKey key)
+  {
+    return EqualityComparer.GetHashCode(key);
+  }
+}

--- a/src/ZoneTree/Hashers/IKeyHasher.cs
+++ b/src/ZoneTree/Hashers/IKeyHasher.cs
@@ -1,0 +1,20 @@
+namespace ZoneTree.Hashers;
+
+/// <summary>
+/// Defines a method that computes a hash code for a key.
+/// </summary>
+/// <typeparam name="TKey">Key type</typeparam>
+/// <remarks>
+/// Keys considered equal by the configured key comparer must produce the same
+/// hash code. Custom comparer and hasher compatibility is the caller's
+/// responsibility.
+/// </remarks>
+public interface IKeyHasher<TKey>
+{
+  /// <summary>
+  /// Computes a hash code for the specified key.
+  /// </summary>
+  /// <param name="key">The key to hash.</param>
+  /// <returns>The hash code for the key.</returns>
+  int GetHashCode(in TKey key);
+}

--- a/src/ZoneTree/Options/DefaultValues.cs
+++ b/src/ZoneTree/Options/DefaultValues.cs
@@ -7,6 +7,8 @@ public static class DefaultValues
 {
   public static readonly int MutableSegmentMaxItemCount = 1_000_000;
 
+  public static readonly int MutableSegmentBloomFilterBitsPerItem = 8;
+
   public static readonly int DiskSegmentMaxItemCount = 20_000_000;
 
   public static readonly BTreeLockMode BTreeLockMode = BTreeLockMode.NodeLevelMonitor;

--- a/src/ZoneTree/Options/ZoneTreeOptionValidationRules.cs
+++ b/src/ZoneTree/Options/ZoneTreeOptionValidationRules.cs
@@ -5,6 +5,9 @@ internal static class ZoneTreeOptionValidationRules
   public static readonly Rule MutableSegmentMaxItemCount =
       Rule.Min(1000);
 
+  public static readonly Rule MutableSegmentBloomFilterBitsPerItem =
+      Rule.Min(0).Max(64);
+
   public static readonly Rule DiskSegmentMaxItemCount =
       Rule.Min(10000);
 

--- a/src/ZoneTree/Options/ZoneTreeOptions.cs
+++ b/src/ZoneTree/Options/ZoneTreeOptions.cs
@@ -5,6 +5,7 @@ using ZoneTree.Serializers;
 using ZoneTree.Comparers;
 using ZoneTree.Segments.RandomAccess;
 using ZoneTree.PresetTypes;
+using ZoneTree.Hashers;
 
 namespace ZoneTree.Options;
 
@@ -42,6 +43,15 @@ public sealed class ZoneTreeOptions<TKey, TValue>
   public int MutableSegmentMaxItemCount { get; set; } = DefaultValues.MutableSegmentMaxItemCount;
 
   /// <summary>
+  /// Requested Bloom-filter bits per mutable-segment item. Higher values reduce
+  /// false positives but use more memory. The allocation is rounded up to a
+  /// power of two. Setting this value to zero disables the mutable-segment
+  /// Bloom filter. Valid values are between 0 and 64. Default value is 8.
+  /// </summary>
+  public int MutableSegmentBloomFilterBitsPerItem { get; set; } =
+      DefaultValues.MutableSegmentBloomFilterBitsPerItem;
+
+  /// <summary>
   /// Disk segment maximum key-value pair count.
   /// After a merge creates a disk segment, segments larger than this value are
   /// enqueued into the bottom segments layer.
@@ -52,6 +62,12 @@ public sealed class ZoneTreeOptions<TKey, TValue>
   /// The key comparer.
   /// </summary>
   public IRefComparer<TKey> Comparer { get; set; }
+
+  /// <summary>
+  /// The key hasher. Keys considered equal by <see cref="Comparer"/> must
+  /// produce the same hash code.
+  /// </summary>
+  public IKeyHasher<TKey> KeyHasher { get; set; }
 
   /// <summary>
   /// The key serializer.

--- a/src/ZoneTree/Options/ZoneTreeOptionsValidator.cs
+++ b/src/ZoneTree/Options/ZoneTreeOptionsValidator.cs
@@ -23,6 +23,9 @@ internal static class ZoneTreeOptionsValidator
     if (options.Comparer == null)
       return new MissingOptionException(nameof(options.Comparer));
 
+    if (options.KeyHasher == null)
+      return new MissingOptionException(nameof(options.KeyHasher));
+
     if (options.IsDeleted == null)
       return new MissingOptionException(nameof(options.IsDeleted));
 
@@ -44,7 +47,11 @@ internal static class ZoneTreeOptionsValidator
     if (options.DiskSegmentOptions == null)
       return new MissingOptionException(nameof(options.DiskSegmentOptions));
 
-    Exception exception = ValidateDefinedEnum(
+    Exception exception = ValidateCommonKeyHasherCompatibility(options);
+    if (exception != null)
+      return exception;
+
+    exception = ValidateDefinedEnum(
         nameof(options.BTreeLockMode),
         options.BTreeLockMode);
     if (exception != null)
@@ -62,6 +69,28 @@ internal static class ZoneTreeOptionsValidator
       return null;
 
     return ValidateOptionValues(options);
+  }
+
+  static InvalidOptionValueException ValidateCommonKeyHasherCompatibility<TKey, TValue>(
+      ZoneTreeOptions<TKey, TValue> options)
+  {
+    if (typeof(TKey) != typeof(string))
+      return null;
+
+    var lowerCase = (TKey)(object)"a";
+    var upperCase = (TKey)(object)"A";
+    if (options.Comparer.Compare(in lowerCase, in upperCase) != 0)
+      return null;
+
+    var lowerCaseHash = options.KeyHasher.GetHashCode(in lowerCase);
+    var upperCaseHash = options.KeyHasher.GetHashCode(in upperCase);
+    if (lowerCaseHash == upperCaseHash)
+      return null;
+
+    return new InvalidOptionValueException(
+        nameof(options.KeyHasher),
+        options.KeyHasher.GetType().Name,
+        "Keys considered equal by Comparer must produce the same hash code");
   }
 
   static Exception ValidateWriteAheadLogOptions(WriteAheadLogOptions options)
@@ -116,6 +145,12 @@ internal static class ZoneTreeOptionsValidator
     Exception exception = ZoneTreeOptionValidationRules.MutableSegmentMaxItemCount.Validate(
         nameof(options.MutableSegmentMaxItemCount),
         options.MutableSegmentMaxItemCount);
+    if (exception != null)
+      return exception;
+
+    exception = ZoneTreeOptionValidationRules.MutableSegmentBloomFilterBitsPerItem.Validate(
+        nameof(options.MutableSegmentBloomFilterBitsPerItem),
+        options.MutableSegmentBloomFilterBitsPerItem);
     if (exception != null)
       return exception;
 

--- a/src/ZoneTree/PresetTypes/ComponentsForKnownTypes.cs
+++ b/src/ZoneTree/PresetTypes/ComponentsForKnownTypes.cs
@@ -3,6 +3,7 @@ using ZoneTree.Comparers;
 using ZoneTree.Exceptions;
 using ZoneTree.Options;
 using ZoneTree.Serializers;
+using ZoneTree.Hashers;
 
 namespace ZoneTree.PresetTypes;
 
@@ -49,6 +50,35 @@ public static class ComponentsForKnownTypes
       throw new ZoneTreeException("ZoneTree<byte[], ...> is not supported. Use ZoneTree<Memory<byte>, ...> instead.");
     }
     return comparer;
+  }
+
+  /// <summary>
+  /// Returns a key hasher for a known key type.
+  /// </summary>
+  /// <typeparam name="TKey">The key type.</typeparam>
+  /// <returns>
+  /// An implementation of <see cref="IKeyHasher{TKey}"/> appropriate for the
+  /// type, or null if the type is unsupported.
+  /// </returns>
+  public static IKeyHasher<TKey> GetKeyHasher<TKey>()
+  {
+    TKey key = default;
+    var isKnownType = key is byte or char or DateTime or decimal or double or
+        short or ushort or int or uint or long or ulong or Guid;
+
+    if (isKnownType || typeof(TKey) == typeof(string))
+      return new DefaultKeyHasher<TKey>();
+
+    if (typeof(TKey) == typeof(Memory<byte>))
+      return new ByteArrayKeyHasher() as IKeyHasher<TKey>;
+
+    if (typeof(TKey) == typeof(byte[]))
+    {
+      throw new ZoneTreeException(
+          "ZoneTree<byte[], ...> is not supported. " +
+          "Use ZoneTree<Memory<byte>, ...> instead.");
+    }
+    return null;
   }
 
   /// <summary>

--- a/src/ZoneTree/Segments/InMemory/MutableSegment.cs
+++ b/src/ZoneTree/Segments/InMemory/MutableSegment.cs
@@ -21,6 +21,8 @@ public sealed class MutableSegment<TKey, TValue> : IMutableSegment<TKey, TValue>
 
   readonly BTree<TKey, TValue> BTree;
 
+  readonly ConcurrentBloomFilter<TKey> BloomFilter;
+
   readonly IRefComparer<TKey> Comparer;
 
   readonly IWriteAheadLog<TKey, TValue> WriteAheadLog;
@@ -51,6 +53,8 @@ public sealed class MutableSegment<TKey, TValue> : IMutableSegment<TKey, TValue>
             options.KeySerializer,
             options.ValueSerializer);
     Comparer = options.Comparer;
+    MutableSegmentMaxItemCount = options.MutableSegmentMaxItemCount;
+    BloomFilter = CreateBloomFilter(options);
 
     BTree = new(Comparer,
         Options.BTreeLockMode,
@@ -59,7 +63,6 @@ public sealed class MutableSegment<TKey, TValue> : IMutableSegment<TKey, TValue>
         Options.BTreeLeafSize);
 
     MarkValueDeleted = options.MarkValueDeleted;
-    MutableSegmentMaxItemCount = options.MutableSegmentMaxItemCount;
   }
 
   public MutableSegment(
@@ -75,6 +78,8 @@ public sealed class MutableSegment<TKey, TValue> : IMutableSegment<TKey, TValue>
     WriteAheadLog = wal;
     Options = options;
     Comparer = options.Comparer;
+    MutableSegmentMaxItemCount = options.MutableSegmentMaxItemCount;
+    BloomFilter = CreateBloomFilter(options);
 
     BTree = new(
         Comparer,
@@ -84,7 +89,6 @@ public sealed class MutableSegment<TKey, TValue> : IMutableSegment<TKey, TValue>
         Options.BTreeLeafSize);
 
     MarkValueDeleted = options.MarkValueDeleted;
-    MutableSegmentMaxItemCount = options.MutableSegmentMaxItemCount;
     if (collectGarbage)
     {
       // If there isn't any disk segment and readonly segment,
@@ -108,6 +112,7 @@ public sealed class MutableSegment<TKey, TValue> : IMutableSegment<TKey, TValue>
       var value = values[i];
       // TODO: Search if we can create faster construction
       // of mutable segment from log entries.
+      BloomFilter?.Add(in key);
       BTree.Upsert(in key, in value, out var _);
     }
   }
@@ -131,17 +136,30 @@ public sealed class MutableSegment<TKey, TValue> : IMutableSegment<TKey, TValue>
       {
         continue;
       }
+      BloomFilter?.Add(in key);
       BTree.Upsert(in key, in value, out var _);
     }
   }
 
   public bool ContainsKey(in TKey key)
   {
+    if (BTree.Length == 0)
+      return false;
+    if (BloomFilter != null &&
+        !BloomFilter.MightContain(in key))
+      return false;
     return BTree.ContainsKey(key);
   }
 
   public bool TryGet(in TKey key, out TValue value)
   {
+    if (BTree.Length == 0 ||
+        (BloomFilter != null &&
+         !BloomFilter.MightContain(in key)))
+    {
+      value = default;
+      return false;
+    }
     return BTree.TryGetValue(key, out value);
   }
 
@@ -162,6 +180,7 @@ public sealed class MutableSegment<TKey, TValue> : IMutableSegment<TKey, TValue>
         opIndex = 0;
         return AddOrUpdateResult.RETRY_SEGMENT_IS_FULL;
       }
+      BloomFilter?.Add(in key);
       var result = BTree.Upsert(in key, in value, out opIndex);
       WriteAheadLog.Append(in key, in value, opIndex);
       return result ? AddOrUpdateResult.ADDED : AddOrUpdateResult.UPDATED;
@@ -192,6 +211,7 @@ public sealed class MutableSegment<TKey, TValue> : IMutableSegment<TKey, TValue>
         opIndex = 0;
         return AddOrUpdateResult.RETRY_SEGMENT_IS_FULL;
       }
+      BloomFilter?.Add(in key);
       var result = BTree.Upsert(in key, valueGetter, out var value, out opIndex);
       WriteAheadLog.Append(in key, in value, opIndex);
       return result ? AddOrUpdateResult.ADDED : AddOrUpdateResult.UPDATED;
@@ -222,6 +242,7 @@ public sealed class MutableSegment<TKey, TValue> : IMutableSegment<TKey, TValue>
 
       TValue insertedValue = default;
 
+      BloomFilter?.Add(in key);
       var status = BTree
           .AddOrUpdate(key,
               void (ref TValue x) =>
@@ -247,6 +268,18 @@ public sealed class MutableSegment<TKey, TValue> : IMutableSegment<TKey, TValue>
   {
     IsFrozenFlag = true;
     new Thread(FreezeWriteAheadLog).Start();
+  }
+
+  ConcurrentBloomFilter<TKey> CreateBloomFilter(
+      ZoneTreeOptions<TKey, TValue> options)
+  {
+    var bitsPerItem = options.MutableSegmentBloomFilterBitsPerItem;
+    return bitsPerItem == 0 ?
+        null :
+        new ConcurrentBloomFilter<TKey>(
+            MutableSegmentMaxItemCount,
+            bitsPerItem,
+            options.KeyHasher);
   }
 
   void FreezeWriteAheadLog()

--- a/src/ZoneTree/ZoneTreeFactory.cs
+++ b/src/ZoneTree/ZoneTreeFactory.cs
@@ -11,6 +11,7 @@ using ZoneTree.Logger;
 using ZoneTree.Segments.RandomAccess;
 using ZoneTree.PresetTypes;
 using ZoneTree.Backup;
+using ZoneTree.Hashers;
 
 namespace ZoneTree;
 
@@ -87,6 +88,18 @@ public sealed class ZoneTreeFactory<TKey, TValue>
   }
 
   /// <summary>
+  /// Sets the key hasher.
+  /// </summary>
+  /// <param name="keyHasher">The key hasher.</param>
+  /// <returns>ZoneTree Factory</returns>
+  public ZoneTreeFactory<TKey, TValue> SetKeyHasher(
+      IKeyHasher<TKey> keyHasher)
+  {
+    Options.KeyHasher = keyHasher;
+    return this;
+  }
+
+  /// <summary>
   /// Configures mutable segment maximum item count.
   /// </summary>
   /// <param name="mutableSegmentMaxItemCount">The maximum item count</param>
@@ -95,6 +108,19 @@ public sealed class ZoneTreeFactory<TKey, TValue>
       SetMutableSegmentMaxItemCount(int mutableSegmentMaxItemCount)
   {
     Options.MutableSegmentMaxItemCount = mutableSegmentMaxItemCount;
+    return this;
+  }
+
+  /// <summary>
+  /// Configures the requested Bloom-filter bits per mutable-segment item.
+  /// Setting this value to zero disables the mutable-segment Bloom filter.
+  /// </summary>
+  /// <param name="bitsPerItem">The requested number of bits per item.</param>
+  /// <returns>ZoneTree Factory</returns>
+  public ZoneTreeFactory<TKey, TValue>
+      SetMutableSegmentBloomFilterBitsPerItem(int bitsPerItem)
+  {
+    Options.MutableSegmentBloomFilterBitsPerItem = bitsPerItem;
     return this;
   }
 
@@ -331,6 +357,7 @@ public sealed class ZoneTreeFactory<TKey, TValue>
     }
     Options.CreateDefaultDeleteDelegates();
     FillComparer();
+    FillKeyHasher();
     FillKeySerializer();
     FillValueSerializer();
   }
@@ -340,6 +367,13 @@ public sealed class ZoneTreeFactory<TKey, TValue>
     if (Options.Comparer != null)
       return;
     Options.Comparer = ComponentsForKnownTypes.GetComparer<TKey>();
+  }
+
+  void FillKeyHasher()
+  {
+    if (Options.KeyHasher != null)
+      return;
+    Options.KeyHasher = ComponentsForKnownTypes.GetKeyHasher<TKey>();
   }
 
   void FillKeySerializer()


### PR DESCRIPTION
## Summary

This PR unlocks concurrent read scaling by adding a production-ready Bloom filter to mutable and frozen in-memory segments.

Negative lookups can now bypass the B+tree entirely instead of entering its synchronized read path. This matters across the whole LSM read pipeline: lookups commonly probe several segments before finding a key, and most of those probes are misses.

The result is dramatically better parallel read and query scaling while preserving strong single-thread performance.

## What Changed

- Added a fixed-size concurrent Bloom filter for in-memory segments.
- Applied it to both mutable and fully frozen segments.
- Covered inserts, updates, deletes, and WAL reconstruction.
- Added configurable memory usage through `MutableSegmentBloomFilterBitsPerItem`.
  - Default: `8`
  - Valid range: `0–64`
  - `0` disables the filter
- Introduced `IKeyHasher<TKey>` for comparer-compatible hashing.
- Added automatic hashers for supported primitive types, strings, and `Memory<byte>`.
- Added content-based hashing for `Memory<byte>` keys.
- Added factory methods for configuring the hasher and Bloom-filter size.
- Added validation for missing hashers and common comparer/hasher mismatches.
- Recorded the active hasher type and Bloom-filter setting in JSON metadata.
- Preserved compatibility with metadata written before these fields existed.

## Concurrency Design

The filter uses three probes contained within one 64-bit word:

- Writers publish all bits with one `Interlocked.Or`.
- Readers inspect the word with one `Volatile.Read`.
- Publication happens before the corresponding B+Tree mutation.
- Concurrent readers never observe partially published entries.
- False positives fall through to the B+Tree as expected.
- Compatible hashers cannot produce false negatives.

The allocation is rounded to a power of two, keeping lookup indexing inexpensive. With the default one-million-item mutable segment and eight bits per item, the filter occupies approximately 1 MiB.

## Performance

On the current 1M-profile Windows reference workload:

| Operation | P1 | P16 | Scaling |
|---|---:|---:|---:|
| Read by user ID | 0.97M/s | 6.84M/s | 7.1x |
| Lookup by email | 0.40M/s | 4.47M/s | 11.2x |
| Country/status query | 29.5K/s | 141.4K/s | 4.8x |
| Created-at range query | 40.7K/s | 320.7K/s | 7.9x |
| Top-reputation query | 51.4K/s | 241.1K/s | 4.7x |

The complete P16 workload finished its measured phases in **10.6 seconds**, compared with **56.8 seconds** at P1.

These numbers demonstrate the branch’s parallel scaling rather than a controlled before/after comparison.

## Compatibility

Known key types receive an appropriate hasher automatically.

Custom key types must provide an `IKeyHasher<TKey>`. Keys considered equal by the configured comparer must always produce the same hash code. Custom hashers must also be deterministic and safe for concurrent use.

The Bloom filter can be disabled when required:

```csharp
factory.SetMutableSegmentBloomFilterBitsPerItem(0);
```

## Verification

- Concurrent insertion coverage
- Custom comparer and compatible hasher coverage
- `Memory<byte>` content-equivalence coverage
- Disabled-filter coverage
- WAL reconstruction paths
- Metadata persistence and legacy metadata compatibility
- Option validation coverage
- Successful .NET 9 and .NET 10 Release builds